### PR TITLE
docs: add deployment workstream plan

### DIFF
--- a/.serena/memories/deployment_target.md
+++ b/.serena/memories/deployment_target.md
@@ -1,24 +1,47 @@
 # Deployment Target
 
-## Primary: Kubernetes
-- Running in the `butterfly` namespace
-- Behind Cilium Gateway API (HTTPRoute)
-- HTTPS with fixed domain name
-- TLS certificate managed by StepClusterIssuer (step-ca)
-- TLS terminates at the gateway — binary serves plain HTTP
-- AI agent k8s identity: `github:butterflysky-ai` with RBAC for secrets, services, pods, deployments, httproutes
+## Primary: Kubernetes (goddess cluster)
 
-## Token storage in k8s
+### What's done
+- Container image: `ghcr.io/butterflyskies/memory-mcp` built in CI, multi-stage with pre-warmed model
+- K8s manifests in `deploy/k8s/`: namespace, rbac, pvc, service, deployment, secret
+- Container hardened: non-root, readOnlyRootFilesystem, drop ALL caps, seccomp RuntimeDefault
+- SLSA provenance + SBOM attestations on every image push
+- `--features k8s` for `--store k8s-secret` token storage backend
+- AI agent k8s identity: `github:butterflysky-ai` with RBAC for secrets, services, pods, deployments, httproutes
+- Namespace: `butterfly`
+
+### What's NOT done
+- **ArgoCD Application manifest** — no GitOps deployment yet, manifests exist but aren't wired to ArgoCD
+- **Gateway API HTTPRoute** — manifests use generic Service but no HTTPRoute defined for external access
+- **TLS** — StepClusterIssuer manages certs via gateway `gw-ext` listener config; not configured for memory-mcp yet
+- **Storage class** — PVC exists but may not specify `ceph-block` (the cluster default StorageClass)
+- **Abstraction** — current manifests mix generic concerns with goddess-cluster-specific concerns; need to separate:
+  - Generic: deployment spec, service, rbac, container config
+  - Cluster-specific: StorageClass (`ceph-block`), Gateway API config, cert management, ArgoCD app
+
+### Cluster environment specifics (goddess)
+- **Ingress**: Gateway API only, never Ingress. Gateway name: `gw-ext`
+- **Certs**: StepClusterIssuer (step-ca), typically managed within the gateway definition derived from listener configs and HTTPRoute
+- **Storage**: `ceph-block` is the default StorageClass
+- **GitOps**: ArgoCD for all deployments
+- **TLS termination**: at the gateway — the binary serves plain HTTP internally
+
+### Token storage in k8s
 - GitHub token stored as a Kubernetes Secret
 - Mounted as env var `MEMORY_MCP_GITHUB_TOKEN` in the pod spec
 - Existing auth chain (env var → file → keyring) handles this natively
 
-## Client access
+### Client access
 - Claude Code sessions connect via MCP server URL in `~/.claude.json`
 - No local binary or local git repo needed on client devices
 - Memories centralized in the k8s-hosted instance
 
-## Auth subcommand plan
-- `memory-mcp auth login` — OAuth device flow + auto-detect storage
-- `memory-mcp auth login --store k8s-secret` — creates K8s Secret directly (kube crate, behind `k8s` cargo feature)
-- `memory-mcp auth status` — reports which auth source resolved
+### Deployment work items needed
+1. Review and update PVC to confirm ceph-block StorageClass
+2. Create HTTPRoute for memory-mcp behind gw-ext gateway
+3. Verify TLS cert provisioning via StepClusterIssuer
+4. Create ArgoCD Application manifest
+5. Separate generic manifests from goddess-cluster overlays (kustomize or similar)
+6. Test end-to-end: deploy → auth → remember → recall → sync
+7. Operational runbook: model weights mmap concern (see operational_concerns memory)

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -4,6 +4,7 @@
 A semantic memory system for AI coding agents, exposed as an MCP server. Memories are stored as markdown files in a git repository, synced across devices via GitHub, and indexed for semantic retrieval using local embeddings.
 
 **Repo**: https://github.com/butterflyskies/memory-mcp (public, MIT OR Apache-2.0)
+**crates.io**: https://crates.io/crates/memory-mcp (published v0.3.0, 2026-03-21)
 
 ## Tech Stack
 - **Language**: Rust (edition 2021)
