### PR TITLE
feat: add truncation signals to recall results

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -349,10 +349,7 @@ impl MemoryServer {
                     }
                 };
 
-                // Truncate content for the snippet and signal when content was cut.
-                let content_length = memory.content.chars().count();
-                let truncated = content_length > SNIPPET_MAX_CHARS;
-                let snippet: String = memory.content.chars().take(SNIPPET_MAX_CHARS).collect();
+                let (snippet, content_length, truncated) = build_snippet(&memory.content);
 
                 results_vec.push(serde_json::json!({
                     "id": memory.id,
@@ -794,5 +791,63 @@ impl ServerHandler for MemoryServer {
             (remember, edit, read, forget). Use scope='all' to search across all projects."
                 .to_string(),
         )
+    }
+}
+
+/// Truncate content to [`SNIPPET_MAX_CHARS`] and return `(snippet, content_length, truncated)`.
+fn build_snippet(content: &str) -> (String, usize, bool) {
+    let content_length = content.chars().count();
+    let truncated = content_length > SNIPPET_MAX_CHARS;
+    let snippet: String = content.chars().take(SNIPPET_MAX_CHARS).collect();
+    (snippet, content_length, truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snippet_short_content_not_truncated() {
+        let content = "Hello, world!";
+        let (snippet, content_length, truncated) = build_snippet(content);
+        assert_eq!(snippet, "Hello, world!");
+        assert_eq!(content_length, 13);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn snippet_exact_limit_not_truncated() {
+        let content: String = "a".repeat(SNIPPET_MAX_CHARS);
+        let (snippet, content_length, truncated) = build_snippet(&content);
+        assert_eq!(snippet, content);
+        assert_eq!(content_length, SNIPPET_MAX_CHARS);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn snippet_over_limit_is_truncated() {
+        let content: String = "b".repeat(SNIPPET_MAX_CHARS + 100);
+        let (snippet, content_length, truncated) = build_snippet(&content);
+        assert_eq!(snippet.chars().count(), SNIPPET_MAX_CHARS);
+        assert_eq!(content_length, SNIPPET_MAX_CHARS + 100);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn snippet_counts_unicode_chars_not_bytes() {
+        // Each emoji is 1 char but multiple bytes.
+        let emoji_content: String = "\u{1F600}".repeat(SNIPPET_MAX_CHARS + 1);
+        let (snippet, content_length, truncated) = build_snippet(&emoji_content);
+        assert_eq!(snippet.chars().count(), SNIPPET_MAX_CHARS);
+        assert_eq!(content_length, SNIPPET_MAX_CHARS + 1);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn snippet_empty_content() {
+        let (snippet, content_length, truncated) = build_snippet("");
+        assert_eq!(snippet, "");
+        assert_eq!(content_length, 0);
+        assert!(!truncated);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,9 @@
 use std::{sync::Arc, time::Instant};
 
+/// Maximum number of characters included in recall result snippets.
+/// Content longer than this is truncated and flagged with `truncated: true`.
+const SNIPPET_MAX_CHARS: usize = 500;
+
 use chrono::Utc;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -266,8 +270,11 @@ impl MemoryServer {
     /// Returns a JSON array of matching memories sorted by relevance.
     #[tool(
         name = "recall",
-        description = "Search memories by semantic similarity. Returns the top matching memories as a JSON array \
-        with name, scope, tags, and content snippet.\n\n\
+        description = "Search memories by semantic similarity. Embeds the query and returns the top matching memories as a JSON array \
+        with name, scope, tags, and a content snippet (max 500 chars).\n\n\
+        Each result includes `truncated` (bool) and `content_length` (total character count). \
+        When `truncated` is true, the snippet is incomplete — use the `read` tool with the memory's name and scope \
+        to retrieve the full content before acting on it.\n\n\
         Scope: pass 'project:<basename-of-your-cwd>' to search your current project + global memories, \
         'global' for global-only, or 'all' to search everything. Omitting scope defaults to global-only."
     )]
@@ -342,8 +349,10 @@ impl MemoryServer {
                     }
                 };
 
-                // Truncate content to 500 chars for the snippet.
-                let snippet: String = memory.content.chars().take(500).collect();
+                // Truncate content for the snippet and signal when content was cut.
+                let content_length = memory.content.chars().count();
+                let truncated = content_length > SNIPPET_MAX_CHARS;
+                let snippet: String = memory.content.chars().take(SNIPPET_MAX_CHARS).collect();
 
                 results_vec.push(serde_json::json!({
                     "id": memory.id,
@@ -351,6 +360,8 @@ impl MemoryServer {
                     "scope": memory.metadata.scope.to_string(),
                     "tags": memory.metadata.tags,
                     "content": snippet,
+                    "content_length": content_length,
+                    "truncated": truncated,
                     "distance": distance,
                 }));
             }


### PR DESCRIPTION
## Summary
- Each `recall` result now includes `truncated` (bool) and `content_length` (total character count) so agents can detect when a snippet is incomplete and follow up with `read`
- Updated the MCP tool description to guide agents toward reading full content when truncated
- Extracted snippet-building into a `build_snippet()` helper with 5 unit tests covering short content, exact limit boundary, over-limit truncation, unicode character counting, and empty content

Closes #106

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all 101 tests pass (96 existing + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)