### PR TITLE
fix(test): stabilize flaky push_pull_with_bare_remote test

### DIFF
--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -122,8 +122,11 @@ async fn push_pull_with_bare_remote() {
         .await
         .expect("pull should succeed");
     assert!(
-        matches!(pull_result, PullResult::FastForward { .. }),
-        "expected FastForward pull, got: {pull_result:?}",
+        matches!(
+            pull_result,
+            PullResult::FastForward { .. } | PullResult::Merged { .. }
+        ),
+        "expected FastForward or Merged pull, got: {pull_result:?}",
     );
 
     // The cloned repo should have the memory.


### PR DESCRIPTION
## Summary
- `push_pull_with_bare_remote` asserted `FastForward` but `init_or_open` creates an initial commit in the clone repo, giving it a different root than the bare remote — git2 correctly classifies this as a merge
- Accept both `FastForward` and `Merged` since the test's purpose is verifying the memory round-trips, not the merge strategy
- Flaky failure: https://github.com/butterflyskies/memory-mcp/actions/runs/23508402082/job/68422517805

## Test plan
- [x] `cargo test --test repo_round_trip push_pull_with_bare_remote` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)