### PR TITLE
fix(ci): use GitHub App token for release-please to trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,21 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
+      # Generate a token from the release-manager GitHub App so that PRs
+      # created by release-please trigger CI workflows. The default
+      # GITHUB_TOKEN doesn't trigger workflows (anti-cascade rule).
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - id: release
         uses: googleapis/release-please-action@8bb7a2ed0f90c9802c83129a9488d235a1f31a7c # main (2026-02-20, includes release-please 17.3.0 with force-tag-creation)
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
   # All publish jobs share this CI gate. It waits for the CI workflow (triggered
   # by the same push event) to pass before allowing any artifacts to ship.


### PR DESCRIPTION
## Summary
- Release-please PRs created with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows (GitHub's anti-cascade rule)
- This left PR #53 (v0.2.0 release) stalled with zero CI checks, blocked by branch protection
- Adds a dedicated GitHub App (`butterflyskies-release-manager-bot`) to generate a scoped token for release-please
- PRs created with App tokens trigger workflows normally

## Details
- App permissions: `contents: write`, `pull_requests: write` (minimum required)
- Org secrets: `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`
- Private key backed up in 1Password
- Uses `actions/create-github-app-token@v3.0.0` (pinned to commit SHA)

## Test plan
- [ ] This PR's CI passes (proves the workflow YAML is valid)
- [ ] After merge, close and re-create PR #53 (or push to its branch) to verify release-please PRs now trigger CI
- [ ] Alternatively: wait for next release-please PR to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)