### PR TITLE
ci: add trusted publishing for crates.io releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,11 +152,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: refs/tags/${{ needs.release-please.outputs.tag_name }}
 
-  # Undraft the release after all artifacts (image + binaries) are uploaded.
+  # Publish to crates.io using Trusted Publishing (OIDC — no API token needed).
+  # Requires the "release" environment configured in GitHub repo settings and
+  # a Trusted Publisher entry in crates.io linking this repo + workflow.
+  publish-crate:
+    needs: [release-please, ci-gate]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master (2026-02-13)
+        with:
+          toolchain: stable
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+        id: auth
+      - name: Publish crate
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Undraft the release after all artifacts (image + binaries + crate) are uploaded.
   # release-please creates a draft so that immutable-release rules don't block
   # asset uploads; this job flips the draft flag once everything is in place.
   publish-release:
-    needs: [release-please, publish-image, publish-binaries]
+    needs: [release-please, publish-image, publish-binaries, publish-crate]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Add `publish-crate` job to `release.yml` using OIDC Trusted Publishing (`rust-lang/crates-io-auth-action@v1.0.3`)
- Job requires the `release` GitHub Actions environment (configured with required reviewer + branch restriction to `main`)
- `publish-release` (undraft) now waits for crate publish in addition to image + binaries
- No API tokens needed — authentication is entirely OIDC-based

## Setup completed outside this PR
- Created `release` environment in GitHub repo settings (required reviewer, `main` only, no admin bypass)
- Configured Trusted Publisher in crates.io linking this repo + `release.yml`

## Test plan
- [ ] Merge a conventional commit to main that triggers a release
- [ ] Verify release-please creates a release PR
- [ ] After merge, confirm `publish-crate` job requests environment approval
- [ ] Approve and verify crate publishes to crates.io successfully

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)