### PR TITLE
fix: atomic file writes with RAII cleanup and symlink defense

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -459,43 +459,11 @@ fn store_in_file(token: &str) -> Result<(), MemoryError> {
         }
     }
 
-    // Write to a temporary file in the same directory, then rename into place.
-    // This ensures the token file is never left in a truncated state on crash,
-    // and the 0600 mode is set before any content is written.
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let parent = token_path.parent().expect("token_path always has a parent");
-        let tmp_path = parent.join(".token.tmp");
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&tmp_path)
-            .map_err(|e| {
-                MemoryError::TokenStorage(format!("failed to open temp token file: {e}"))
-            })?;
-        f.write_all(token.as_bytes()).map_err(|e| {
-            MemoryError::TokenStorage(format!("failed to write temp token file: {e}"))
-        })?;
-        f.write_all(b"\n").map_err(|e| {
-            MemoryError::TokenStorage(format!("failed to write temp token file: {e}"))
-        })?;
-        f.sync_all().map_err(|e| {
-            MemoryError::TokenStorage(format!("failed to sync temp token file: {e}"))
-        })?;
-        drop(f);
-        std::fs::rename(&tmp_path, &token_path).map_err(|e| {
-            MemoryError::TokenStorage(format!("failed to rename token file into place: {e}"))
-        })?;
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(&token_path, format!("{token}\n"))
-            .map_err(|e| MemoryError::TokenStorage(format!("failed to write token file: {e}")))?;
-    }
+    // Atomic write: temp file → sync → rename. On Unix the temp file is
+    // created with mode 0o600. On any failure the temp file is cleaned up
+    // automatically by the RAII guard inside `atomic_write`.
+    crate::fs_util::atomic_write(&token_path, format!("{token}\n").as_bytes())
+        .map_err(|e| MemoryError::TokenStorage(format!("failed to write token file: {e}")))?;
 
     info!("token stored in file ({})", token_path.display());
     Ok(())

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,0 +1,234 @@
+//! Filesystem utilities — atomic writes with crash-safe temp-file-then-rename.
+
+use std::path::Path;
+
+/// RAII guard that removes a temp file on drop unless defused.
+struct TempGuard<'a> {
+    path: &'a Path,
+    active: bool,
+}
+
+impl<'a> TempGuard<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self { path, active: true }
+    }
+
+    /// Disarm the guard so the temp file is **not** deleted on drop.
+    fn defuse(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for TempGuard<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = std::fs::remove_file(self.path);
+        }
+    }
+}
+
+/// Atomically write `data` to `path` via a temp file and rename.
+///
+/// 1. Creates a temp file (`.tmp`) in the same directory as `path`.
+/// 2. On Unix the temp file is opened with mode `0o600`.
+/// 3. Writes `data`, calls `sync_all`, then renames into `path`.
+/// 4. Fsyncs the parent directory so the rename is durable on crash.
+/// 5. If any step after temp-file creation fails, the temp file is
+///    cleaned up automatically (RAII guard).
+///
+/// Callers must ensure no concurrent writes target the same `path`.
+pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path has no parent directory",
+        )
+    })?;
+
+    // Build a deterministic temp name: .<filename>.tmp
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no file name")
+        })?
+        .to_string_lossy();
+    let tmp_path = parent.join(format!(".{file_name}.tmp"));
+
+    let mut guard = TempGuard::new(&tmp_path);
+
+    // Open + write + sync.
+    write_tmp(&tmp_path, data)?;
+
+    // Atomic rename into the final location.
+    std::fs::rename(&tmp_path, path)?;
+    guard.defuse();
+
+    // Fsync the parent directory so the rename is durable even on hard crash.
+    // Best-effort: the rename already committed, so a dir-fsync failure should
+    // not cause callers to treat the write as failed.
+    if let Err(e) = fsync_dir(parent) {
+        tracing::warn!("fsync of parent directory failed (data is written): {e}");
+    }
+
+    Ok(())
+}
+
+/// Create and write the temp file with platform-appropriate options.
+fn write_tmp(tmp_path: &Path, data: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut f = opts.open(tmp_path)?;
+    f.write_all(data)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+/// Fsync a directory to ensure metadata (renames) is persisted.
+#[cfg(unix)]
+fn fsync_dir(dir: &Path) -> std::io::Result<()> {
+    let d = std::fs::File::open(dir)?;
+    d.sync_all()?;
+    Ok(())
+}
+
+/// No-op on non-Unix — Windows flushes directory metadata on rename.
+#[cfg(not(unix))]
+fn fsync_dir(_dir: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("test.txt");
+
+        atomic_write(&target, b"hello world").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "hello world");
+        // Temp file should not linger.
+        assert!(!dir.path().join(".test.txt.tmp").exists());
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("test.txt");
+
+        fs::write(&target, "old content").unwrap();
+        atomic_write(&target, b"new content").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new content");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_sets_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("secret.txt");
+
+        atomic_write(&target, b"secret").unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "file should be 0600, got {mode:o}");
+    }
+
+    #[test]
+    fn temp_file_cleaned_on_missing_parent() {
+        // Writing to a path whose parent doesn't exist should fail
+        // and not leave debris.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("nonexistent_dir").join("file.txt");
+
+        assert!(atomic_write(&target, b"data").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temp_file_cleaned_on_rename_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        // Create a read-only subdirectory. write_tmp can create the temp
+        // file (it already exists by the time rename runs), but rename
+        // into a read-only directory fails.
+        let sub = dir.path().join("ro");
+        fs::create_dir(&sub).unwrap();
+
+        // Pre-create target so the temp file lands in `sub`, then make
+        // the directory read-only so rename fails.
+        let target = sub.join("file.txt");
+        let tmp = sub.join(".file.txt.tmp");
+
+        // Create the temp file so write_tmp succeeds (truncate), then
+        // make dir read-only before rename.  We can't do this mid-call,
+        // so instead we make `target` a path where rename will fail:
+        // make `sub` read-only so rename (which modifies the directory)
+        // is denied.
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = atomic_write(&target, b"data");
+        assert!(result.is_err(), "expected rename to fail in read-only dir");
+        // TempGuard should have cleaned up — but remove_file also fails
+        // in a read-only dir. Restore permissions and verify the temp
+        // file was at least attempted (it may or may not exist depending
+        // on whether write_tmp itself failed).
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
+
+        // If write_tmp succeeded, the guard should have tried cleanup.
+        // On a read-only dir, both the write and cleanup fail, so the
+        // temp won't exist because write_tmp couldn't create it.
+        assert!(!tmp.exists(), "temp file should not persist after failure");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_tightens_permissions_on_overwrite() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("wide.txt");
+
+        // Create file with wide permissions.
+        fs::write(&target, "old").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+
+        // Overwrite via atomic_write — should end up 0o600.
+        atomic_write(&target, b"new").unwrap();
+
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "overwritten file should be 0600, got {mode:o}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_rejects_symlink_temp_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("file.txt");
+        let tmp = dir.path().join(".file.txt.tmp");
+
+        // Pre-plant a symlink at the temp path.
+        let decoy = dir.path().join("decoy.txt");
+        std::os::unix::fs::symlink(&decoy, &tmp).unwrap();
+
+        // atomic_write should fail because O_NOFOLLOW rejects the symlink.
+        let result = atomic_write(&target, b"secret");
+        assert!(result.is_err(), "should reject symlink at temp path");
+
+        // Decoy should not have been written to.
+        assert!(!decoy.exists(), "symlink target should be untouched");
+    }
+}

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -159,39 +159,22 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn temp_file_cleaned_on_rename_failure() {
-        use std::os::unix::fs::PermissionsExt;
-
+        // Make the rename target a *directory* so write_tmp succeeds
+        // (creating .file.txt.tmp in the parent) but rename fails with
+        // EISDIR. This exercises TempGuard cleanup after a real write.
         let dir = tempfile::tempdir().unwrap();
-        // Create a read-only subdirectory. write_tmp can create the temp
-        // file (it already exists by the time rename runs), but rename
-        // into a read-only directory fails.
-        let sub = dir.path().join("ro");
-        fs::create_dir(&sub).unwrap();
+        let target = dir.path().join("file.txt");
+        let tmp = dir.path().join(".file.txt.tmp");
 
-        // Pre-create target so the temp file lands in `sub`, then make
-        // the directory read-only so rename fails.
-        let target = sub.join("file.txt");
-        let tmp = sub.join(".file.txt.tmp");
-
-        // Create the temp file so write_tmp succeeds (truncate), then
-        // make dir read-only before rename.  We can't do this mid-call,
-        // so instead we make `target` a path where rename will fail:
-        // make `sub` read-only so rename (which modifies the directory)
-        // is denied.
-        fs::set_permissions(&sub, fs::Permissions::from_mode(0o555)).unwrap();
+        // Create a directory at the target path — rename(file, dir) → EISDIR.
+        fs::create_dir(&target).unwrap();
 
         let result = atomic_write(&target, b"data");
-        assert!(result.is_err(), "expected rename to fail in read-only dir");
-        // TempGuard should have cleaned up — but remove_file also fails
-        // in a read-only dir. Restore permissions and verify the temp
-        // file was at least attempted (it may or may not exist depending
-        // on whether write_tmp itself failed).
-        fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
-
-        // If write_tmp succeeded, the guard should have tried cleanup.
-        // On a read-only dir, both the write and cleanup fail, so the
-        // temp won't exist because write_tmp couldn't create it.
-        assert!(!tmp.exists(), "temp file should not persist after failure");
+        assert!(result.is_err(), "expected rename to fail with EISDIR");
+        // TempGuard should have cleaned up the temp file.
+        assert!(!tmp.exists(), "temp file should be cleaned up by TempGuard");
+        // The directory target should still be intact.
+        assert!(target.is_dir(), "target directory should be untouched");
     }
 
     #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod auth;
 pub mod embedding;
 /// Error types used throughout the crate.
 pub mod error;
