### PR TITLE
Add --store k8s-secret backend for auth login

### DIFF
--- a/.serena/memories/session_handoff.md
+++ b/.serena/memories/session_handoff.md
@@ -1,24 +1,18 @@
 # Session Handoff — memory-mcp
 
 ## Canonical tracking
-- **TODO.md** in repo root — Phase 2 checklist with completion status
-- **butterflyskies/tasks#80** — tracking issue with PR links and status comments (keep reopening — auto-closes on PR merge)
+- **[TODO.md](https://github.com/butterflyskies/memory-mcp/blob/main/TODO.md)** — single source of truth for task status
+- **butterflyskies/tasks#80** — discussion thread, references TODO.md (keep reopening if auto-closed on PR merge)
 
 ## Current state
-On `main`, all Phase 2 work through auth subcommand merged (PRs #1–#10).
+On `main`, Phase 2 roughly half complete (auth + sync done, migration + deployment remaining).
 
-## What's next
-- `--store k8s-secret` backend (cargo feature-gated)
-- Extract GitHub OAuth client ID from hardcoded const into config file/module (follow-up on tasks#80)
-- Integration tests for `auth login`, `auth status`, `MEMORY_MCP_BIND` env var (follow-up on tasks#80)
-- Migration tools (Serena global, Serena project, Claude Code auto-memories)
-- Configure as MCP server in `~/.claude.json`
-- K8s deployment: Cilium Gateway API, StepClusterIssuer certs
+## Ordering intent
+Deploy to k8s first, then wire up as MCP server in Claude Code. The server needs to be running and reachable before pointing clients at it.
 
 ## Context worth preserving
 - Review cycles take 2-3 passes — pre-flight checklist helped but P3s still emerge
 - IDE diagnostics are frequently stale — always verify with `cargo check`
-- `capture_head_oid` used in fast_forward but NOT in merge_with_remote (defensive)
-- User strongly prefers no tech debt, even P3-level findings get fixed
 - Never amend commits — always add new commits on top
 - Never silently fall back to plaintext file storage for credentials
+- `capture_head_oid` used in fast_forward but NOT in merge_with_remote (defensive)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "built"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,7 +394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
@@ -531,6 +540,15 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -577,6 +595,16 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cxx"
@@ -778,6 +806,37 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1095,6 +1154,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,12 +1391,27 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1623,6 +1707,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1751,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+dependencies = [
+ "base64 0.22.1",
+ "jiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keyring"
 version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1784,69 @@ dependencies = [
  "dbus-secret-service",
  "log",
  "zeroize",
+]
+
+[[package]]
+name = "kube"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "either",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http",
+ "jiff",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1869,7 +2065,9 @@ dependencies = [
  "clap",
  "fastembed",
  "git2",
+ "k8s-openapi",
  "keyring",
+ "kube",
  "libc",
  "reqwest",
  "rmcp",
@@ -2180,6 +2378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2475,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2434,7 +2694,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2778,6 +3038,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,6 +3072,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2921,6 +3202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3247,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -3037,6 +3337,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -3420,6 +3731,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3431,16 +3743,19 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "base64 0.22.1",
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3522,6 +3837,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "memory-mcp"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+k8s = ["dep:kube", "dep:k8s-openapi"]
+
 [dependencies]
 rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server"] }
 axum = "0.8"
@@ -25,6 +28,8 @@ tokio-util = { version = "0.7", features = ["rt"] }
 libc = "0.2"
 keyring = { version = "3", features = ["sync-secret-service"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+kube = { version = "3.1", default-features = false, features = ["client", "rustls-tls"], optional = true }
+k8s-openapi = { version = "0.27", features = ["v1_31"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 - [x] Input validation — name validation, content size limits, nesting depth limits
 - [x] Error mapping — `From<MemoryError> for ErrorData` with appropriate MCP error codes
 
-## Phase 2: Sync + Migration
+## Phase 2: Sync + Auth + Migration
 
 - [x] Implement real git push/pull with remote auth (PR #4)
   - [x] Lazy token resolution — local-only mode works without credentials
@@ -26,14 +26,29 @@
   - [x] Configurable branch name (ADR-0009)
   - [x] Path-traversal and symlink protection in conflict resolution
   - [x] Integration tests (20 new, all offline with local bare remotes)
-- [ ] Keyring-based token storage via `keyring` crate (sync-secret-service for KWallet/GNOME Keyring)
-- [ ] Index rebuild on pull (incremental if possible)
+- [x] Incremental index rebuild on pull (PR #7)
+  - [x] Diff old/new HEAD trees, re-embed only changed files
+  - [x] VectorIndex::remove name_map corruption fix
+  - [x] Refactor pull() into smaller named helpers
+- [x] Keyring-based token storage (PR #9, ADR-0010)
+  - [x] Resolution chain: env var → token file → system keyring
+  - [x] Graceful degradation for headless/k8s (NoStorageAccess)
+- [x] Auth subcommand with OAuth device flow (PR #10, ADR-0011, ADR-0012)
+  - [x] CLI restructure: `serve` (default), `auth login`, `auth status`
+  - [x] GitHub OAuth device flow with scoped token acquisition
+  - [x] Token storage: keyring default, explicit `--store file|stdout` opt-in
+  - [x] Security hardening: umask 0o077, atomic file writes, request/loop timeouts
+- [ ] `--store k8s-secret` backend (cargo feature-gated)
+- [ ] Extract OAuth client ID from hardcoded const into config module
+- [ ] Integration tests for `auth login`, `auth status`, `MEMORY_MCP_BIND` env var
 - [ ] Migration tool: import Serena global memories (preserve content + metadata) (ADR-0008)
 - [ ] Migration tool: import Serena project-scoped memories
 - [ ] Migration tool: import Claude Code auto-memories
+- [ ] Container image (Dockerfile, publish to Harbor)
+- [ ] K8s deployment: Cilium Gateway API, StepClusterIssuer certs
+- [ ] Test cross-device sync workflow
 - [ ] Configure as MCP server in `~/.claude.json`
 - [ ] Update CLAUDE.md instructions to use memory-mcp instead of Serena memories
-- [ ] Test cross-device sync workflow
 
 ## Phase 3: Polish
 

--- a/docs/adr/0013-k8s-secret-token-storage.md
+++ b/docs/adr/0013-k8s-secret-token-storage.md
@@ -1,0 +1,24 @@
+# ADR-0013: Kubernetes Secret token storage
+
+## Status
+Accepted
+
+## Context
+memory-mcp needs to store GitHub tokens in Kubernetes for server deployments. The token
+must end up in a K8s Secret so the pod spec can mount it as `MEMORY_MCP_GITHUB_TOKEN`.
+
+## Decision
+Add `--store k8s-secret` to `auth login`, feature-gated behind a `k8s` cargo feature.
+Uses the `kube` crate to create/update an Opaque Secret with a single `token` key.
+The k8s store is write-only — token resolution uses the existing env var chain (pod
+mounts the Secret as an env var). This avoids pulling kube deps into the server's hot path.
+
+Namespace and secret name are configurable via `--k8s-namespace` (default: `butterfly`)
+and `--k8s-secret-name` (default: `memory-mcp-github-token`). The data key `token` is
+hardcoded to prevent drift with the pod spec.
+
+## Consequences
+- Desktop builds are unaffected (feature is opt-in)
+- `cargo build --features k8s` pulls kube + k8s-openapi (large deps, compile time increase)
+- Re-running `auth login --store k8s-secret` overwrites the Secret (get-then-replace)
+- RBAC for secrets in the target namespace is required

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,6 +67,21 @@ pub enum StoreBackend {
     File,
     /// Print token to stdout and do not persist it.
     Stdout,
+    #[cfg(feature = "k8s")]
+    /// Store token as a Kubernetes Secret.
+    #[clap(name = "k8s-secret")]
+    K8sSecret,
+}
+
+// ---------------------------------------------------------------------------
+// K8sSecretConfig — configuration for Kubernetes Secret storage
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "k8s")]
+#[derive(Debug)]
+pub struct K8sSecretConfig {
+    pub namespace: String,
+    pub secret_name: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -238,7 +253,10 @@ impl Default for AuthProvider {
 /// Authenticate with GitHub via the OAuth device flow and persist the token.
 ///
 /// Prints user-facing prompts to stderr. Never logs the token value.
-pub async fn device_flow_login(store: Option<StoreBackend>) -> Result<(), MemoryError> {
+pub async fn device_flow_login(
+    store: Option<StoreBackend>,
+    #[cfg(feature = "k8s")] k8s_config: Option<K8sSecretConfig>,
+) -> Result<(), MemoryError> {
     use std::time::{Duration, Instant};
     use tokio::time::sleep;
 
@@ -355,7 +373,13 @@ pub async fn device_flow_login(store: Option<StoreBackend>) -> Result<(), Memory
     };
 
     // Step 4: Store the token.
-    store_token(&token, store)?;
+    store_token(
+        &token,
+        store,
+        #[cfg(feature = "k8s")]
+        k8s_config,
+    )
+    .await?;
     eprintln!("Authentication successful.");
 
     Ok(())
@@ -368,7 +392,11 @@ pub async fn device_flow_login(store: Option<StoreBackend>) -> Result<(), Memory
 /// Persist a token via the specified backend.
 ///
 /// Never logs the token value — only the chosen storage destination.
-fn store_token(token: &str, backend: Option<StoreBackend>) -> Result<(), MemoryError> {
+async fn store_token(
+    token: &str,
+    backend: Option<StoreBackend>,
+    #[cfg(feature = "k8s")] k8s_config: Option<K8sSecretConfig>,
+) -> Result<(), MemoryError> {
     match backend {
         Some(StoreBackend::Stdout) => {
             println!("{token}");
@@ -380,12 +408,27 @@ fn store_token(token: &str, backend: Option<StoreBackend>) -> Result<(), MemoryE
         Some(StoreBackend::File) => {
             store_in_file(token)?;
         }
+        #[cfg(feature = "k8s")]
+        Some(StoreBackend::K8sSecret) => {
+            let config = k8s_config.ok_or_else(|| {
+                MemoryError::TokenStorage(
+                    "k8s-secret backend requires namespace and secret name".into(),
+                )
+            })?;
+            store_in_k8s_secret(token, &config).await?;
+        }
         None => {
             // No --store flag: try keyring ONLY. Do NOT fall back to file.
             store_in_keyring(token).map_err(|e| {
                 MemoryError::TokenStorage(format!(
                     "Keyring unavailable: {e}. Use --store file to write to \
-                     ~/.config/memory-mcp/token, or --store stdout to print the token."
+                     ~/.config/memory-mcp/token, --store stdout to print the token\
+                     {k8s_hint}.",
+                    k8s_hint = if cfg!(feature = "k8s") {
+                        ", or --store k8s-secret to store in a Kubernetes Secret"
+                    } else {
+                        ""
+                    }
                 ))
             })?;
         }
@@ -470,6 +513,107 @@ fn store_in_file(token: &str) -> Result<(), MemoryError> {
 
     info!("token stored in file ({})", token_path.display());
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes Secret storage (k8s feature)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "k8s")]
+async fn store_in_k8s_secret(token: &str, config: &K8sSecretConfig) -> Result<(), MemoryError> {
+    use k8s_openapi::api::core::v1::Secret;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use kube::{api::PostParams, Api, Client};
+    use std::collections::BTreeMap;
+
+    let client = Client::try_default().await.map_err(|e| {
+        MemoryError::TokenStorage(format!(
+            "Failed to initialize Kubernetes client. Ensure KUBECONFIG is set \
+             or the pod has a service account: {e}"
+        ))
+    })?;
+
+    let secrets: Api<Secret> = Api::namespaced(client, &config.namespace);
+    let secret_name = &config.secret_name;
+
+    let mut data = BTreeMap::new();
+    data.insert(
+        "token".to_string(),
+        k8s_openapi::ByteString(token.as_bytes().to_vec()),
+    );
+
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        "app.kubernetes.io/managed-by".to_string(),
+        "memory-mcp".to_string(),
+    );
+    labels.insert(
+        "app.kubernetes.io/component".to_string(),
+        "auth".to_string(),
+    );
+
+    let mut secret = Secret {
+        metadata: ObjectMeta {
+            name: Some(secret_name.clone()),
+            namespace: Some(config.namespace.clone()),
+            labels: Some(labels),
+            ..Default::default()
+        },
+        data: Some(data),
+        type_: Some("Opaque".to_string()),
+        ..Default::default()
+    };
+
+    // Create-first: attempt to create the secret; on 409 AlreadyExists, GET to
+    // fetch the current resourceVersion and replace. This avoids the TOCTOU
+    // race inherent in a GET-then-create/replace approach.
+    match secrets.create(&PostParams::default(), &secret).await {
+        Ok(_) => {
+            debug!(
+                "created Kubernetes Secret '{secret_name}' in namespace '{}'",
+                config.namespace
+            );
+        }
+        Err(kube::Error::Api(ref err_resp)) if err_resp.code == 409 => {
+            // Secret already exists; fetch resourceVersion then replace.
+            let existing = secrets
+                .get(secret_name)
+                .await
+                .map_err(|e| map_kube_error(e, &config.namespace))?;
+            secret.metadata.resource_version = existing.metadata.resource_version;
+            secrets
+                .replace(secret_name, &PostParams::default(), &secret)
+                .await
+                .map_err(|e| map_kube_error(e, &config.namespace))?;
+            debug!(
+                "updated Kubernetes Secret '{secret_name}' in namespace '{}'",
+                config.namespace
+            );
+        }
+        Err(e) => {
+            return Err(map_kube_error(e, &config.namespace));
+        }
+    }
+
+    eprintln!(
+        "Token stored in Kubernetes Secret '{secret_name}' (namespace: {})",
+        config.namespace
+    );
+    Ok(())
+}
+
+#[cfg(feature = "k8s")]
+fn map_kube_error(e: kube::Error, namespace: &str) -> MemoryError {
+    match &e {
+        kube::Error::Api(err_resp) if err_resp.code == 403 => MemoryError::TokenStorage(format!(
+            "Access denied. Ensure the service account has RBAC permission \
+                 for secrets in namespace '{namespace}': {e}"
+        )),
+        kube::Error::Api(err_resp) if err_resp.code == 404 => {
+            MemoryError::TokenStorage(format!("Namespace '{namespace}' does not exist: {e}"))
+        }
+        _ => MemoryError::TokenStorage(format!("Kubernetes API error: {e}")),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -683,8 +827,19 @@ mod tests {
     #[tokio::test]
     #[ignore = "requires real GitHub OAuth interaction"]
     async fn test_device_flow_login_ignored_in_ci() {
-        device_flow_login(Some(StoreBackend::Stdout))
-            .await
-            .expect("device flow should succeed");
+        device_flow_login(
+            Some(StoreBackend::Stdout),
+            #[cfg(feature = "k8s")]
+            None,
+        )
+        .await
+        .expect("device flow should succeed");
+    }
+
+    #[cfg(feature = "k8s")]
+    #[test]
+    #[ignore] // Requires a real Kubernetes cluster
+    fn test_store_in_k8s_secret_ignored_in_ci() {
+        // Placeholder for manual/integration testing
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,16 @@ struct LoginArgs {
     /// Where to store the token
     #[arg(long, value_enum)]
     store: Option<StoreBackend>,
+
+    #[cfg(feature = "k8s")]
+    #[arg(long, default_value = "butterfly")]
+    /// Kubernetes namespace for the token Secret.
+    k8s_namespace: String,
+
+    #[cfg(feature = "k8s")]
+    #[arg(long, default_value = "memory-mcp-github-token")]
+    /// Name of the Kubernetes Secret to create/update.
+    k8s_secret_name: String,
 }
 
 #[derive(Args)]
@@ -141,9 +151,22 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Serve(args)) => run_serve(args).await?,
         Some(Command::Auth(auth_cmd)) => match auth_cmd.action {
             AuthAction::Login(login_args) => {
-                auth::device_flow_login(login_args.store)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                #[cfg(feature = "k8s")]
+                let k8s_config = if matches!(login_args.store, Some(StoreBackend::K8sSecret)) {
+                    Some(auth::K8sSecretConfig {
+                        namespace: login_args.k8s_namespace.clone(),
+                        secret_name: login_args.k8s_secret_name.clone(),
+                    })
+                } else {
+                    None
+                };
+                auth::device_flow_login(
+                    login_args.store,
+                    #[cfg(feature = "k8s")]
+                    k8s_config,
+                )
+                .await
+                .map_err(|e| anyhow::anyhow!("{}", e))?;
             }
             AuthAction::Status => {
                 auth::print_auth_status();
@@ -333,5 +356,51 @@ mod tests {
         // produces a Serve command.
         let cli = Cli::parse_from(["memory-mcp", "serve"]);
         assert!(matches!(cli.command, Some(Command::Serve(_))));
+    }
+
+    #[cfg(feature = "k8s")]
+    #[test]
+    fn test_cli_auth_login_store_k8s_secret() {
+        let cli = Cli::try_parse_from(["memory-mcp", "auth", "login", "--store", "k8s-secret"])
+            .expect("auth login --store k8s-secret should parse");
+        match cli.command {
+            Some(Command::Auth(auth_cmd)) => match auth_cmd.action {
+                AuthAction::Login(login_args) => {
+                    assert!(matches!(login_args.store, Some(StoreBackend::K8sSecret)));
+                    assert_eq!(login_args.k8s_namespace, "butterfly");
+                    assert_eq!(login_args.k8s_secret_name, "memory-mcp-github-token");
+                }
+                _ => panic!("expected Login action"),
+            },
+            _ => panic!("expected Auth command"),
+        }
+    }
+
+    #[cfg(feature = "k8s")]
+    #[test]
+    fn test_cli_auth_login_k8s_namespace_override() {
+        let cli = Cli::try_parse_from([
+            "memory-mcp",
+            "auth",
+            "login",
+            "--store",
+            "k8s-secret",
+            "--k8s-namespace",
+            "custom-ns",
+            "--k8s-secret-name",
+            "custom-name",
+        ])
+        .expect("auth login with k8s flags should parse");
+        match cli.command {
+            Some(Command::Auth(auth_cmd)) => match auth_cmd.action {
+                AuthAction::Login(login_args) => {
+                    assert!(matches!(login_args.store, Some(StoreBackend::K8sSecret)));
+                    assert_eq!(login_args.k8s_namespace, "custom-ns");
+                    assert_eq!(login_args.k8s_secret_name, "custom-name");
+                }
+                _ => panic!("expected Login action"),
+            },
+            _ => panic!("expected Auth command"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `--store k8s-secret` to `auth login`, feature-gated behind `k8s` cargo feature
- Creates/updates a Kubernetes Secret containing the GitHub token
- Create-first strategy with 409 fallback to replace (no TOCTOU race)
- Configurable `--k8s-namespace` (default: butterfly) and `--k8s-secret-name` (default: memory-mcp-github-token)
- `store_token` made async (sole caller already async)
- TODO.md reconciled as canonical task list

## ADRs
- ADR-0013: Kubernetes Secret token storage

## Test plan
- [x] 58 tests pass without k8s feature (2 ignored)
- [x] 60 tests pass with k8s feature (3 ignored)
- [x] `cargo clippy -- -D warnings` clean (both configurations)
- [x] `cargo fmt --check` clean
- [x] `cargo doc --no-deps --features k8s` clean
- [x] Manual: `cargo run --features k8s -- auth login --store k8s-secret` against live cluster — Secret created with correct labels and token data

Related: butterflyskies/tasks#80

🤖 Generated with [Claude Code](https://claude.com/claude-code)