### PR TITLE
docs: fix README accuracy and update TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ AI coding agents are stateless between sessions. They lose context about your pr
 
 ## Quick start
 
-### From source
+### Install from crates.io
+
+```bash
+cargo install memory-mcp
+```
+
+### Or from source
 
 ```bash
 git clone https://github.com/butterflyskies/memory-mcp.git
@@ -25,14 +31,17 @@ cargo build --release
 
 ### Run the server
 
+On first run, the embedding model (~130MB) is downloaded from HuggingFace Hub.
+You can pre-download it with `memory-mcp warmup`.
+
 ```bash
 # Starts on 127.0.0.1:8080 with a local git repo at ~/.memory-mcp
-./target/release/memory-mcp serve
+memory-mcp serve
 
 # Or configure via environment variables
 MEMORY_MCP_BIND=0.0.0.0:9090 \
 MEMORY_MCP_REPO_PATH=/path/to/memories \
-./target/release/memory-mcp serve
+memory-mcp serve
 ```
 
 ### Connect Claude Code
@@ -154,7 +163,7 @@ memory-mcp auth login
 
 # Or specify storage explicitly
 memory-mcp auth login --store keyring   # system keyring (default)
-memory-mcp auth login --store file      # ~/.memory-mcp-token
+memory-mcp auth login --store file      # ~/.config/memory-mcp/token
 memory-mcp auth login --store stdout    # print token, pipe to your own storage
 
 # Kubernetes deployments (requires --features k8s)
@@ -164,7 +173,7 @@ memory-mcp auth login --store k8s-secret
 memory-mcp auth status
 ```
 
-Token resolution order: `MEMORY_MCP_GITHUB_TOKEN` env var → `~/.memory-mcp-token` file → system keyring.
+Token resolution order: `MEMORY_MCP_GITHUB_TOKEN` env var → `~/.config/memory-mcp/token` file → system keyring.
 
 ## Embedding model
 
@@ -218,6 +227,18 @@ Significant design decisions are documented as Architecture Decision Records in 
 - **Input validation**: memory names, content size, and nesting depth are validated. Path traversal and symlink attacks are blocked.
 - **Container hardening**: non-root user, read-only filesystem, dropped capabilities, seccomp profile.
 - **Supply chain**: CI pins all GitHub Actions to commit SHAs. Container images include SLSA provenance and SBOM attestations. Dependencies are audited with `cargo audit` on every build.