+/// Filesystem utilities — atomic writes with crash-safe temp-file-then-rename.
+pub(crate) mod fs_util;
 /// HNSW vector index for approximate nearest-neighbour search.
 pub mod index;
 /// Git-backed memory repository — read, write, sync, and diff operations.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1042,29 +1042,48 @@ impl MemoryRepo {
         Ok(())
     }
 
-    /// Open `path` for writing using `O_NOFOLLOW` on Unix so the final path
-    /// component cannot be a symlink, then write `data`.
+    /// Atomically write `data` to `path` via temp-file + rename.
     ///
-    /// On non-Unix platforms falls back to a plain `std::fs::write`.
+    /// Defense-in-depth against symlink attacks (layered):
+    /// 1. `validate_path` rejects symlinks in all path components.
+    /// 2. An `lstat` check here catches symlinks created between
+    ///    validation and write (narrows the TOCTOU window).
+    /// 3. On Unix, an `O_NOFOLLOW` probe rejects symlinks at the
+    ///    final component at the kernel level.
     fn write_memory_file(&self, path: &Path, data: &[u8]) -> Result<(), MemoryError> {
+        // Layer 2: lstat — reject if the target is currently a symlink.
+        if path
+            .symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            return Err(MemoryError::InvalidInput {
+                reason: format!("refusing to write through symlink: {}", path.display()),
+            });
+        }
+
+        // Layer 3 (Unix): O_NOFOLLOW probe — kernel-level symlink rejection.
+        // NotFound is fine (file doesn't exist yet); any other error (ELOOP
+        // from a symlink, permission denied, etc.) is rejected.
         #[cfg(unix)]
         {
-            use std::io::Write as _;
             use std::os::unix::fs::OpenOptionsExt as _;
-            let mut f = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
+            if let Err(e) = std::fs::OpenOptions::new()
+                .read(true)
                 .custom_flags(libc::O_NOFOLLOW)
-                .open(path)?;
-            f.write_all(data)?;
-            Ok(())
+                .open(path)
+            {
+                // NotFound is fine — the file doesn't exist yet.
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    return Err(MemoryError::InvalidInput {
+                        reason: format!("O_NOFOLLOW check failed for {}: {e}", path.display()),
+                    });
+                }
+            }
         }
