### PR TITLE
feat: add secret-avoidance guidance to MCP tool instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.5.1]
+
+### Added
+- Add secret-avoidance guidance to MCP tool instructions
+- Add docker run quick-start section to README
+- Add development roadmap
+
+## [0.5.0]
+
+### Changed
+- Supply chain audit — reduce deps, vendor native libs, unify TLS
+
 ## [0.4.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/server.rs
+++ b/src/server.rs
@@ -194,7 +194,9 @@ impl MemoryServer {
         name = "remember",
         description = "Store a new memory. Saves the content to the git-backed repository and \
         indexes it for semantic search. Use scope 'project:<basename-of-your-cwd>' for \
-        project-specific memories or omit for global. Returns the assigned memory ID."
+        project-specific memories or omit for global. Returns the assigned memory ID. \
+        IMPORTANT: Never store credentials, API keys, tokens, passwords, or other secrets — \
+        memories are plaintext files in a git repo and may be synced to a remote."
     )]
     async fn remember(
         &self,
@@ -435,7 +437,9 @@ impl MemoryServer {
         name = "edit",
         description = "Edit an existing memory. Supports partial updates — omit content or \
         tags to preserve existing values. Re-embeds and re-indexes the memory. Use scope \
-        'project:<basename-of-your-cwd>' for project-scoped memories. Returns the memory ID."
+        'project:<basename-of-your-cwd>' for project-scoped memories. Returns the memory ID. \
+        IMPORTANT: Never store credentials, API keys, tokens, passwords, or other secrets — \
+        memories are plaintext files in a git repo and may be synced to a remote."
     )]
     async fn edit(&self, Parameters(args): Parameters<EditArgs>) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
@@ -780,7 +784,10 @@ impl ServerHandler for MemoryServer {
             Scope convention: always pass scope='project:<basename-of-your-cwd>' when working within \
             a project. This returns project memories alongside global ones. Omitting scope defaults to \
             global-only for queries (recall, list) and targets a single memory for point operations \
-            (remember, edit, read, forget). Use scope='all' to search across all projects."
+            (remember, edit, read, forget). Use scope='all' to search across all projects.\n\n\
+            IMPORTANT: Never store credentials, API keys, tokens, passwords, or other secrets in \
+            memory content. Memories are stored as plaintext markdown files committed to a git \
+            repository and may be synced to a remote. Treat all memory content as public."
                 .to_string(),
         )
     }


### PR DESCRIPTION
## Summary
- Add warnings against storing secrets/credentials in memory content to server instructions, `remember` tool, and `edit` tool descriptions
- Bump version to 0.5.1
- Update CHANGELOG with v0.5.0 and v0.5.1 entries (github-keepachangelog format)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)