### PR TITLE
fix: show help text for k8s-secret store variant

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,8 +67,8 @@ pub enum StoreBackend {
     File,
     /// Print token to stdout and do not persist it.
     Stdout,
-    #[cfg(feature = "k8s")]
     /// Store token as a Kubernetes Secret.
+    #[cfg(feature = "k8s")]
     #[clap(name = "k8s-secret")]
     K8sSecret,
 }


### PR DESCRIPTION
## Summary
- Move `///` doc comment above `#[cfg(feature = "k8s")]` on `StoreBackend::K8sSecret`
- Same class of bug as 64d5807 (fixed in `LoginArgs`), this time in the enum variant

This also serves as the releasable commit to trigger v0.1.4 — the first release to validate the draft → upload → publish flow from PR #26.

## Test plan
- [ ] `cargo build --features k8s` — verify `--help` shows description for `--store k8s-secret`
- [ ] v0.1.4 release produces draft, uploads binaries, then publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)