@@ -14,6 +15,8 @@ A semantic memory system for AI coding agents, exposed as an MCP server. Memorie
 - **Vector index**: usearch 2 (HNSW with cosine metric)
 - **CLI**: clap with derive
 - **Auth**: GitHub token via env var → keyring → token file; OAuth device flow; k8s-secret backend (feature-gated)
+- **Credentials**: secrecy crate (SecretString, zeroize-on-drop)
+- **Path resolution**: homedir + shellexpand
 
 ## Transport
 Streamable HTTP only (no stdio, no SSE). Single binary serves both local dev and k8s.
@@ -21,39 +24,27 @@ Streamable HTTP only (no stdio, no SSE). Single binary serves both local dev and
 ## CLI Structure
 - `memory-mcp serve` (default) — runs the MCP server
 - `memory-mcp auth login [--store keyring|file|stdout|k8s-secret]` — OAuth device flow
-- `memory-mcp auth status` — show resolved token source
+- `memory-mcp auth status` — show resolved token source and provenance
 - `memory-mcp warmup` — pre-download embedding model (used in Dockerfile)
 
 ## Container & CI
 - **Registry**: ghcr.io/butterflyskies/memory-mcp
 - **Dockerfile**: multi-stage (rust:trixie → model warmup → debian:trixie-slim runtime)
