### PR TITLE
fix: draft release flow for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           gh run watch "$run_id" --repo "${{ github.repository }}" --exit-status > /dev/null
           echo "CI run $run_id passed."
 
-  # Build and push a semver-tagged container image when a release is published.
+  # Build and push a semver-tagged container image.
   #
   # This runs in the same workflow as release-please because GITHUB_TOKEN events
   # don't trigger other workflows (anti-cascade rule).
@@ -141,3 +141,20 @@ jobs:
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: refs/tags/${{ needs.release-please.outputs.tag_name }}
+
+  # Undraft the release after all artifacts (image + binaries) are uploaded.
+  # release-please creates a draft so that immutable-release rules don't block
+  # asset uploads; this job flips the draft flag once everything is in place.
+  publish-release:
+    needs: [release-please, publish-image, publish-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "${{ needs.release-please.outputs.tag_name }}" \
+            --draft=false \
+            --repo "${{ github.repository }}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,9 @@
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "draft": true,
+      "force-tag-creation": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- release-please now creates **draft** releases with `force-tag-creation: true`
- Binary uploads (via upload-rust-binary-action) and image pushes happen against the draft
- New `publish-release` job undrafts the release after all artifacts are in place

Fixes the `HTTP 422: Cannot upload assets to an immutable release` failure on v0.1.3.

## How it works
1. `release-please` → creates draft release + pushes git tag
2. `ci-gate` → waits for build.yml to pass
3. `publish-image` + `publish-binaries` → upload artifacts to draft release
4. `publish-release` → `gh release edit --draft=false`

## Test plan
- [ ] Merge and verify next release creates a draft, uploads binaries, then publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)