### PR TITLE
fix: show help text for k8s CLI flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,14 +74,14 @@ struct LoginArgs {
     #[arg(long, value_enum)]
     store: Option<StoreBackend>,
 
+    /// Kubernetes namespace for the token Secret.
     #[cfg(feature = "k8s")]
     #[arg(long, default_value = "memory-mcp")]
-    /// Kubernetes namespace for the token Secret.
     k8s_namespace: String,
 
+    /// Name of the Kubernetes Secret to create/update.
     #[cfg(feature = "k8s")]
     #[arg(long, default_value = "memory-mcp-github-token")]
-    /// Name of the Kubernetes Secret to create/update.
     k8s_secret_name: String,
 }
 


### PR DESCRIPTION
## Summary
- Move `///` doc comments above `#[cfg(feature = "k8s")]` so clap's derive macro picks them up
- Without this, `--help` showed no description for `--k8s-namespace` and `--k8s-secret-name`

This is also the trivial releasable commit to trigger release-please for v0.1.3 — the first release with binary assets.

## Test plan
- [ ] `cargo build --features k8s` — verify `--help` shows descriptions for both flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)