### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.6.1]
+
+### Fixed
+- Atomic file writes with RAII cleanup and symlink defense
+- Drop `--locked` from `cargo publish`
+
+### Changed
+- Refresh `Cargo.lock` to unblock v0.6.0 release
+
 ## [0.6.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,22 +9,25 @@ Earlier phases should be implemented with awareness of where the project is head
 
 ---
 
-## Phase 1: Stabilize & Quick Wins
+## Phase 1: Stabilize & Quick Wins ✓
 
 **Goal:** Fix known bugs, improve agent UX, and clear low-hanging fruit.
 
-| Issue | Title | Effort |
-|-------|-------|--------|
-| #88 | Flaky test: FastForward vs Merged | Small |
-| #81 | git push silently succeeds on reject | Small |
-| #69 | Atomic file writes + cleanup | Medium |
-| #106 | Recall truncation guidance for agents | Small |
-| #108 | Secret-avoidance in tool instructions | Small |
-| #105 | Document `docker run` pattern in README | Small |
+**Completed 2026-04-12.** All 6 issues closed. Released in v0.6.0 and v0.6.1.
 
-**Forward-looking notes:**
-- #69 (atomic writes): Design as a reusable utility for index persistence, config files, and multi-user writes.
-- #106 (recall results): Structure the response type to be extensible for future audit logging and access identity fields.
+| Issue | Title | Effort | Status |
+|-------|-------|--------|--------|
+| #88 | Flaky test: FastForward vs Merged | Small | v0.5.1 |
+| #81 | git push silently succeeds on reject | Small | v0.6.0 |
+| #69 | Atomic file writes + cleanup | Medium | v0.6.1 |
+| #106 | Recall truncation guidance for agents | Small | v0.6.0 |
+| #108 | Secret-avoidance in tool instructions | Small | v0.6.0 |
+| #105 | Document `docker run` pattern in README | Small | v0.6.0 |
+
+**Design decisions carried forward:**
+- `MemoryError` is `#[non_exhaustive]` — future variants are patch-compatible.
+- `fs_util::atomic_write` is `pub(crate)` — reusable for index persistence and config writes in later phases.
+- Recall response includes `truncated` flag and `content_length` — extensible for audit logging fields.
 
 ---
 
@@ -62,12 +65,16 @@ Earlier phases should be implemented with awareness of where the project is head
 
 ## Phase 4: Search & Memory Lifecycle
 
-**Goal:** Richer retrieval capabilities and memory lifecycle management.
+**Goal:** Richer retrieval capabilities, better embedding quality, and memory lifecycle management.
 
 | Issue | Title | Effort | Depends on |
 |-------|-------|--------|------------|
+| #141 | Upgrade to ModernBERT Embed (8192 token context) | Medium | -- |
+| #140 | Chunk long memories for embedding | Medium | #141 |
 | #55 | BM25 keyword search via Tantivy | Large | -- |
 | #107 | Memory expiry: TTL + completion-triggered deletion | Medium | -- |
+
+**Key insight:** BGE-small-en-v1.5 silently truncates memories beyond 512 tokens (~400 words). ModernBERT Embed (`nomic-ai/modernbert-embed-base`) provides a 16x context window (8192 tokens), alternating attention for CPU efficiency, and Matryoshka dimensions. Already implemented in candle-transformers. Chunking (#140) handles memories that still exceed the new window. BM25 (#55) provides a complementary retrieval path with no token limit.
 
 ---
 
@@ -116,7 +123,7 @@ Windows support (#42, #56) is deferred until demand materializes.
 ## Priority Order
 
 ```
-Phase 1 (Stabilize)           ███░░░░░░░░░░░░░░░░░  Now
+Phase 1 (Stabilize)           ████████████████████  Done (v0.6.0/v0.6.1)
 Phase 2 (Tracing + Quality)   ░░░████░░░░░░░░░░░░░  Next
   #79 (GitHub App Auth)       ░░░░░██░░░░░░░░░░░░░  Interleave anytime
 Phase 3 (Transport/Stdio)     ░░░░░░░███░░░░░░░░░░  After core quality


### PR DESCRIPTION
## Summary
Version bump and changelog for v0.6.1. Catches the delta since v0.6.0:

- **fix:** Atomic file writes with RAII cleanup and symlink defense (#139, closes #69)
- **fix(ci):** Drop `--locked` from `cargo publish` (#137)
- **chore:** Refresh `Cargo.lock` (#138)

`cargo semver-checks` passes: 196 checks, 0 failures. `fs_util` is `pub(crate)` — no public API changes, patch bump is correct.

## Test plan
- [x] `cargo semver-checks check-release` — 196 pass, 0 fail
- [ ] CI green
- [ ] v0.6.1 release pipeline succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)