### PR TITLE
fix: surface server-side push rejections instead of silently succeeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .memory-mcp-index/
 .serena/
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-## [0.5.2]
+## [0.6.0]
 
 ### Added
-- Add PushRejected error variant and integration test
+- Add `PushRejected` error variant and integration test
+
+### Changed
+- Mark `MemoryError` as `#[non_exhaustive]` (breaking: downstream `match` must add `_ =>`)
 
 ### Fixed
-- Rmcp 1.4 compat and dependency refresh
 - Surface server-side push rejections instead of silently succeeding
+- rmcp 1.4 compat and dependency refresh
 
 ## [0.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.5.2]
+
+### Added
+- Add PushRejected error variant and integration test
+
+### Fixed
+- Rmcp 1.4 compat and dependency refresh
+- Surface server-side push rejections instead of silently succeeding
+
 ## [0.5.1]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 /// Errors produced by the memory engine.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MemoryError {
     /// An operation on the git-backed store failed.
     #[error("git error: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,10 @@ pub enum MemoryError {
     #[error("yaml error: {0}")]
     Yaml(#[from] serde_yaml_ng::Error),
 
+    /// The remote server rejected one or more ref updates during push.
+    #[error("push rejected: {0}")]
+    PushRejected(String),
+
     /// A background task failed to join.
     #[error("task join error: {0}")]
     Join(String),
@@ -64,6 +68,10 @@ impl From<MemoryError> for rmcp::model::ErrorData {
             MemoryError::NotFound { .. } | MemoryError::InvalidInput { .. } => {
                 rmcp::model::ErrorCode::INVALID_PARAMS
             }
+            // PushRejected is a server-side policy decision (e.g. branch
+            // protection), not an internal fault. No standard JSON-RPC code
+            // fits precisely; INTERNAL_ERROR is the least-bad option until
+            // MCP defines application-level error codes.
             _ => rmcp::model::ErrorCode::INTERNAL_ERROR,
         };
         rmcp::model::ErrorData {

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,16 +260,16 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     let ct = CancellationToken::new();
     let ct_child = ct.child_token();
 
+    // SessionConfig and StreamableHttpServerConfig are #[non_exhaustive] in
+    // rmcp 1.4+, so struct literal syntax is unavailable from external crates.
+    // Default + field mutation is the intended pattern (see mcp-session#11).
+    #[allow(clippy::field_reassign_with_default)]
     let service = StreamableHttpService::new(
         move || Ok(MemoryServer::new(Arc::clone(&state))),
         Arc::new({
-            let mgr = BoundedSessionManager::new(
-                SessionConfig {
-                    keep_alive: Some(std::time::Duration::from_secs(4 * 60 * 60)),
-                    ..Default::default()
-                },
-                args.max_sessions,
-            );
+            let mut session_config = SessionConfig::default();
+            session_config.keep_alive = Some(std::time::Duration::from_secs(4 * 60 * 60));
+            let mgr = BoundedSessionManager::new(session_config, args.max_sessions);
             if args.session_rate_limit > 0 && args.session_rate_window_secs > 0 {
                 mgr.with_rate_limit(
                     args.session_rate_limit,
@@ -279,9 +279,10 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
                 mgr
             }
         }),
-        StreamableHttpServerConfig {
-            cancellation_token: ct_child,
-            ..Default::default()
+        {
+            let mut server_config = StreamableHttpServerConfig::default();
+            server_config.cancellation_token = ct_child;
+            server_config
         },
     );
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -441,12 +441,36 @@ impl MemoryRepo {
 
             // Origin exists — we need the token now.
             let token = token_result?;
-            let callbacks = build_auth_callbacks(token);
+            let mut callbacks = build_auth_callbacks(token);
+
+            // git2's Remote::push() does not surface server-side rejections
+            // through its return value — they arrive via this callback.
+            let rejections: Arc<Mutex<Vec<String>>> =
+                Arc::new(Mutex::new(Vec::new()));
+            let rej = Arc::clone(&rejections);
+            callbacks.push_update_reference(move |refname, status| {
+                if let Some(msg) = status {
+                    rej.lock()
+                        .expect("rejection lock poisoned")
+                        .push(format!("{refname}: {msg}"));
+                }
+                Ok(())
+            });
+
             let mut push_opts = git2::PushOptions::new();
             push_opts.remote_callbacks(callbacks);
 
             let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
             remote.push(&[&refspec], Some(&mut push_opts))?;
+
+            let rejected = rejections.lock().expect("rejection lock poisoned");
+            if !rejected.is_empty() {
+                return Err(MemoryError::Git(git2::Error::from_str(&format!(
+                    "remote rejected push: {}",
+                    rejected.join("; ")
+                ))));
+            }
+
             info!("pushed branch '{}' to origin", branch);
             Ok(())
         })

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -445,8 +445,7 @@ impl MemoryRepo {
 
             // git2's Remote::push() does not surface server-side rejections
             // through its return value — they arrive via this callback.
-            let rejections: Arc<Mutex<Vec<String>>> =
-                Arc::new(Mutex::new(Vec::new()));
+            let rejections: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
             let rej = Arc::clone(&rejections);
             callbacks.push_update_reference(move |refname, status| {
                 if let Some(msg) = status {
@@ -461,14 +460,14 @@ impl MemoryRepo {
             push_opts.remote_callbacks(callbacks);
 
             let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
-            remote.push(&[&refspec], Some(&mut push_opts))?;
+            if let Err(e) = remote.push(&[&refspec], Some(&mut push_opts)) {
+                warn!("push to origin failed at transport level: {e}");
+                return Err(MemoryError::Git(e));
+            }
 
             let rejected = rejections.lock().expect("rejection lock poisoned");
             if !rejected.is_empty() {
-                return Err(MemoryError::Git(git2::Error::from_str(&format!(
-                    "remote rejected push: {}",
-                    rejected.join("; ")
-                ))));
+                return Err(MemoryError::PushRejected(rejected.join("; ")));
             }
 
             info!("pushed branch '{}' to origin", branch);

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -7,6 +7,8 @@
 use std::sync::Arc;
 
 use memory_mcp::auth::AuthProvider;
+#[cfg(unix)]
+use memory_mcp::error::MemoryError;
 use memory_mcp::repo::MemoryRepo;
 use memory_mcp::types::{Memory, MemoryMetadata, PullResult, Scope};
 
@@ -137,4 +139,120 @@ async fn push_pull_with_bare_remote() {
     assert_eq!(memories.len(), 1);
     assert_eq!(memories[0].name, "push-memory");
     assert_eq!(memories[0].content, "Content for push test.");
+}
+
+/// Push via `git://` to a daemon whose bare remote has an `update` hook
+/// that rejects all ref updates.
+///
+/// This exercises the `push_update_reference` callback path — the fix for
+/// issue #81. Unlike `file://` transport, the git smart protocol runs
+/// server-side hooks and reports per-ref rejection status through the
+/// callback. Our code collects those rejections and surfaces them as
+/// `MemoryError::PushRejected`.
+#[cfg(unix)]
+#[tokio::test]
+async fn push_rejected_by_server_hook() {
+    use std::fs;
+    use std::net::TcpListener;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::{Child, Command, Stdio};
+
+    /// RAII guard that kills `git daemon` on drop.
+    struct GitDaemon(Child);
+    impl Drop for GitDaemon {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    // Reserve a free port. Hold the listener open so nothing else can grab
+    // it; git daemon's --reuseaddr lets it bind the same port concurrently.
+    // We drop the listener after the daemon is confirmed ready.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    // Set up a bare remote with an `update` hook that rejects all pushes.
+    let remote_dir = tempfile::tempdir().unwrap();
+    git2::Repository::init_bare(remote_dir.path()).expect("failed to init bare repo");
+
+    let hooks_dir = remote_dir.path().join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    let hook_path = hooks_dir.join("update");
+    fs::write(
+        &hook_path,
+        "#!/bin/sh\necho \"branch protection: PRs required\" >&2\nexit 1\n",
+    )
+    .unwrap();
+    fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Start git daemon serving the bare repo's parent directory.
+    let base_path = remote_dir.path().parent().unwrap();
+    let child = Command::new("git")
+        .args([
+            "daemon",
+            "--reuseaddr",
+            "--listen=127.0.0.1",
+            &format!("--port={port}"),
+            &format!("--base-path={}", base_path.display()),
+            "--enable=receive-pack",
+            "--export-all",
+            &base_path.to_string_lossy(),
+        ])
+        .stderr(Stdio::null())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to start git daemon — is git installed?");
+
+    let _daemon = GitDaemon(child);
+
+    // Poll the port until the daemon is accepting connections, then release
+    // our placeholder listener so only the daemon holds the port.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "git daemon did not become ready within 5 seconds",
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    drop(listener);
+
+    // Build the git:// URL pointing at the bare repo.
+    let repo_name = remote_dir.path().file_name().unwrap().to_string_lossy();
+    let remote_url = format!("git://127.0.0.1:{port}/{repo_name}");
+
+    // Init a local repo, save a memory, and push.
+    let local_dir = tempfile::tempdir().unwrap();
+    let repo = Arc::new(
+        MemoryRepo::init_or_open(local_dir.path(), Some(&remote_url))
+            .expect("should init local repo"),
+    );
+    let auth = AuthProvider::with_token("ghp_fake_token");
+
+    let metadata = MemoryMetadata::new(Scope::Global, vec!["rejected".into()], None);
+    let memory = Memory::new(
+        "rejected-memory".into(),
+        "This push should be rejected.".into(),
+        metadata,
+    );
+    repo.save_memory(&memory)
+        .await
+        .expect("save should succeed");
+
+    let result = repo.push(&auth, "main").await;
+    assert!(result.is_err(), "push to a rejecting remote should fail");
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, MemoryError::PushRejected(_)),
+        "expected PushRejected, got: {err:?}",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("refs/heads/main"),
+        "rejection should name the rejected ref, got: {msg}",
+    );
 }

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -153,6 +153,7 @@ async fn push_pull_with_bare_remote() {
 #[tokio::test]
 async fn push_rejected_by_server_hook() {
     use std::fs;
+    use std::io::{BufRead, BufReader};
     use std::net::TcpListener;
     use std::os::unix::fs::PermissionsExt;
     use std::process::{Child, Command, Stdio};
@@ -166,11 +167,12 @@ async fn push_rejected_by_server_hook() {
         }
     }
 
-    // Reserve a free port. Hold the listener open so nothing else can grab
-    // it; git daemon's --reuseaddr lets it bind the same port concurrently.
-    // We drop the listener after the daemon is confirmed ready.
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    let port = listener.local_addr().unwrap().port();
+    // Grab a free port, then release it immediately. The TOCTOU window
+    // before the daemon binds is negligible in test environments.
+    let port = {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
 
     // Set up a bare remote with an `update` hook that rejects all pushes.
     let remote_dir = tempfile::tempdir().unwrap();
@@ -186,11 +188,13 @@ async fn push_rejected_by_server_hook() {
     .unwrap();
     fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
 
-    // Start git daemon serving the bare repo's parent directory.
+    // Start git daemon with --verbose so it prints "Ready to rumble" to
+    // stderr once it has bound the port and is accepting connections.
     let base_path = remote_dir.path().parent().unwrap();
-    let child = Command::new("git")
+    let mut child = Command::new("git")
         .args([
             "daemon",
+            "--verbose",
             "--reuseaddr",
             "--listen=127.0.0.1",
             &format!("--port={port}"),
@@ -199,27 +203,30 @@ async fn push_rejected_by_server_hook() {
             "--export-all",
             &base_path.to_string_lossy(),
         ])
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .stdout(Stdio::null())
         .spawn()
         .expect("failed to start git daemon — is git installed?");
 
+    // Block until the daemon confirms it's ready, then keep draining stderr
+    // in a background thread so verbose logging doesn't fill the pipe buffer
+    // and block the daemon mid-connection.
+    let stderr = child.stderr.take().unwrap();
     let _daemon = GitDaemon(child);
 
-    // Poll the port until the daemon is accepting connections, then release
-    // our placeholder listener so only the daemon holds the port.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+    let reader = BufReader::new(stderr);
+    let mut lines = reader.lines();
+    let mut ready = false;
+    for line in &mut lines {
+        if line.unwrap_or_default().contains("Ready to rumble") {
+            ready = true;
             break;
         }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "git daemon did not become ready within 5 seconds",
-        );
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    drop(listener);
+    assert!(ready, "git daemon exited without becoming ready");
+
+    // Drain remaining stderr in the background so the daemon doesn't stall.
+    std::thread::spawn(move || for _ in lines {});
 
     // Build the git:// URL pointing at the bare repo.
     let repo_name = remote_dir.path().file_name().unwrap().to_string_lossy();


### PR DESCRIPTION
## Summary
- Register `push_update_reference` callback to detect server-side push rejections (e.g. branch protection rules) that git2 silently swallows
- Add `MemoryError::PushRejected` variant to distinguish server-side rejections from transport failures
- Mark `MemoryError` as `#[non_exhaustive]` so future variant additions are semver-compatible
- Log transport-level push failures with `warn!` before propagating as `MemoryError::Git`
- Fix rmcp 1.4+ compat: use Default + field mutation for non-exhaustive `SessionConfig` and `StreamableHttpServerConfig`
- Refresh `Cargo.lock` to fix `cargo publish --locked` CI failures

**Breaking:** `MemoryError` is now `#[non_exhaustive]` — downstream `match` arms must add `_ =>`. Bumps to 0.6.0.

Closes #81

## Test plan
- [x] Integration test spins up `git daemon` with rejecting `update` hook, pushes via `git://`, asserts `PushRejected`
- [x] 102/102 tests pass with `cargo nextest` (CI-equivalent)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)