### PR TITLE
docs: add docker run pattern to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,28 @@ Zed does not yet support Streamable HTTP natively. Use `mcp-remote` as a stdio b
 
 The agent can now use `remember`, `recall`, `read`, `edit`, `forget`, `list`, and `sync` as tools.
 
+### Docker
+
+If you have Docker installed, the container image is the fastest way to get running — the embedding model is pre-baked so there's no download delay on first start:
+
+```bash
+docker run -d --name memory-mcp \
+  -p 8080:8080 \
+  -v ~/.memory-mcp:/data/repo \
+  ghcr.io/butterflyskies/memory-mcp:latest
+```
+
+The `-v` volume mount is required for persistence. Without it, memories are lost when the container stops.
+
+To sync memories across devices, initialize a git remote inside the mounted repo:
+
+```bash
+cd ~/.memory-mcp
+git init && git remote add origin git@github.com:you/my-memories.git
+```
+
+Then use the `sync` tool from your editor, or call `memory-mcp sync` directly.
+
 ## Tools
 
 | Tool | Description |


### PR DESCRIPTION
## Summary
- Adds a "Docker" subsection under Quick Start documenting the `docker run` one-liner for persistent local containers
- Covers the volume mount requirement, pre-baked embedding model (no warmup delay), and git remote setup for cross-device sync

Closes #105

## Test plan
- [ ] Verify the `docker run` command works against a fresh `~/.memory-mcp` directory
- [ ] Confirm memories persist across container restarts with the volume mount
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)