### PR TITLE
fix: vendor OpenSSL for macOS and Windows release binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "keyring",
  "kube",
  "libc",
+ "openssl",
  "reqwest",
  "rmcp",
  "schemars 0.8.22",
@@ -2364,6 +2365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2381,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ schemars = "0.8"
 tokio-util = { version = "0.7", features = ["rt"] }
 libc = "0.2"
 keyring = { version = "3", features = ["sync-secret-service", "apple-native", "windows-native"] }
+openssl = { version = "0.10", features = ["vendored"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 kube = { version = "3.1", default-features = false, features = ["client", "rustls-tls"], optional = true }
 k8s-openapi = { version = "0.27", features = ["v1_31"], optional = true }


### PR DESCRIPTION
## Summary
Add `openssl = { version = "0.10", features = ["vendored"] }` to compile OpenSSL from source in release builds.

## Problem
macOS and Windows CI runners don't have OpenSSL dev headers. `openssl-sys` (pulled in transitively by `git2` and `fastembed` → `hf-hub` → `native-tls`) fails to build:
```
Could not find directory of OpenSSL installation
```

## Fix
Vendored OpenSSL compiles from source — no system dependency needed. Builds are self-contained across all platforms. Tradeoff is slightly longer build times on macOS/Windows.

## Test plan
- [ ] v0.1.5 release builds succeed on all three platforms (gnu, darwin, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)