-- **Trixie used**: Debian Trixie base image (no longer required by glibc constraints since fastembed/ort-sys removal)
-- **HF_HOME**: HuggingFace Hub model cache directory; pinned to absolute path in Docker
-- **CI**: GitHub Actions — fmt, clippy, nextest, cargo audit, Docker build, cross-platform build (Linux + macOS)
-- **Cross-compile**: `cargo build --features k8s` on ubuntu-latest + macos-latest in PRs; Windows blocked by usearch (#42)
-- **OpenSSL**: vendored on non-Linux (macOS/Windows lack system headers); Linux uses system OpenSSL via pkg-config
+- **CI**: GitHub Actions — fmt, clippy, nextest, cargo-deny, cargo-semver-checks, Docker build, cross-platform build (Linux + macOS)
+- **Cross-compile**: `cargo build --features k8s` on ubuntu-latest + macos-latest; Windows blocked by usearch (#42)
 - **Attestations**: SLSA provenance + SBOM on every image push
-- **Release**: release-please (draft → upload assets → undraft) with conventional commits, Node.js 24 opt-in
+- **Release**: release-please with conventional commits
 
 ## Security
-- Process-wide umask 0o077, atomic token writes, no silent credential fallback
-- Container: non-root user, readOnlyRootFilesystem, drop ALL capabilities, seccomp RuntimeDefault
+- Process-wide umask 0o077, no silent credential fallback
+- SecretString (secrecy crate) for all token handling — zeroize-on-drop
+- Container: non-root user, readOnlyRootFilesystem, drop ALL caps, seccomp RuntimeDefault
 - All GHA actions pinned to commit SHAs
-- cargo audit in CI pipeline
+- cargo-deny in CI pipeline
 
 ## Branch Protection
-- **Org ruleset** (`protect main branch`): deletion, no force-push, linear history, signed commits, 1 approving review, Copilot code review
-- **Repo ruleset** (`require CI checks`): test, build, audit, msrv, cross-compile (Linux + macOS), lint — all must pass before merge
-
-## Trust Signals
-- **Shipped**: Cargo.toml metadata (description, repository, keywords, categories incl. artificial-intelligence), cargo-deny replacing cargo-audit, `#![warn(missing_docs)]` on lib crate, MSRV 1.88 declared + CI enforced
-- **ADRs**: 0017 (MSRV match-deps policy), 0018 (dedicated GitHub App for release-please)
-- **Deferred**: cargo-auditable (#60, blocked on upstream action support), cargo-semver-checks (#61 prereq: lib refactor), crates.io publish (#62, blocked on #61)
-
-## Release Infrastructure
-- **GitHub App**: `butterflyskies-release-manager-bot` (app ID 3144639) generates tokens for release-please so its PRs trigger CI workflows
-- **Org secrets**: `RELEASE_BOT_APP_ID`, `RELEASE_BOT_PRIVATE_KEY`
-- **deny.toml**: license allowlist tuned to actual transitive deps; webpki-roots CDLA-Permissive-2.0 as scoped exception; unmaintained transitive deps (number_prefix, paste) ignored
+- **Org ruleset**: deletion, no force-push, linear history, signed commits, 1 review, Copilot review
+- **Repo ruleset**: test, build, audit, msrv, semver-checks, cross-compile (Linux + macOS), lint
 
 ## Status
-v0.2.0 released. Trust signals Phase 1+2 shipped. Next: lib refactor (#61), then semver-checks + crates.io publish (#62). Also: BM25/Tantivy (#55), cross-platform vector index (#56), tracing/observability (#52).
+v0.3.0 published to crates.io. Trust signals Phase 2.5 complete. Next: k8s deployment workstream (see docs/deployment-workstream.md), then Serena memory migration.

--- a/.serena/memories/session_handoff.md
+++ b/.serena/memories/session_handoff.md
@@ -1,22 +1,36 @@
 # Session Handoff — memory-mcp
 
 ## What just shipped
-- PR #43: cross-platform CI (Linux + macOS `cargo build`) + vendored OpenSSL + Windows removed from matrices
-- PR #45: conditional OpenSSL vendoring (non-Linux only) + Node.js 24 opt-in for release-please
-- v0.1.5 release cut with `Release-As: 0.1.5` — check that release pipeline completed (draft → binaries → undraft)
+- PR #64: fat lib / thin binary refactor closing 7 issues (#61, #65, #66, #67, #68, #70, #72)
+- PR #73: cargo-semver-checks as required CI check (8 required checks total)
+- PR #74: README accuracy fixes (token path, cargo install, TODO overhaul)
+- PR #75: MCP client config snippets for 7 editors
+- v0.3.0 published to crates.io (first publish, manual — Trusted Publishing not yet configured)
 
 ## Open PRs
-- PR #47 (memory-mcp): project overview memory update — trivial, ready to merge
-- PR #4 (flight-log): evening flight log entry
-- PR #5 (rust-template): accumulated CI improvements — needs cross-platform CI ported from memory-mcp
+- PR #76: deployment workstream doc + Serena memory updates — needs CI + merge
 
-## Pending items
-- **rust-template**: port the cross-compile job and conditional OpenSSL vendoring from memory-mcp
-- **v0.1.5 release verification**: confirm macOS binary was uploaded and release was undrafted
-- **Node.js 24 compatibility**: first real test happens on next release-please run — watch for failures
-- **cc-toolgate#19 / tasks#90**: config_env process environment fallback — on Friday Focus milestone
+## Next up: k8s deployment workstream
+Detailed plan in `docs/deployment-workstream.md`. Seven phases:
+1. Manifest separation (kustomize base + goddess overlay)
+2. Gateway API + TLS (StepClusterIssuer, HTTPRoute for gw-ext)
+3. ArgoCD Application
+4. Token bootstrap
+5. Serena → memory-mcp migration
+6. Claude Code integration (CLAUDE.md rewrite)
+7. Operational concerns (health probes, resource sizing)
 
-## Context
-- Windows builds are blocked by usearch v2.24.0 MAP_FAILED incompatibility (#42) — no upstream fix available
-- Git identity must use AI account for all pushes (user can't approve their own PRs)
-- User prefers new commits over amend + force-push
+Key decisions needed:
+- Namespace: `butterfly` (shared) or `memory-mcp` (dedicated)?
+- Image updates: ArgoCD Image Updater or manual sync?
+- ArgoCD app: in this repo or separate gitops repo?
+
+## Also pending
+- #62: Trusted Publishing (OIDC from GitHub Actions) — first manual publish done, need to configure TP in crates.io web UI
+- #69: atomic file writes / symlink safety in token I/O — pre-existing, surfaced in code review
+- cc-toolgate: 12 issues filed (#24-#35) — no Rust CI is the critical gap
+
+## Operational notes
+- semver-checks requires a crates.io baseline — won't work until the crate is published. Future versions will compare against the last published release automatically.
+- `cargo publish` ships source as-is; feature flags are resolved by consumers, not at publish time
+- The `docs/deployment.md` goddess cluster section describes a future state that isn't built yet — `docs/deployment-workstream.md` is the plan to get there

--- a/docs/deployment-workstream.md
+++ b/docs/deployment-workstream.md
@@ -1,0 +1,234 @@
+# Deployment Workstream: Kubernetes Production Readiness
+
+Status: planning (not yet started)
+
+## Goal
+
+Deploy memory-mcp to the goddess Kubernetes cluster as the production memory
+backend for all AI agent sessions. Replace Serena's memory layer while keeping
+Serena's code intelligence tools.
+
+## Prerequisites (done)
+
+- [x] Container image builds in CI (`ghcr.io/butterflyskies/memory-mcp`)
+- [x] Multi-stage Dockerfile with pre-warmed embedding model
+- [x] Container hardening (non-root, read-only root fs, dropped caps, seccomp)
+- [x] SLSA provenance + SBOM attestations
+- [x] Generic k8s manifests in `deploy/k8s/`
+- [x] `--features k8s` for `--store k8s-secret` token storage backend
+- [x] Streamable HTTP transport (no stdio dependency)
+
+## Phase 1: Manifest separation (generic vs cluster-specific)
+
+The current manifests in `deploy/k8s/` mix generic and cluster-specific concerns.
+Separate them using kustomize so the generic base works on any cluster.
+
+### Base (`deploy/k8s/base/`)
+
+These should work on any Kubernetes cluster with no modifications:
+
+- `namespace.yml` — creates the namespace
+- `rbac.yml` — ServiceAccounts (runtime + bootstrap), Roles, RoleBindings
+- `pvc.yml` — PersistentVolumeClaim for the git-backed memory repo (no
+  StorageClass specified — uses cluster default)
+- `service.yml` — ClusterIP Service on port 8080
+- `deployment.yml` — Deployment with security context, resource limits,
+  health probes, volume mounts
+- `kustomization.yaml` — ties them together
+
+### Overlay (`deploy/k8s/overlays/goddess/`)
+
+Cluster-specific configuration:
+
+- `kustomization.yaml` — patches the base with goddess-specific values
+- `httproute.yml` — Gateway API HTTPRoute for `gw-ext` gateway
+- PVC patch: set `storageClassName: ceph-block` (matches cluster default,
+  but explicit is better than implicit)
+- Deployment patch: set image to `ghcr.io/butterflyskies/memory-mcp`,
+  configure `MEMORY_MCP_REMOTE_URL`, mount the GitHub token secret
+- Namespace patch: if deploying to `butterfly` instead of `memory-mcp`
+
+## Phase 2: Gateway API + TLS
+
+The goddess cluster uses Cilium Gateway API with StepClusterIssuer (step-ca)
+for automatic TLS certificate provisioning.
+
+### HTTPRoute
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: memory-mcp
+spec:
+  parentRefs:
+    - name: gw-ext
+      sectionName: https
+  hostnames:
+    - memories.svc.echoes  # or whatever domain is chosen
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: memory-mcp
+          port: 8080
+```
+
+### TLS considerations
+
+- Certificate is managed by the gateway listener configuration, not by the
+  application. The `gw-ext` gateway's HTTPS listener references a
+  StepClusterIssuer — certs are provisioned automatically when the
+  HTTPRoute attaches to the listener.
+- The memory-mcp pod serves plain HTTP. TLS terminates at the gateway.
+- No cert-manager Certificate resource needed in the application namespace
+  (the gateway handles it).
+
+## Phase 3: ArgoCD Application
+
+Create an ArgoCD Application that syncs the goddess overlay:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: memory-mcp
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/butterflyskies/memory-mcp.git
+    targetRevision: main
+    path: deploy/k8s/overlays/goddess
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: butterfly  # or memory-mcp, depending on namespace decision
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+### Decisions needed
+
+- **Namespace**: `butterfly` (shared with other workloads) or `memory-mcp`
+  (dedicated)? The existing manifests use `memory-mcp`. Using `butterfly`
+  would share the RBAC boundary with other AI agent infrastructure.
+- **Image updates**: ArgoCD Image Updater for automatic rollouts on new
+  image tags, or manual sync?
+- **Should the ArgoCD Application live in this repo** (alongside the
+  manifests) or in a separate gitops repo?
+
+## Phase 4: Token bootstrap
+
+The pod needs a GitHub token for git sync. Options:
+
+1. **Pre-create the secret manually** — `kubectl create secret` with a PAT
+2. **Use `memory-mcp auth login --store k8s-secret`** — run as a one-off
+   Job using the bootstrap ServiceAccount
+3. **Mount an existing secret** — if the token is already in the cluster
+   from another workload
+
+The existing RBAC in `deploy/k8s/rbac.yml` has a `memory-mcp-bootstrap`
+ServiceAccount with permission to create/update secrets. Option 2 is the
+intended flow.
+
+## Phase 5: Migration (Serena → memory-mcp)
+
+Import existing Serena memories into the memory-mcp store. Two sources:
+
+### Global memories (`~/.serena/memories/`)
+
+~20 memories covering environment variables, code standards, workflow
+preferences, project standards, etc. These become `scope: global` memories
+in memory-mcp.
+
+### Project memories (`.serena/memories/` in each repo)
+
+Project-specific context: session handoffs, overviews, deployment targets,
+operational concerns. These become `scope: project:{repo-name}` memories.
+
+### Migration approach
+
+1. Write a script that reads each Serena memory file, extracts the name and
+   content, and calls the `remember` MCP tool (or directly writes markdown
+   files to the memory-mcp git repo in the expected format)
+2. Verify with `list` and `recall` that all memories are searchable
+3. Run a parallel session using both Serena memories and memory-mcp to
+   validate parity
+
+## Phase 6: Claude Code integration
+
+### Update CLAUDE.md
+
+Replace Serena memory references in `~/.claude/CLAUDE.md` with memory-mcp
+tool calls:
+
+| Serena | memory-mcp |
+|--------|-----------|
+| `read_memory` | `read` tool |
+| `write_memory` | `remember` tool |
+| `edit_memory` | `edit` tool |
+| `delete_memory` | `forget` tool |
+| `list_memories` | `list` tool |
+| `rename_memory` | `forget` + `remember` (no native rename yet) |
+
+### MCP server config
+
+Add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "type": "http",
+      "url": "https://memories.svc.echoes/mcp"
+    }
+  }
+}
+```
+
+### Parallel run period
+
+Run both Serena memories and memory-mcp for 2-3 sessions to validate:
+- Session startup instructions work
+- Memory reads/writes are reliable
+- Semantic search (recall) finds relevant memories
+- Latency is acceptable (network hop to k8s vs local file reads)
+- Error handling when the server is temporarily unreachable
+
+## Phase 7: Operational concerns
+
+### Model weights mmap safety
+
+The embedding model is memory-mapped from the HuggingFace cache. If the
+cache is mutated while the server is running (e.g., by `huggingface-cli`),
+the mmap'd region becomes undefined. The container image pre-warms the
+model so this is only a concern if the cache volume is shared.
+
+**Mitigation**: The container's HF_HOME is on its own volume, not shared.
+Document in the operational runbook.
+
+### Health probes
+
+The deployment should include liveness and readiness probes. The MCP
+endpoint itself can serve as a readiness check (POST to `/mcp` with
+an MCP initialize request). A simpler option is a dedicated `/healthz`
+endpoint — this doesn't exist yet and would need to be added.
+
+### Resource sizing
+
+- **Memory**: ~300MB baseline (model weights + index). Grows with memory
+  count — plan for 512MB request, 1Gi limit as a starting point.
+- **CPU**: Embedding computation is CPU-bound. Single-query latency is
+  ~50ms on modern hardware. 250m request, 1 core limit.
+- **Disk**: The git repo + HF model cache. 1Gi PVC should be generous
+  for the foreseeable future.
+
+### Backup
+
+The git repo IS the backup — it syncs to a GitHub remote. If the PVC is
+lost, re-clone from the remote. The vector index is rebuilt from the repo
+on startup.


### PR DESCRIPTION
## Summary

- Add `docs/deployment-workstream.md` — 7-phase plan for k8s production deployment
- Update Serena project memories (project_overview, deployment_target)

## Phases covered

1. Manifest separation (kustomize base + goddess overlay)
2. Gateway API + TLS (StepClusterIssuer, HTTPRoute)
3. ArgoCD Application
4. Token bootstrap
5. Serena → memory-mcp migration
6. Claude Code integration (CLAUDE.md rewrite)
7. Operational concerns (model mmap, health probes, resource sizing)

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)