-        #[cfg(not(unix))]
-        {
-            std::fs::write(path, data)?;
-            Ok(())
-        }
+
+        crate::fs_util::atomic_write(path, data)?;
+        Ok(())
     }
 
     /// Open `path` for reading using `O_NOFOLLOW` on Unix, then return its

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1048,8 +1048,10 @@ impl MemoryRepo {
     /// 1. `validate_path` rejects symlinks in all path components.
     /// 2. An `lstat` check here catches symlinks created between
     ///    validation and write (narrows the TOCTOU window).
-    /// 3. On Unix, an `O_NOFOLLOW` probe rejects symlinks at the
-    ///    final component at the kernel level.
+    /// 3. On Unix, an `O_NOFOLLOW` probe on the final path detects
+    ///    symlinks planted in the window between lstat and
+    ///    `atomic_write`. The temp file itself is separately guarded
+    ///    by `O_NOFOLLOW` inside `write_tmp`.
     fn write_memory_file(&self, path: &Path, data: &[u8]) -> Result<(), MemoryError> {
         // Layer 2: lstat — reject if the target is currently a symlink.
         if path


### PR DESCRIPTION
## Summary
- Extract reusable `atomic_write` utility (`src/fs_util.rs`): temp file → sync → rename → dir fsync, with RAII cleanup guard
- Fix `store_in_file` in `auth.rs`: both Unix and non-Unix paths now use atomic writes with proper cleanup on failure
- Fix `write_memory_file` in `repo.rs`: atomic writes with layered symlink defense (lstat + O_NOFOLLOW probe + O_NOFOLLOW on temp file)

### Security hardening
- `O_NOFOLLOW` on temp file open prevents symlink-redirect attacks on the deterministic temp path
- Layered symlink defense in `write_memory_file`: validate_path (layer 1) → lstat check (layer 2) → O_NOFOLLOW kernel probe (layer 3)
- Dir fsync after rename for full crash durability (best-effort, logged on failure)
- `pub(crate)` visibility — no public API surface added

### What was wrong before
- **Non-Unix `store_in_file`**: bare `std::fs::write` — no temp file, no atomic rename, no crash safety
- **Unix `store_in_file`**: temp file not cleaned up on write/sync/rename failure
- **`write_memory_file`**: no crash safety (bare write), non-Unix had no atomicity at all

Closes #69

## Test plan
- [x] `atomic_write_creates_file` — basic creation and no temp file lingering
- [x] `atomic_write_overwrites_existing` — atomic replacement of existing file
- [x] `atomic_write_sets_permissions` — temp file created with 0o600
- [x] `atomic_write_tightens_permissions_on_overwrite` — 0o644 file replaced with 0o600
- [x] `temp_file_cleaned_on_missing_parent` — error path, no debris
- [x] `temp_file_cleaned_on_rename_failure` — EISDIR forces rename failure after successful write, verifies TempGuard cleanup
- [x] `atomic_write_rejects_symlink_temp_path` — O_NOFOLLOW blocks symlink at temp path
- [x] All 109 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Three rounds of structured code review (correctness, design, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)