+
+## Roadmap
+
+The core memory engine is stable — store, search, sync, and authenticate all work today. Planned next:
+
+- **BM25 keyword search** alongside semantic search ([#55](https://github.com/butterflyskies/memory-mcp/issues/55))
+- **Cross-platform vector index** with brute-force fallback for Windows ([#56](https://github.com/butterflyskies/memory-mcp/issues/56))
+- **Deduplication** on remember (semantic similarity threshold)
+- **Tag-based filtering** in recall
+- **Richer observability** with structured tracing across all subsystems ([#52](https://github.com/butterflyskies/memory-mcp/issues/52))
+
+See [TODO.md](TODO.md) for the full plan and [open issues](https://github.com/butterflyskies/memory-mcp/issues) for what's in flight.
 
 ## Development
 

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [x] Scaffold Rust MCP server with streamable HTTP transport (PR #1)
 - [x] Define memory file format (markdown + YAML frontmatter for tags, timestamps, source)
 - [x] Implement memory repo management (init, open existing, commit) — git2
-- [x] Choose local embedding model — fastembed (AllMiniLML6V2)
+- [x] Choose local embedding model — ~~fastembed~~ candle direct (BGE-small-en-v1.5, ADR-0016)
 - [x] Build HNSW vector index alongside storage — usearch with cosine metric
 - [x] Implement `remember` — embed, index (atomic via `add_with_next_key`), commit to git
 - [x] Implement `recall` — semantic search with scope filtering, limit clamping, over-fetch
@@ -13,12 +13,12 @@
 - [x] Implement `edit` — partial updates, skip re-embed when only tags change
 - [x] Implement `list` — browse memories with optional scope filter
 - [x] Implement `read` — read specific memory by name with full metadata
-- [x] Implement `sync` — pull/push orchestration (stubs wired, auth flow pending)
+- [x] Implement `sync` — pull/push orchestration with remote auth
 - [x] Structured observability — tracing spans with timing on all handlers (ADR-0006)
 - [x] Input validation — name validation, content size limits, nesting depth limits
 - [x] Error mapping — `From<MemoryError> for ErrorData` with appropriate MCP error codes
 
-## Phase 2: Sync + Auth + Migration
+## Phase 2: Sync + Auth + Deployment
 
 - [x] Implement real git push/pull with remote auth (PR #4)
   - [x] Lazy token resolution — local-only mode works without credentials
@@ -38,24 +38,44 @@
   - [x] GitHub OAuth device flow with scoped token acquisition
   - [x] Token storage: keyring default, explicit `--store file|stdout` opt-in
   - [x] Security hardening: umask 0o077, atomic file writes, request/loop timeouts
-- [ ] `--store k8s-secret` backend (cargo feature-gated)
+- [x] `--store k8s-secret` backend (cargo feature-gated, `--features k8s`)
+- [x] Container image (Dockerfile, publish to ghcr.io) — PR #13
+- [x] K8s deployment manifests (`deploy/k8s/`)
 - [ ] Extract OAuth client ID from hardcoded const into config module
 - [ ] Integration tests for `auth login`, `auth status`, `MEMORY_MCP_BIND` env var
-- [ ] Migration tool: import Serena global memories (preserve content + metadata) (ADR-0008)
-- [ ] Migration tool: import Serena project-scoped memories
-- [ ] Migration tool: import Claude Code auto-memories
-- [ ] Container image (Dockerfile, publish to ghcr.io) — PR #13
-- [ ] K8s deployment: Cilium Gateway API, StepClusterIssuer certs
-- [ ] Container signing (cosign) — keyless vs long-lived key ADR, verify in deploy pipeline
-- [ ] CVE scanning gate in CI — consume SBOM attestation with Grype/Trivy, block on critical
-- [ ] Test cross-device sync workflow
-- [ ] Configure as MCP server in `~/.claude.json`
-- [ ] Update CLAUDE.md instructions to use memory-mcp instead of Serena memories
 
-## Phase 3: Polish
+## Phase 2.5: Trust signals + crates.io
 
+- [x] Cargo.toml metadata (description, repository, keywords, categories)
+- [x] cargo-deny replacing cargo-audit in CI
+- [x] `#![warn(missing_docs)]` on lib crate
+- [x] MSRV 1.88 declared + CI enforced (ADR-0017)
+- [x] Dedicated GitHub App for release-please (ADR-0018)
+- [x] Fat lib / thin binary refactor — public API surface (PR #64, closes #61)
+- [x] Replace `Secret<T>` with `secrecy` crate — zeroize-on-drop (#66)
+- [x] Semver hardening — `#[non_exhaustive]`, constructors, serde strategy (ADR-0019)
+- [x] Proper path resolution with `homedir` + `shellexpand` (#68)
+- [x] cargo-semver-checks in CI (PR #73)
+- [x] Published to crates.io (v0.3.0)
+- [ ] Trusted Publishing (OIDC from GitHub Actions) (#62)
+- [ ] Atomic file writes and symlink safety in token I/O (#69)
+- [ ] cargo-auditable — embed dep tree in release binaries (#60, blocked on upstream)
+
+## Phase 3: Retrieval + Polish
+
+- [ ] BM25 keyword search via Tantivy (#55)
+- [ ] Cross-platform vector index — brute-force fallback for Windows (#56)
 - [ ] Deduplication / update detection on `remember` (semantic similarity threshold)
+- [ ] Tag-based filtering in `recall` (tags are stored but not queried)
 - [ ] Memory metadata enrichment (last-accessed, access count, confidence)
 - [ ] Periodic background sync
+- [ ] Comprehensive tracing and observability pass (#52)
+- [ ] recall over-fetch multiplier — handle truncated results (#71)
+
+## Future
+
+- [ ] Migration tools: import from Serena memories, Claude Code auto-memories (ADR-0008)
+- [ ] Container signing (cosign)
+- [ ] CVE scanning gate in CI (Grype/Trivy on SBOM attestation)
 - [ ] CLI for manual memory management outside of agent sessions
-- [ ] Tag-based filtering in `recall` (currently semantic-only; tags are stored but not queried)
+- [ ] Configure as default MCP server in `~/.claude.json` / Cursor / Windsurf


### PR DESCRIPTION
## Summary

- Fix token file path in README (`~/.config/memory-mcp/token`, was `~/.memory-mcp-token`)
- Add `cargo install memory-mcp` as primary install method (published to crates.io in v0.3.0)
- Document first-run model download (~130MB) and `warmup` subcommand
- Add Roadmap section linking to TODO.md and open issues
- Overhaul TODO.md to reflect current state: mark completed work, add Phase 2.5 (trust signals), reorganize remaining items with issue cross-references

## Why

The crate is now published on crates.io but the README didn't mention `cargo install`. The token file path was wrong in two places — would actively mislead users. TODO.md was stale with items marked incomplete that shipped months ago.

## Test plan

- [x] No code changes — documentation only
- [x] Verified token file path matches `src/auth.rs` constant (`TOKEN_FILE = ".config/memory-mcp/token"`)
- [x] All issue cross-references in TODO.md link to real open issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)