### PR TITLE
ci: add release binary assets with SHA256 checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           echo "Waiting for CI workflow on ${{ github.sha }}..."
           for attempt in $(seq 1 20); do
             run_id=$(gh run list --repo "${{ github.repository }}" --workflow=build.yml \
-              --commit="${{ github.sha }}" --limit=1 --json databaseId -q '.[0].databaseId')
+              --event=push --commit="${{ github.sha }}" --limit=1 --json databaseId -q '.[0].databaseId')
             [ -n "$run_id" ] && break
             echo "CI run not found yet, retrying in 30s (attempt $attempt/20)..."
             sleep 30
@@ -104,14 +104,12 @@ jobs:
   publish-binaries:
     needs: [release-please, ci-gate]
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             build-tool: cargo
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-            build-tool: cross
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             build-tool: cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1781,8 +1781,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2162,7 +2166,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3083,7 +3087,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3208,6 +3212,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,0 @@
-[target.x86_64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install -y libdbus-1-dev"]


### PR DESCRIPTION
## Summary
- Extract CI gate into a shared `ci-gate` job — both `publish-image` and `publish-binaries` depend on it
- Add `publish-binaries` job using `taiki-e/upload-rust-binary-action` (pinned to SHA) following the cargo-nextest release pattern
- All binaries built with `--features k8s` (opt-in at runtime via `--store k8s-secret`, safe without a cluster)

## Job graph
```
release-please
    └── ci-gate (waits for CI workflow)
            ├── publish-image (parallel)
            └── publish-binaries (parallel, per-target matrix)
```

## Targets
| Target | Runner | Build tool | Notes |
|--------|--------|-----------|-------|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | cargo | Native, installs libdbus-1-dev |
| `universal-apple-darwin` | `macos-latest` | cargo | Fat binary (x86_64 + aarch64 via lipo) |

## Release assets produced per target
| File | Description |
|------|-------------|
| `memory-mcp-<tag>-<target>.tar.gz` | Binary archive |
| `memory-mcp-<tag>-<target>.tar.gz.sha256` | SHA256 checksum |

## Deferred targets
- `x86_64-unknown-linux-musl` — blocked by libdbus C FFI dependency; needs either vendored dbus, async-secret-service (zbus), or conditional features
- `x86_64-pc-windows-msvc` — needs keyring backend investigation
- `x86_64-unknown-freebsd` / `x86_64-unknown-illumos` — only if user demand materializes

## Test plan
- [ ] CI gate correctly blocks until build.yml passes
- [ ] publish-image and publish-binaries run in parallel after gate
- [ ] GNU binary archive contains the correct `memory-mcp` binary with k8s feature
- [ ] macOS universal binary works on both Intel and Apple Silicon
- [ ] SHA256 checksum files are present and correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)