### PR TITLE
chore(deps): bump candle crates 0.9 → 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "byteorder",
  "float8",
@@ -276,15 +276,16 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror 2.0.18",
+ "tokenizers",
  "yoke",
  "zip",
 ]
 
 [[package]]
 name = "candle-nn"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
  "candle-core",
  "half",
@@ -298,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -970,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "float8"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
@@ -2198,6 +2199,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl"
@@ -3476,6 +3499,7 @@ dependencies = [
  "log",
  "macro_rules_attribute",
  "monostate",
+ "onig",
  "paste",
  "rand 0.9.4",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,8 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
 dependencies = [
  "byteorder",
  "float8",
@@ -275,6 +276,7 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror 2.0.18",
+ "tokenizers",
  "yoke",
  "zip",
 ]
@@ -282,7 +284,8 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
 dependencies = [
  "candle-core",
  "half",
@@ -297,7 +300,8 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.10.2"
-source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -2197,6 +2201,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3473,6 +3499,7 @@ dependencies = [
  "log",
  "macro_rules_attribute",
  "monostate",
+ "onig",
  "paste",
  "rand 0.9.4",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,8 +260,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 [[package]]
 name = "candle-core"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
 dependencies = [
  "byteorder",
  "float8",
@@ -276,7 +275,6 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror 2.0.18",
- "tokenizers",
  "yoke",
  "zip",
 ]
@@ -284,8 +282,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
 dependencies = [
  "candle-core",
  "half",
@@ -300,8 +297,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+source = "git+https://github.com/butterflyskies/candle.git?branch=patch%2Foptional-tokenizers#acd773417b25fdb16b34fc1b3aa640067071bcab"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -723,13 +719,13 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2201,28 +2197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "openssl"
 version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,9 +2302,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pem"
@@ -2858,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",
@@ -3499,7 +3473,6 @@ dependencies = [
  "log",
  "macro_rules_attribute",
  "monostate",
- "onig",
  "paste",
  "rand 0.9.4",
  "rayon",
@@ -4156,15 +4129,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ dirs = "6"
 mcp-session = "0.1"
 
 # Candle direct — pure-Rust BERT inference for embeddings.
-candle-core = "0.10"
-candle-nn = "0.10"
-candle-transformers = "0.10"
+candle-core = { version = "0.10", default-features = false }
+candle-nn = { version = "0.10", default-features = false }
+candle-transformers = { version = "0.10", default-features = false }
 # Disable defaults to drop onig (C regex library); fancy-regex is a pure-Rust
 # drop-in. esaxx_fast enables the C++ suffix-array builder for BPE tokenizers.
 tokenizers = { version = "0.22", default-features = false, features = ["progressbar", "fancy-regex", "esaxx_fast"] }
@@ -81,6 +81,17 @@ libz-sys = { version = "1", features = ["static"] }
 [dev-dependencies]
 git2 = "0.20"
 tempfile = "3"
+
+# TEMPORARY FORK: candle 0.10 unconditionally pulls in the onig C regex library
+# via tokenizers for GGUF support we don't use. Our fork makes it opt-out.
+# Upstream PR: https://github.com/huggingface/candle/pull/3490
+# If merged, remove this [patch] section and drop default-features = false from
+# the candle deps above. Note: [patch.crates-io] overrides break dependabot's
+# ability to track candle version updates — check manually after removing.
+[patch.crates-io]
+candle-core = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
+candle-nn = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
+candle-transformers = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ dirs = "6"
 mcp-session = "0.1"
 
 # Candle direct — pure-Rust BERT inference for embeddings.
-candle-core = { version = "0.10", default-features = false }
-candle-nn = { version = "0.10", default-features = false }
-candle-transformers = { version = "0.10", default-features = false }
+candle-core = "0.10"
+candle-nn = "0.10"
+candle-transformers = "0.10"
 # Disable defaults to drop onig (C regex library); fancy-regex is a pure-Rust
 # drop-in. esaxx_fast enables the C++ suffix-array builder for BPE tokenizers.
 tokenizers = { version = "0.22", default-features = false, features = ["progressbar", "fancy-regex", "esaxx_fast"] }
@@ -82,16 +82,10 @@ libz-sys = { version = "1", features = ["static"] }
 git2 = "0.20"
 tempfile = "3"
 
-# TEMPORARY FORK: candle 0.10 unconditionally pulls in the onig C regex library
-# via tokenizers for GGUF support we don't use. Our fork makes it opt-out.
-# Upstream PR: https://github.com/huggingface/candle/pull/3490
-# If merged, remove this [patch] section and drop default-features = false from
-# the candle deps above. Note: [patch.crates-io] overrides break dependabot's
-# ability to track candle version updates — check manually after removing.
-[patch.crates-io]
-candle-core = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
-candle-nn = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
-candle-transformers = { git = "https://github.com/butterflyskies/candle.git", branch = "patch/optional-tokenizers" }
+# candle 0.10 unconditionally pulls in the onig C regex library via tokenizers
+# for GGUF support we don't use. Upstream PR to make it optional:
+# https://github.com/huggingface/candle/pull/3490
+# Track removal in #161. Until then we accept the onig build cost.
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,9 @@ dirs = "6"
 mcp-session = "0.1"
 
 # Candle direct — pure-Rust BERT inference for embeddings.
-candle-core = "0.9"
-candle-nn = "0.9"
-candle-transformers = "0.9"
+candle-core = "0.10"
+candle-nn = "0.10"
+candle-transformers = "0.10"
 # Disable defaults to drop onig (C regex library); fancy-regex is a pure-Rust
 # drop-in. esaxx_fast enables the C++ suffix-array builder for BPE tokenizers.
 tokenizers = { version = "0.22", default-features = false, features = ["progressbar", "fancy-regex", "esaxx_fast"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,6 +154,7 @@ Items without a phase assignment yet. These will be scheduled as priorities beco
 | #152 | Container signing with cosign | Security |
 | #153 | CVE scanning gate in CI (Grype/Trivy) | Security |
 | #154 | CLI for manual memory management outside agent sessions | UX |
+| #161 | Revisit candle fork patch when upstream merges | Dependencies |
 
 
 ---


### PR DESCRIPTION
## Summary

- Bump candle-core, candle-nn, candle-transformers from 0.9.2 to 0.10.2
- All three crates are from the huggingface/candle monorepo and must be upgraded atomically
- No API breakage — zero code changes needed in `src/embedding/candle.rs`

### The onig situation

candle-core 0.10 added an unconditional dependency on `tokenizers` with the `onig` feature, pulling in the Oniguruma C regex library for a GGUF tokenizer module we don't use. We investigated several approaches to avoid it:

1. **Fork with `[patch.crates-io]`** — worked locally but cargo-deny rejects git sources, and it breaks dependabot tracking
2. **Upstream PR** — submitted as [huggingface/candle#3490](https://github.com/huggingface/candle/pull/3490), makes tokenizers opt-out across the candle crate stack

For now we accept the onig dependency. If the upstream PR merges, we can opt out by adding `default-features = false` to our candle deps. Tracked in #161.

### Supersedes

- #125 (dependabot candle-core bump)
- #126 (dependabot candle-transformers bump)
- #127 (dependabot candle-nn bump)

## Test plan

- [x] `cargo check` and `cargo check --features k8s` pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] All 109 tests pass (including 9 candle embedding tests)
- [ ] CI passes (cargo-deny, semver-checks, cross-compile, Docker build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)