### PR TITLE
docs: design artifacts for tracing scaffold (#52)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,6 +110,7 @@ Closed issues from original TODO: #60 (cargo-auditable), #62 (Trusted Publishing
 | #111 | Log returned memory names on recall | Small | Phase 2 scaffold |
 | #112 | Log auth events | Small | Phase 2 scaffold |
 | #117 | Git commit SHA in write operation logs | Small | Phase 2 scaffold |
+| #162 | W3C Trace Context propagation | Small | #52, OTLP export |
 
 ---
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -3,6 +3,6 @@
 Design documents produced by `/design` before implementation begins.
 Each component or feature gets its own subdirectory.
 
-| Design | Issue | Phase | Status |
-|--------|-------|-------|--------|
-| [Tracing Scaffold](tracing/) | #52 | 2 | Draft |
+| Design | Issue | Phase | Date | Status |
+|--------|-------|-------|------|--------|
+| [Tracing Scaffold](tracing/) | #52 | 2 | 2026-04-23 | Approved |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,8 @@
+# Design Artifacts
+
+Design documents produced by `/design` before implementation begins.
+Each component or feature gets its own subdirectory.
+
+| Design | Issue | Phase | Status |
+|--------|-------|-------|--------|
+| [Tracing Scaffold](tracing/) | #52 | 2 | Draft |

--- a/docs/design/tracing/README.md
+++ b/docs/design/tracing/README.md
@@ -1,5 +1,5 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-23
 -->
 
@@ -14,11 +14,11 @@ spans for free by following the conventions established here.
 
 | Document | Phase | Status | Description |
 |----------|-------|--------|-------------|
-| [Problem Space](problem.md) | 1 | Draft | What we're solving, current gaps, success criteria |
-| [Requirements](requirements.md) | 2 | Draft | Use cases, requirements (R-01–R-21), ASVS/ISO review, SRTM |
-| [Architecture](architecture.md) | 3 | Draft | 9 decisions, field dictionary, Mermaid diagrams, audit vs. privacy tension |
-| [Threat Model](threat-model.md) | 4 | Draft | Lightweight review — trace output boundary. Full STRIDE deferred to #115 |
-| [Test Plan](test-plan.md) | 5 | Draft | 21 test cases (TC-01–TC-21), CI integration, PR review checklist |
+| [Problem Space](problem.md) | 1 | Approved | What we're solving, current gaps, success criteria |
+| [Requirements](requirements.md) | 2 | Approved | Use cases, requirements (R-01–R-21), ASVS/ISO review, SRTM |
+| [Architecture](architecture.md) | 3 | Approved | 9 decisions, field dictionary, Mermaid diagrams, audit vs. privacy tension |
+| [Threat Model](threat-model.md) | 4 | Approved | Lightweight review — trace output boundary. Full STRIDE deferred to #115 |
+| [Test Plan](test-plan.md) | 5 | Approved | 21 test cases (TC-01–TC-21), CI integration |
 
 ## Key decisions
 

--- a/docs/design/tracing/README.md
+++ b/docs/design/tracing/README.md
@@ -1,0 +1,35 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-23
+-->
+
+# Design: Tracing Scaffold (#52)
+
+Comprehensive structured tracing across all memory-mcp subsystems, with
+optional OTLP export behind a feature flag. This is the load-bearing
+observability foundation for Phase 2 — every subsequent feature gets
+spans for free by following the conventions established here.
+
+## Artifacts
+
+| Document | Phase | Status | Description |
+|----------|-------|--------|-------------|
+| [Problem Space](problem.md) | 1 | Draft | What we're solving, current gaps, success criteria |
+| [Requirements](requirements.md) | 2 | Draft | Use cases, requirements (R-01–R-21), ASVS/ISO review, SRTM |
+| [Architecture](architecture.md) | 3 | Draft | 9 decisions, field dictionary, Mermaid diagrams, audit vs. privacy tension |
+| [Threat Model](threat-model.md) | 4 | Draft | Lightweight review — trace output boundary. Full STRIDE deferred to #115 |
+| [Test Plan](test-plan.md) | 5 | Draft | 21 test cases (TC-01–TC-21), CI integration, PR review checklist |
+
+## Key decisions
+
+- Span naming: `module.operation` (e.g. `handler.remember`, `embedding.embed`)
+- Field naming: flat `snake_case`, canonical dictionary in architecture.md
+- Sensitive data: redact at source, never in spans (tokens, content, credentials)
+- OTLP: behind `--features otlp`, zero dep cost for default builds
+- Audit content (query text, memory content): excluded from scaffold, deferred to Phase 5 tiered output — see architecture.md "Design Tension" section
+
+## Forward references
+
+- **#162** — W3C Trace Context propagation (Phase 5)
+- **#115** — Full STRIDE threat model required (Phase 6)
+- **#110, #111, #112** — Audit logging fields, informed by audit vs. privacy tension

--- a/docs/design/tracing/architecture.md
+++ b/docs/design/tracing/architecture.md
@@ -1,12 +1,12 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-23
 phase: 3
 -->
 
 # Architecture: Tracing Scaffold (#52)
 
-*Draft — 2026-04-23*
+*Approved — 2026-04-23*
 
 ## Decisions
 

--- a/docs/design/tracing/architecture.md
+++ b/docs/design/tracing/architecture.md
@@ -1,0 +1,310 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-23
+phase: 3
+-->
+
+# Architecture: Tracing Scaffold (#52)
+
+## Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| 1 | Subscriber composition | Two `#[cfg]` branches in `init_tracing()` — `fmt`-only (default) or `fmt` + OpenTelemetry layer (with `--features otlp`) | Avoids type system complexity of conditional layers; duplication is minimal |
+| 2 | Span placement | `#[instrument]` for straightforward methods; manual spans for complex flows (auth resolution, pull/merge, handlers) | `#[instrument]` where params map to fields; manual where fields are computed mid-function |
+| 3 | Span naming | `module.operation` everywhere — `handler.remember`, `embedding.embed`, `index.search`, `repo.push`, `auth.resolve` | Consistent, greppable, sorts well in trace UIs |
+| 4 | Field naming | Flat `snake_case` — `batch_size`, `content_size`, `key_count`, `session_id` | Native to `tracing` crate; domain-specific fields don't need OTel dotted conventions |
+| 5 | Session ID | Extract `http::request::Parts` via rmcp's `Extension` extractor, read `mcp-session-id` header | rmcp already injects HTTP parts into request extensions; no new plumbing needed |
+| 6 | Sensitive data | Redact at source — tokens, content, credentials never enter span fields | Simpler and more secure than filtering layers; follows existing `redact_url` pattern |
+| 7 | OTLP deps | `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `tracing-opentelemetry` all optional behind `otlp` feature | Zero dep cost for default builds |
+| 8 | OTLP endpoint | Standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var (handled by OpenTelemetry SDK) | No custom config; follows OTel conventions. Compatible with Honeycomb, Jaeger, Tempo, etc. |
+| 9 | Default levels | Handler spans at `info`, subsystem spans at `debug`, security events at `warn` | Operators get handler-level flow at defaults; `debug` for detail; security events always visible |
+
+## Field Dictionary
+
+Canonical field names used across all modules:
+
+| Field | Type | Modules | Description |
+|-------|------|---------|-------------|
+| `session_id` | str | handlers | MCP session identifier (from `mcp-session-id` header) |
+| `name` | str | handlers, repo | Memory name |
+| `scope` | str | handlers, index | Scope value (`global`, `project:x`) |
+| `content_size` | usize | handlers | Content size in bytes |
+| `batch_size` | usize | embedding | Number of items in batch |
+| `chunk_size` | usize | embedding | Items in current chunk |
+| `dimensions` | usize | embedding, index | Vector dimensions |
+| `model` | str | embedding | Model identifier |
+| `count` | usize | index, handlers | Result/item count |
+| `key_count` | usize | index | Keys in index |
+| `branch` | str | repo | Git branch name |
+| `file_count` | usize | repo | Files affected |
+| `oid` | str | repo | Git object ID (short) |
+| `token_source` | str | auth | Resolved token provenance |
+| `duration_ms` | u64 | various | Timing (where not captured by span duration) |
+
+## Design Tension: Audit Content vs. Privacy
+
+### The tension
+
+Both memory content and query text are valuable from an auditing perspective —
+knowing what was stored and what was searched for enables security monitoring
+(e.g. detecting attempts to recall credentials) and compliance. But both
+could contain sensitive or private information that needs protection.
+
+### Why this can't be fully resolved in the scaffold
+
+The tracing scaffold is the operational observability layer: timing, flow,
+counts, errors. It should be broadly accessible to operators for debugging
+and alerting. Audit logging — who accessed what, with full content — is a
+different concern with different access control requirements.
+
+Collapsing both into a single trace output channel creates a conflict:
+either the traces are too sensitive for broad operator access, or the
+audit trail is too sparse for compliance.
+
+### Decision for the scaffold
+
+The scaffold defaults to the **safe choice**: sizes and counts, not content
+or query text. Memory content → `content_size`. No `query` field on recall
+spans.
+
+This is explicitly **not a permanent decision** — it's a Phase 2 default
+that Phase 5 (Audit Logging) will revisit.
+
+### How Phase 5 should resolve this
+
+The standard enterprise pattern is **tiered output** — separate channels
+with different content and access controls:
+
+- **Operational traces** (this scaffold): timing, counts, sizes, flow.
+  Broadly accessible. Powers debugging and alerting.
+- **Audit log** (Phase 5): who accessed what, full query text, memory
+  names, content hashes or full content. Restricted access. Powers
+  compliance and incident investigation.
+
+Both can use the same `tracing` infrastructure — different subscribers or
+different span fields routed to different sinks. A span can carry both a
+`content_size` field (operational) and emit an audit event with the full
+content (routed only to the audit channel).
+
+The scaffold supports this by:
+1. Using layered subscribers (already composing `fmt` + optional OTLP)
+2. Manual spans with explicit field lists (trivial to add audit-specific fields)
+3. Not hardcoding any assumption about what "trace output" means
+
+See #110, #111, #112 for the specific Phase 5 issues that will implement
+audit fields on top of this scaffold.
+
+## Diagrams
+
+### System Context
+
+memory-mcp sits between three external actors: an AI agent sending MCP tool
+calls over streamable HTTP, an operator consuming trace output, and an optional
+OTLP collector receiving structured telemetry. Trace output always goes to
+stderr (formatted logs); when the `otlp` feature is compiled in, spans are
+also exported to a collector (Honeycomb, Jaeger, Tempo, etc.).
+
+```mermaid
+graph TB
+    agent["AI Agent\n(MCP client — Claude Code, etc.)"]
+    operator["Operator\n(reads structured logs)"]
+    collector["OTLP Collector\n(Honeycomb / Jaeger / Tempo)\n[optional — otlp feature]"]
+    remote["GitHub Remote\n(butterflyskies/memories)"]
+
+    subgraph memory_mcp["memory-mcp"]
+        server["MCP Server\n(Axum + rmcp)"]
+    end
+
+    agent -->|"MCP tool calls\nHTTP POST /mcp"| server
+    server -->|"Tool results (JSON)"| agent
+    server -->|"Structured traces\n(stderr, fmt layer)"| operator
+    server -.->|"Span export\n(OTLP/gRPC)"| collector
+    server -->|"git push/pull\n(HTTPS + PAT)"| remote
+
+    style collector stroke-dasharray: 5 5
+```
+
+### Component Diagram
+
+Internal components are organized around the MCP handler layer, which is the
+entry point for every tool call. Spans flow down from handlers through
+subsystems — each nested under the parent handler span. The tracing subscriber,
+composed in `main.rs`, consumes all spans; it always includes `EnvFilter` +
+`fmt`, and conditionally adds an OpenTelemetry layer when `otlp` is active.
+
+```mermaid
+graph TB
+    subgraph binary["memory-mcp binary"]
+        subgraph main["main.rs — startup"]
+            init["init_tracing()\nRegistry + EnvFilter + fmt\n+ OtelLayer if otlp"]
+            startup["Startup timing spans\nrepo.init, embedding.load_model,\nindex.load"]
+        end
+
+        subgraph handlers["server.rs — MCP Handlers (info level)"]
+            remember["handler.remember\nsession_id, name, scope, content_size"]
+            recall["handler.recall\nsession_id, scope, count"]
+            forget["handler.forget\nsession_id, name, scope"]
+            edit["handler.edit\nsession_id, name, scope"]
+            list["handler.list\nsession_id, scope, count"]
+            read["handler.read\nsession_id, name, scope"]
+            sync["handler.sync\nsession_id, branch"]
+        end
+
+        subgraph embedding["embedding/ (debug level)"]
+            embed["embedding.embed\nbatch_size, dimensions, model"]
+            load_model["embedding.load_model\nmodel, duration_ms"]
+        end
+
+        subgraph index["index.rs (debug level)"]
+            idx_add["index.add\nscope, key_count, dimensions"]
+            idx_search["index.search\nscope, count, dimensions"]
+            idx_remove["index.remove\nscope"]
+            idx_save["index.save / index.load\nkey_count"]
+        end
+
+        subgraph repo["repo.rs (debug level)"]
+            repo_save["repo.save\nbranch, oid"]
+            repo_read["repo.read\nbranch"]
+            repo_list["repo.list\nbranch, file_count"]
+            repo_push["repo.push\nbranch, oid"]
+            repo_pull["repo.pull\nbranch, oid"]
+        end
+
+        subgraph auth["auth.rs (debug/warn level)"]
+            auth_resolve["auth.resolve\ntoken_source (info)\nper-source attempts (debug)\nfailures (warn)"]
+        end
+    end
+
+    handlers -->|parent span| embedding
+    handlers -->|parent span| index
+    handlers -->|parent span| repo
+    sync -->|parent span| auth
+
+    style auth stroke-dasharray: 3 3
+```
+
+### Span Hierarchy — `handler.remember`
+
+Shows the full span nesting for a `remember` call, the tool that touches
+the most subsystems. Each span is annotated with its structured fields.
+Content text and tokens never appear in any span field (R-16–R-18). The
+session ID propagates from the handler span to all children via tracing's
+implicit span inheritance.
+
+```mermaid
+flowchart TD
+    A["handler.remember  [info]
+    ───────────────────
+    session_id: &lt;mcp-session-id&gt;
+    name: 'my-memory'
+    scope: 'project:foo'
+    content_size: 1024"]
+
+    B["embedding.embed  [debug]
+    ───────────────────
+    batch_size: 1
+    dimensions: 384
+    model: 'BAAI/bge-small-en-v1.5'
+    ⚠ content text: NEVER in span"]
+
+    C["index.add  [debug]
+    ───────────────────
+    scope: 'project:foo'
+    key_count: 42
+    dimensions: 384"]
+
+    D["repo.save  [debug]
+    ───────────────────
+    branch: 'main'
+    oid: 'a1b2c3d'"]
+
+    A -->|"1. generate vector"| B
+    A -->|"2. upsert vector"| C
+    A -->|"3. write + commit"| D
+```
+
+### Span Hierarchy — `handler.sync`
+
+The `sync` tool involves auth (for git push/pull) and is the only handler
+where `auth.resolve` appears in the span tree.
+
+```mermaid
+flowchart TD
+    A["handler.sync  [info]
+    ───────────────────
+    session_id: &lt;mcp-session-id&gt;
+    branch: 'main'"]
+
+    B["auth.resolve  [info/debug]
+    ───────────────────
+    token_source: 'env_var'
+    ⚠ token value: NEVER in span"]
+
+    C["repo.pull  [debug]
+    ───────────────────
+    branch: 'main'
+    oid: 'b2c3d4e'"]
+
+    D["embedding.embed  [debug]
+    ───────────────────
+    batch_size: 3
+    dimensions: 384"]
+
+    E["index.add  [debug]
+    ───────────────────
+    scope: 'global'
+    key_count: 45"]
+
+    F["repo.push  [debug]
+    ───────────────────
+    branch: 'main'
+    oid: 'c3d4e5f'"]
+
+    A -->|"1. resolve token"| B
+    A -->|"2. pull from remote"| C
+    A -->|"3. reindex changed"| D
+    A -->|"4. update index"| E
+    A -->|"5. push to remote"| F
+```
+
+### Subscriber Composition
+
+`init_tracing()` has two compile-time paths. The default build composes
+`Registry` + `EnvFilter` + `fmt` layer writing to stderr. With `--features otlp`,
+a `tracing-opentelemetry` layer bridges spans to the OpenTelemetry SDK, which
+exports via OTLP to the configured collector. Both paths share identical
+instrumentation in all subsystems; the difference is purely in what the
+subscriber does with the spans.
+
+```mermaid
+flowchart LR
+    subgraph default_build["Default build — cargo build"]
+        d_registry["tracing::Registry"]
+        d_env["EnvFilter\nRUST_LOG or 'memory_mcp=info'"]
+        d_fmt["fmt::Layer\nstderr"]
+        d_out["stderr\nstructured log lines"]
+
+        d_registry --> d_env --> d_fmt --> d_out
+    end
+
+    subgraph otlp_build["OTLP build — cargo build --features otlp"]
+        o_registry["tracing::Registry"]
+        o_env["EnvFilter\nRUST_LOG or 'memory_mcp=info'"]
+        o_fmt["fmt::Layer\nstderr"]
+        o_otel["tracing_opentelemetry\n::layer()"]
+        o_sdk["opentelemetry_sdk\nBatchSpanProcessor"]
+        o_exporter["opentelemetry-otlp\nOtlpSpanExporter"]
+        o_stderr["stderr\nlog lines"]
+        o_collector["OTLP Collector\nOTEL_EXPORTER_OTLP_ENDPOINT"]
+
+        o_registry --> o_env
+        o_env --> o_fmt --> o_stderr
+        o_env --> o_otel --> o_sdk --> o_exporter --> o_collector
+    end
+
+    style o_otel stroke-dasharray: 5 5
+    style o_sdk stroke-dasharray: 5 5
+    style o_exporter stroke-dasharray: 5 5
+    style o_collector stroke-dasharray: 5 5
+```

--- a/docs/design/tracing/architecture.md
+++ b/docs/design/tracing/architecture.md
@@ -6,6 +6,8 @@ phase: 3
 
 # Architecture: Tracing Scaffold (#52)
 
+*Draft — 2026-04-23*
+
 ## Decisions
 
 | # | Decision | Choice | Rationale |
@@ -110,7 +112,7 @@ graph TB
     agent["AI Agent\n(MCP client — Claude Code, etc.)"]
     operator["Operator\n(reads structured logs)"]
     collector["OTLP Collector\n(Honeycomb / Jaeger / Tempo)\n[optional — otlp feature]"]
-    remote["GitHub Remote\n(butterflyskies/memories)"]
+    remote["Git Remote\n(optional — deployment-specific)"]
 
     subgraph memory_mcp["memory-mcp"]
         server["MCP Server\n(Axum + rmcp)"]
@@ -120,7 +122,7 @@ graph TB
     server -->|"Tool results (JSON)"| agent
     server -->|"Structured traces\n(stderr, fmt layer)"| operator
     server -.->|"Span export\n(OTLP/gRPC)"| collector
-    server -->|"git push/pull\n(HTTPS + PAT)"| remote
+    server -->|"git push/pull\n(HTTPS, optional)"| remote
 
     style collector stroke-dasharray: 5 5
 ```

--- a/docs/design/tracing/problem.md
+++ b/docs/design/tracing/problem.md
@@ -1,12 +1,12 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-22
 phase: 1
 -->
 
 # Problem Space: Tracing Scaffold (#52)
 
-*Draft — 2026-04-22*
+*Approved — 2026-04-23*
 
 ## What are we solving?
 

--- a/docs/design/tracing/problem.md
+++ b/docs/design/tracing/problem.md
@@ -6,13 +6,15 @@ phase: 1
 
 # Problem Space: Tracing Scaffold (#52)
 
+*Draft — 2026-04-22*
+
 ## What are we solving?
 
 memory-mcp has minimal, inconsistent observability. The MCP tool handlers in
 `server.rs` have basic spans with timing fields (`embed_ms`, `repo_ms`), but the
 subsystems they delegate to — embedding, vector index, git repo, auth — are opaque.
-When something goes wrong in production (goddess cluster), debugging requires
-guessing which subsystem failed and why, rather than following structured trace data.
+When something goes wrong in production, debugging requires guessing which
+subsystem failed and why, rather than following structured trace data.
 
 An AI agent calling the MCP server can't inspect internal state. The operator's
 only window is trace output — and right now that window is narrow and inconsistent.

--- a/docs/design/tracing/problem.md
+++ b/docs/design/tracing/problem.md
@@ -1,0 +1,99 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-22
+phase: 1
+-->
+
+# Problem Space: Tracing Scaffold (#52)
+
+## What are we solving?
+
+memory-mcp has minimal, inconsistent observability. The MCP tool handlers in
+`server.rs` have basic spans with timing fields (`embed_ms`, `repo_ms`), but the
+subsystems they delegate to — embedding, vector index, git repo, auth — are opaque.
+When something goes wrong in production (goddess cluster), debugging requires
+guessing which subsystem failed and why, rather than following structured trace data.
+
+An AI agent calling the MCP server can't inspect internal state. The operator's
+only window is trace output — and right now that window is narrow and inconsistent.
+
+## Why now?
+
+Phase 2 is starting. The roadmap comment on #132 explicitly front-loads the tracing
+scaffold because every subsequent feature (#94 vector index trait, #146 integration
+tests, #109 secret scanning) benefits from having spans already in place. Getting
+conventions right now prevents each feature from inventing its own instrumentation
+style.
+
+## Current state
+
+| Module | File(s) | Current tracing | Gap |
+|--------|---------|-----------------|-----|
+| MCP handlers | `server.rs` | Manual `info_span!` per tool, timing fields for embed/repo | No content sizes, result counts, scope values in spans. No span for `incremental_reindex`. |
+| Embedding | `embedding/candle.rs` | `info!` for model loading, `warn!` for mutex poison | No spans for `embed`/`embed_one`, no batch size, no per-chunk timing |
+| Vector index | `index.rs` | `warn!` on errors only | No spans for `add`/`remove`/`search`/`save`/`load`. No key counts, result counts, dimensions |
+| Git repo | `repo.rs` | `info!`/`warn!` for push/pull events | No spans for `save_memory`/`read_memory`/`list_memories`/`push`/`pull`/`init_or_open`. No branch, OID, or file count fields |
+| Auth | `auth.rs` | None | No spans for token resolution path, device flow steps |
+| Startup | `main.rs` | `info!` for bind address and repo path | No timing for subsystem init (repo open, model load, index load) |
+
+## Inputs and outputs
+
+- **Input:** The existing codebase with ad-hoc `info!`/`warn!` logging
+- **Output:** Structured, hierarchical spans with machine-parseable fields across
+  all subsystems, plus an opt-in OTLP exporter for forwarding to Jaeger, Grafana
+  Tempo, Honeycomb, or other OpenTelemetry-compatible backends
+- **Key transformation:** Replace scattered log events with wide spans that capture
+  context as structured fields, creating a consistent instrumentation convention
+  that new code follows naturally
+
+## Boundaries
+
+### In scope
+
+- Structured spans (`#[instrument]` + manual spans) across all subsystems
+- Consistent field naming conventions for the whole codebase
+- MCP session ID (rmcp-internal) as a structured field on handler spans
+- OTLP export behind a `--features otlp` feature flag
+- Ensuring the subscriber setup in `main.rs` supports layered composition
+  (fmt + optional OTLP)
+
+### Out of scope (deferred with tracking)
+
+- **W3C Trace Context propagation** — extracting `traceparent`/`tracestate` from
+  incoming requests so memory-mcp spans nest under the caller's trace. Tracked as
+  #162, scheduled for Phase 5. The scaffold should not preclude this.
+- **Caller-supplied metadata** — agent session names, project context, accounting
+  fields plumbed through as span fields. Phase 6 enterprise concern. The trace
+  architecture should be extensible enough that adding propagation and metadata
+  extraction later is straightforward (Axum middleware + OpenTelemetry extractors).
+
+### Out of scope (not tracked — separate concerns)
+
+- Prometheus metrics endpoint (separate issue)
+- `/readyz` health endpoint with subsystem checks (noted as TODO in `run_serve`)
+- Performance benchmarking of tracing overhead
+
+### Constraints
+
+- Structured fields only — no `format!` interpolation in span fields
+- Must not log sensitive data: auth tokens, memory content beyond snippets,
+  git credentials (URLs are already redacted via `redact_url` in `repo.rs`)
+- OTLP export must be feature-gated to avoid pulling OpenTelemetry deps for
+  users who don't need them
+- Tracing overhead must be negligible for the default `fmt` subscriber
+
+## Success criteria
+
+1. Every public method in embedding, index, repo, and auth has a span with
+   relevant structured fields
+2. An operator can trace a single MCP tool call from handler through
+   embedding → index → repo, seeing timing and context at each level
+3. `RUST_LOG=memory_mcp=debug` produces useful, structured output for any
+   operation
+4. OTLP export works behind `--features otlp` and can send spans to a local
+   collector
+5. New code added in subsequent Phase 2 issues (#94, #146) gets spans by
+   following the established conventions
+6. No sensitive data (tokens, full memory content, git credentials) appears
+   in any span field
+7. MCP session ID is present on every handler span

--- a/docs/design/tracing/problem.md
+++ b/docs/design/tracing/problem.md
@@ -69,11 +69,11 @@ style.
   architecture should be extensible enough that adding propagation and metadata
   extraction later is straightforward (Axum middleware + OpenTelemetry extractors).
 
-### Out of scope (not tracked — separate concerns)
+### Out of scope (separate concerns)
 
-- Prometheus metrics endpoint (separate issue)
-- `/readyz` health endpoint with subsystem checks (noted as TODO in `run_serve`)
-- Performance benchmarking of tracing overhead
+- Prometheus metrics endpoint — #165
+- `/readyz` health endpoint with subsystem checks — #164
+- Performance benchmarking of tracing overhead (PR-level concern for #52)
 
 ### Constraints
 

--- a/docs/design/tracing/requirements.md
+++ b/docs/design/tracing/requirements.md
@@ -1,0 +1,118 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-23
+phase: 2
+-->
+
+# Requirements: Tracing Scaffold (#52)
+
+## Use Cases
+
+| ID | Actor | Use Case | Type | Priority |
+|----|-------|----------|------|----------|
+| UC-01 | Operator | Trace a slow tool call to identify which subsystem (embedding, index, repo) is the bottleneck | Normal | Must |
+| UC-02 | Operator | Monitor startup to see which subsystem initialization is slow (model load, index load, repo open) | Normal | Must |
+| UC-03 | Operator | Filter traces by MCP session ID to isolate a specific client's activity | Normal | Must |
+| UC-04 | Operator | Export traces via OTLP to Honeycomb/Jaeger/Tempo for analysis and alerting | Normal | Must |
+| UC-05 | Operator | Adjust trace verbosity at runtime via `RUST_LOG` without restarting the server | Normal | Should |
+| UC-06 | Developer | Add a new subsystem method and instrument it by following existing conventions | Normal | Must |
+| UC-07 | Developer | Read trace output during local development to understand request flow | Normal | Must |
+| AC-01 | Attacker | Read trace output to extract auth tokens, memory content, or git credentials | Abuse | Must-mitigate |
+| AC-02 | Attacker | Trigger operations that produce excessive trace output to fill disk or flood a log aggregator | Abuse | Should-mitigate |
+| SC-01 | System | Redact sensitive fields (tokens, credentials, full memory content) in all trace output regardless of log level | Security | Must |
+| SC-02 | System | Ensure auth token resolution path is logged at appropriate level (which source was tried/succeeded, never the token value) | Security | Must |
+
+## ASVS Categories Reviewed
+
+| Category | Applicable? | Rationale |
+|----------|-------------|-----------|
+| V7: Error handling, logging | Yes | Directly governs what gets logged, at what level, what must be excluded |
+| V8: Data protection | Yes | Sensitive data (tokens, memory content, credentials) must not appear in traces |
+| V2: Authentication | Yes | Auth flow instrumentation must not leak token values |
+| V1, V3–V6, V9–V14 | No | Not applicable to an observability feature — no sessions, access control, crypto, file handling, or API changes in scope |
+
+## ISO 27001:2022 Annex A Controls Reviewed
+
+| Control | Applicable? | Rationale |
+|---------|-------------|-----------|
+| A.8.15: Logging | Yes | Security-relevant events must be captured at appropriate levels even under conservative settings |
+| A.8.11: Data masking | Yes | Sensitive data redaction in trace output — maps to R-16/R-17/R-18 |
+| A.8.16: Monitoring | Yes | OTLP export enables downstream anomaly detection and alerting |
+| A.8.17: Clock synchronization | Handled | `tracing` crate uses system clock / `Instant` — no action needed |
+| A.5.33: Protection of records | Deferred | Log integrity and tamper evidence are the collector/backend's responsibility; Phase 5 concern |
+| A.8.10: Information deletion | Not applicable | Trace data retention is managed by the collector, not the application |
+| A.8.12: Data leakage prevention | Covered | Overlaps with V8 / R-16–R-18 |
+
+## Requirements
+
+### Span conventions
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-01 | Every public method in embedding, index, repo, and auth modules shall have a tracing span | UC-01, UC-06 | V7.1, A.8.15 | Must |
+| R-02 | Span names shall use `snake_case` and follow the pattern `module.operation` (e.g. `embedding.embed`, `repo.push`, `index.search`) | UC-06, UC-07 | — | Must |
+| R-03 | All span fields shall use structured values (no `format!` interpolation) | UC-01, UC-07 | V7.1 | Must |
+| R-04 | Field names shall use `snake_case` and be consistent across modules (e.g. always `count`, not `num_results` in one place and `result_count` in another) | UC-06 | — | Must |
+| R-05 | Subsystem spans shall nest under the parent MCP handler span, creating a clear hierarchy (handler → embed → index → repo) | UC-01, UC-07 | — | Must |
+
+### Subsystem coverage
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-06 | Embedding spans shall include: batch size, dimensions, per-chunk timing, model ID | UC-01 | — | Must |
+| R-07 | Vector index spans shall include: operation, key count, result count, dimensions, scope | UC-01 | — | Must |
+| R-08 | Git repo spans shall include: operation, branch name, file count; OIDs for push/pull | UC-01 | — | Must |
+| R-09 | Auth spans shall include: resolution source tried (at `debug`), resolution source succeeded (at `info`), token provenance — never the token value | UC-01, SC-02 | V2.10, V7.1, A.8.15 | Must |
+| R-10 | MCP handler spans shall include: session ID, content size, result count, scope, memory name | UC-01, UC-03 | V7.1, A.8.15 | Must |
+| R-11 | Startup shall have timed spans for each subsystem initialization (repo open, embedding model load, index load) | UC-02 | — | Must |
+
+### OTLP export
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-12 | OTLP exporter shall be available behind `--features otlp` feature flag | UC-04 | — | Must |
+| R-13 | When the `otlp` feature is enabled, the subscriber shall compose the `fmt` layer with an OpenTelemetry layer | UC-04 | A.8.16 | Must |
+| R-14 | OTLP endpoint shall be configurable via environment variable (`OTEL_EXPORTER_OTLP_ENDPOINT`) | UC-04 | — | Must |
+| R-15 | The default build (no `otlp` feature) shall not pull in OpenTelemetry dependencies | UC-04 | — | Must |
+
+### Sensitive data protection
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-16 | Auth tokens, git credentials, and API keys shall never appear in span fields at any log level | AC-01, SC-01 | V2.10, V8.3, A.8.11 | Must |
+| R-17 | Memory content in spans shall be limited to a size field (byte count), never the full text | AC-01, SC-01 | V8.3, A.8.11 | Must |
+| R-18 | Git remote URLs in spans shall use the existing `redact_url` function to strip credentials | AC-01, SC-01 | V8.3, A.8.11 | Must |
+
+### Operability
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-19 | Trace verbosity shall be controllable via `RUST_LOG` environment variable with per-module granularity | UC-05 | V7.1 | Must |
+| R-20 | Default log level shall produce useful output without being noisy (info-level for handler spans, debug-level for subsystem internals) | UC-05, AC-02 | V7.1 | Should |
+| R-21 | Security-relevant events (auth failures, invalid inputs, permission denials) shall be logged at `warn` or higher, not gated behind `debug` | SC-01, SC-02 | V7.2, A.8.15 | Must |
+
+## Security Requirements Traceability Matrix (SRTM)
+
+| Req ID | Requirement | Source UC | Security Ref | Test Case |
+|--------|-------------|-----------|--------------|-----------|
+| R-01 | Public methods have spans | UC-01, UC-06 | V7.1, A.8.15 | TC-01: verify span exists for each public method (grep/audit) |
+| R-02 | Span naming convention `module.operation` | UC-06, UC-07 | — | TC-02: verify all span names match pattern |
+| R-03 | Structured fields only | UC-01, UC-07 | V7.1 | TC-03: verify no `format!` in span field values (lint/audit) |
+| R-04 | Consistent field naming | UC-06 | — | TC-04: verify field names consistent across modules (audit) |
+| R-05 | Span hierarchy | UC-01, UC-07 | — | TC-05: `remember` call produces nested spans (handler → embed → index → repo) |
+| R-06 | Embedding span fields | UC-01 | — | TC-06: embed span includes batch_size, dimensions, model |
+| R-07 | Index span fields | UC-01 | — | TC-07: index.search span includes key_count, result_count |
+| R-08 | Repo span fields | UC-01 | — | TC-08: repo.save span includes branch, file_count |
+| R-09 | Auth span fields | UC-01, SC-02 | V2.10, V7.1, A.8.15 | TC-09: auth spans log source, never token value |
+| R-10 | Handler span fields | UC-01, UC-03 | V7.1, A.8.15 | TC-10: handler spans include session_id, content_size |
+| R-11 | Startup timing spans | UC-02 | — | TC-11: startup logs show timed init for each subsystem |
+| R-12 | OTLP behind feature flag | UC-04 | — | TC-12: `cargo check` without `otlp` succeeds, no otel deps |
+| R-13 | Composed subscriber | UC-04 | A.8.16 | TC-13: with `otlp`, subscriber has fmt + otel layers |
+| R-14 | OTLP endpoint configurable | UC-04 | — | TC-14: `OTEL_EXPORTER_OTLP_ENDPOINT` respected |
+| R-15 | No otel deps by default | UC-04 | — | TC-15: `cargo tree` without `otlp` shows no opentelemetry |
+| R-16 | No tokens in spans | AC-01, SC-01 | V2.10, V8.3, A.8.11 | TC-16: auth resolution — captured spans contain no token values |
+| R-17 | Content size only | AC-01, SC-01 | V8.3, A.8.11 | TC-17: remember — span has content_size, no content text |
+| R-18 | Redacted git URLs | AC-01, SC-01 | V8.3, A.8.11 | TC-18: push/pull — span URL fields are redacted |
+| R-19 | RUST_LOG per-module control | UC-05 | V7.1 | TC-19: per-module filtering works (existing EnvFilter) |
+| R-20 | Appropriate default levels | UC-05, AC-02 | V7.1 | TC-20: default config — info handler spans, no debug noise |
+| R-21 | Security events at warn+ | SC-01, SC-02 | V7.2, A.8.15 | TC-21: auth failure produces warn-level event |

--- a/docs/design/tracing/requirements.md
+++ b/docs/design/tracing/requirements.md
@@ -28,22 +28,22 @@ phase: 2
 
 | Category | Applicable? | Rationale |
 |----------|-------------|-----------|
+| V2: Authentication | Yes | Auth flow instrumentation must not leak token values |
 | V7: Error handling, logging | Yes | Directly governs what gets logged, at what level, what must be excluded |
 | V8: Data protection | Yes | Sensitive data (tokens, memory content, credentials) must not appear in traces |
-| V2: Authentication | Yes | Auth flow instrumentation must not leak token values |
 | V1, V3–V6, V9–V14 | No | Not applicable to an observability feature — no sessions, access control, crypto, file handling, or API changes in scope |
 
 ## ISO 27001:2022 Annex A Controls Reviewed
 
 | Control | Applicable? | Rationale |
 |---------|-------------|-----------|
-| A.8.15: Logging | Yes | Security-relevant events must be captured at appropriate levels even under conservative settings |
-| A.8.11: Data masking | Yes | Sensitive data redaction in trace output — maps to R-16/R-17/R-18 |
-| A.8.16: Monitoring | Yes | OTLP export enables downstream anomaly detection and alerting |
-| A.8.17: Clock synchronization | Handled | `tracing` crate uses system clock / `Instant` — no action needed |
 | A.5.33: Protection of records | Deferred | Log integrity and tamper evidence are the collector/backend's responsibility; Phase 5 concern |
 | A.8.10: Information deletion | Not applicable | Trace data retention is managed by the collector, not the application |
+| A.8.11: Data masking | Yes | Sensitive data redaction in trace output — maps to R-16/R-17/R-18 |
 | A.8.12: Data leakage prevention | Covered | Overlaps with V8 / R-16–R-18 |
+| A.8.15: Logging | Yes | Security-relevant events must be captured at appropriate levels even under conservative settings |
+| A.8.16: Monitoring | Yes | OTLP export enables downstream anomaly detection and alerting |
+| A.8.17: Clock synchronization | Handled | `tracing` crate uses system clock / `Instant` — no action needed |
 
 ## Requirements
 

--- a/docs/design/tracing/requirements.md
+++ b/docs/design/tracing/requirements.md
@@ -6,6 +6,8 @@ phase: 2
 
 # Requirements: Tracing Scaffold (#52)
 
+*Draft — 2026-04-23*
+
 ## Use Cases
 
 | ID | Actor | Use Case | Type | Priority |

--- a/docs/design/tracing/requirements.md
+++ b/docs/design/tracing/requirements.md
@@ -1,12 +1,12 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-23
 phase: 2
 -->
 
 # Requirements: Tracing Scaffold (#52)
 
-*Draft — 2026-04-23*
+*Approved — 2026-04-23*
 
 ## Use Cases
 

--- a/docs/design/tracing/test-plan.md
+++ b/docs/design/tracing/test-plan.md
@@ -1,12 +1,12 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-23
 phase: 5
 -->
 
 # Test Plan: Tracing Scaffold (#52)
 
-*Draft — 2026-04-23*
+*Approved — 2026-04-23*
 
 ## Test infrastructure
 

--- a/docs/design/tracing/test-plan.md
+++ b/docs/design/tracing/test-plan.md
@@ -6,6 +6,8 @@ phase: 5
 
 # Test Plan: Tracing Scaffold (#52)
 
+*Draft — 2026-04-23*
+
 ## Test infrastructure
 
 Span-capturing tests use `tracing-test` or a custom in-memory subscriber

--- a/docs/design/tracing/test-plan.md
+++ b/docs/design/tracing/test-plan.md
@@ -1,0 +1,86 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-23
+phase: 5
+-->
+
+# Test Plan: Tracing Scaffold (#52)
+
+## Test infrastructure
+
+Span-capturing tests use `tracing-test` or a custom in-memory subscriber
+layer that collects spans and events for assertion. This infrastructure is
+built as part of this work and can be extended by #146 (integration tests).
+
+## Test cases
+
+### Span conventions (audit/lint)
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-01 | R-01 | Audit | Every public method in embedding, index, repo, auth has a span — verified by grep/review | Manual (PR review checklist) |
+| TC-02 | R-02 | Audit | All span names match `module.operation` pattern | Manual (PR review checklist) |
+| TC-03 | R-03 | Audit | No `format!` interpolation in span field values | Manual (PR review checklist) |
+| TC-04 | R-04 | Audit | Field names consistent with dictionary in architecture.md | Manual (PR review checklist) |
+
+### Span hierarchy
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-05 | R-05 | Integration | `remember` call produces nested spans: `handler.remember` → `embedding.embed` → `index.add` → `repo.save`. Capture spans with in-memory subscriber, assert parent-child relationships. | Yes |
+
+### Subsystem span fields
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-06 | R-06 | Unit | `embedding.embed` span includes `batch_size`, `dimensions`, `model` fields | Yes |
+| TC-07 | R-07 | Unit | `index.search` span includes `count`, `key_count`, `dimensions` fields | Yes |
+| TC-08 | R-08 | Unit | `repo.save` span includes `branch` field | Yes |
+| TC-09 | R-09 | Unit | `auth.resolve` span includes `token_source` field, does not contain any field matching a token pattern | Yes |
+| TC-10 | R-10 | Integration | Handler span includes `session_id` extracted from `mcp-session-id` header, plus `name`, `scope`, `content_size` as appropriate | Yes |
+| TC-11 | R-11 | Integration | Startup emits timed spans for `repo.init`, `embedding.load_model`, `index.load` | Yes |
+
+### OTLP feature flag
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-12 | R-12 | Build | `cargo check` without `otlp` feature succeeds | Yes (CI) |
+| TC-13 | R-13 | Build | `cargo check --features otlp` succeeds | Yes (CI) |
+| TC-14 | R-14 | Manual | With `otlp` feature and a local collector, verify spans arrive at configured `OTEL_EXPORTER_OTLP_ENDPOINT` | Manual |
+| TC-15 | R-15 | Build | `cargo tree` without `otlp` feature shows no `opentelemetry` crates in dependency tree | Yes (CI) |
+
+### Sensitive data protection
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-16 | R-16 | Unit | Set a known token value in env, trigger `auth.resolve`, capture all spans — assert no span field contains the token string | Yes |
+| TC-17 | R-17 | Unit | Call `remember` with known content, capture spans — assert `content_size` field present, no field contains the content string | Yes |
+| TC-18 | R-18 | Unit | Trigger repo operation with a URL containing credentials (`https://user:pass@host`), capture spans — assert URL fields are redacted | Yes |
+
+### Operability
+
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-19 | R-19 | Unit | Verify `EnvFilter` respects per-module `RUST_LOG` settings (existing behavior, regression test) | Yes |
+| TC-20 | R-20 | Unit | With default filter (`memory_mcp=info`), handler spans are captured, subsystem debug spans are not | Yes |
+| TC-21 | R-21 | Unit | Trigger an auth failure, capture events — assert at least one event at `WARN` level | Yes |
+
+## CI integration
+
+Add to the existing `build.yml` workflow:
+
+- `cargo check --features otlp` — verifies OTLP build compiles (TC-12, TC-13)
+- `cargo tree` assertion — verifies no opentelemetry crates without the feature (TC-15)
+- All unit/integration tests above run as part of `cargo nextest` (existing CI step)
+
+## PR review checklist
+
+TC-01 through TC-04 are manual audit checks. Include in the PR description
+as a checklist:
+
+```
+- [ ] Every public method in embedding, index, repo, auth has a span (TC-01/R-01)
+- [ ] All span names follow `module.operation` (TC-02/R-02)
+- [ ] No `format!` in span field values (TC-03/R-03)
+- [ ] Field names match architecture.md dictionary (TC-04/R-04)
+```

--- a/docs/design/tracing/test-plan.md
+++ b/docs/design/tracing/test-plan.md
@@ -10,62 +10,62 @@ phase: 5
 
 ## Test infrastructure
 
-Span-capturing tests use `tracing-test` or a custom in-memory subscriber
-layer that collects spans and events for assertion. This infrastructure is
-built as part of this work and can be extended by #146 (integration tests).
+Span-capturing tests use a custom in-memory subscriber layer that
+collects spans and events for assertion. This infrastructure is built
+as part of this work and can be extended by #146 (integration tests).
 
 ## Test cases
 
-### Span conventions (audit/lint)
+### Span conventions
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-01 | R-01 | Audit | Every public method in embedding, index, repo, auth has a span — verified by grep/review | Manual (PR review checklist) |
-| TC-02 | R-02 | Audit | All span names match `module.operation` pattern | Manual (PR review checklist) |
-| TC-03 | R-03 | Audit | No `format!` interpolation in span field values | Manual (PR review checklist) |
-| TC-04 | R-04 | Audit | Field names consistent with dictionary in architecture.md | Manual (PR review checklist) |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-01 | R-01 | Integration | Exercise every public method in embedding, index, repo, auth — assert the expected span name was emitted | In-memory subscriber |
+| TC-02 | R-02 | Integration | Assert all captured span names match `^[a-z_]+\.[a-z_]+$` | In-memory subscriber |
+| TC-03 | R-03 | Lint | Scan span macro invocations for `format!` in field values | CI grep/script |
+| TC-04 | R-04 | Integration | Capture all field names across all spans, assert every name exists in a canonical allowlist derived from the field dictionary | In-memory subscriber |
 
 ### Span hierarchy
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-05 | R-05 | Integration | `remember` call produces nested spans: `handler.remember` → `embedding.embed` → `index.add` → `repo.save`. Capture spans with in-memory subscriber, assert parent-child relationships. | Yes |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-05 | R-05 | Integration | `remember` call produces nested spans: `handler.remember` → `embedding.embed` → `index.add` → `repo.save` — assert parent-child relationships | In-memory subscriber |
 
 ### Subsystem span fields
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-06 | R-06 | Unit | `embedding.embed` span includes `batch_size`, `dimensions`, `model` fields | Yes |
-| TC-07 | R-07 | Unit | `index.search` span includes `count`, `key_count`, `dimensions` fields | Yes |
-| TC-08 | R-08 | Unit | `repo.save` span includes `branch` field | Yes |
-| TC-09 | R-09 | Unit | `auth.resolve` span includes `token_source` field, does not contain any field matching a token pattern | Yes |
-| TC-10 | R-10 | Integration | Handler span includes `session_id` extracted from `mcp-session-id` header, plus `name`, `scope`, `content_size` as appropriate | Yes |
-| TC-11 | R-11 | Integration | Startup emits timed spans for `repo.init`, `embedding.load_model`, `index.load` | Yes |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-06 | R-06 | Unit | `embedding.embed` span includes `batch_size`, `dimensions`, `model` fields | In-memory subscriber |
+| TC-07 | R-07 | Unit | `index.search` span includes `count`, `key_count`, `dimensions` fields | In-memory subscriber |
+| TC-08 | R-08 | Unit | `repo.save` span includes `branch` field | In-memory subscriber |
+| TC-09 | R-09 | Unit | `auth.resolve` span includes `token_source` field, no field contains a token value | In-memory subscriber |
+| TC-10 | R-10 | Integration | Handler span includes `session_id` from `mcp-session-id` header, plus `name`, `scope`, `content_size` as appropriate | In-memory subscriber |
+| TC-11 | R-11 | Integration | Startup emits timed spans for `repo.init`, `embedding.load_model`, `index.load` | In-memory subscriber |
 
 ### OTLP feature flag
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-12 | R-12 | Build | `cargo check` without `otlp` feature succeeds | Yes (CI) |
-| TC-13 | R-13 | Build | `cargo check --features otlp` succeeds | Yes (CI) |
-| TC-14 | R-14 | Manual | With `otlp` feature and a local collector, verify spans arrive at configured `OTEL_EXPORTER_OTLP_ENDPOINT` | Manual |
-| TC-15 | R-15 | Build | `cargo tree` without `otlp` feature shows no `opentelemetry` crates in dependency tree | Yes (CI) |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-12 | R-12 | Build | `cargo check` without `otlp` feature succeeds | CI workflow |
+| TC-13 | R-13 | Build | `cargo check --features otlp` succeeds | CI workflow |
+| TC-14 | R-14 | Integration | With `otlp` feature and a local collector, verify spans arrive at configured `OTEL_EXPORTER_OTLP_ENDPOINT` | CI workflow with collector sidecar |
+| TC-15 | R-15 | Build | `cargo tree` without `otlp` feature shows no `opentelemetry` crates | CI workflow |
 
 ### Sensitive data protection
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-16 | R-16 | Unit | Set a known token value in env, trigger `auth.resolve`, capture all spans — assert no span field contains the token string | Yes |
-| TC-17 | R-17 | Unit | Call `remember` with known content, capture spans — assert `content_size` field present, no field contains the content string | Yes |
-| TC-18 | R-18 | Unit | Trigger repo operation with a URL containing credentials (`https://user:pass@host`), capture spans — assert URL fields are redacted | Yes |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-16 | R-16 | Unit | Set a known token value in env, trigger `auth.resolve`, capture all spans — assert no span field contains the token string | In-memory subscriber |
+| TC-17 | R-17 | Unit | Call `remember` with known content, capture spans — assert `content_size` field present, no field contains the content string | In-memory subscriber |
+| TC-18 | R-18 | Unit | Trigger repo operation with a URL containing credentials (`https://user:pass@host`), capture spans — assert URL fields are redacted | In-memory subscriber |
 
 ### Operability
 
-| Test ID | Requirement | Type | Description | Automated? |
-|---------|-------------|------|-------------|------------|
-| TC-19 | R-19 | Unit | Verify `EnvFilter` respects per-module `RUST_LOG` settings (existing behavior, regression test) | Yes |
-| TC-20 | R-20 | Unit | With default filter (`memory_mcp=info`), handler spans are captured, subsystem debug spans are not | Yes |
-| TC-21 | R-21 | Unit | Trigger an auth failure, capture events — assert at least one event at `WARN` level | Yes |
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-19 | R-19 | Unit | Verify `EnvFilter` respects per-module `RUST_LOG` settings (existing behavior, regression test) | In-memory subscriber |
+| TC-20 | R-20 | Unit | With default filter (`memory_mcp=info`), handler spans are captured, subsystem debug spans are not | In-memory subscriber |
+| TC-21 | R-21 | Unit | Trigger an auth failure, capture events — assert at least one event at `WARN` level | In-memory subscriber |
 
 ## CI integration
 
@@ -73,16 +73,5 @@ Add to the existing `build.yml` workflow:
 
 - `cargo check --features otlp` — verifies OTLP build compiles (TC-12, TC-13)
 - `cargo tree` assertion — verifies no opentelemetry crates without the feature (TC-15)
+- Span convention lint script for TC-03
 - All unit/integration tests above run as part of `cargo nextest` (existing CI step)
-
-## PR review checklist
-
-TC-01 through TC-04 are manual audit checks. Include in the PR description
-as a checklist:
-
-```
-- [ ] Every public method in embedding, index, repo, auth has a span (TC-01/R-01)
-- [ ] All span names follow `module.operation` (TC-02/R-02)
-- [ ] No `format!` in span field values (TC-03/R-03)
-- [ ] Field names match architecture.md dictionary (TC-04/R-04)
-```

--- a/docs/design/tracing/threat-model.md
+++ b/docs/design/tracing/threat-model.md
@@ -1,12 +1,12 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-23
 phase: 4
 -->
 
 # Threat Model: Tracing Scaffold (#52)
 
-*Draft — 2026-04-23*
+*Approved — 2026-04-23*
 
 ## Scope
 

--- a/docs/design/tracing/threat-model.md
+++ b/docs/design/tracing/threat-model.md
@@ -1,0 +1,55 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-23
+phase: 4
+-->
+
+# Threat Model: Tracing Scaffold (#52)
+
+## Scope
+
+Lightweight review focused on the trace output boundary — the one area
+where this work introduces new risk. Full STRIDE analysis is deferred to
+#115 (auth framework), where the real trust boundary complexity arrives.
+That deferral is documented on #115.
+
+## Trust boundaries
+
+1. **AI agent → MCP server** (HTTP request boundary) — not changed by this work
+2. **MCP server → trace output** (stderr + OTLP) — **new/expanded by this work**
+3. **MCP server → git remote** (HTTPS + PAT) — not changed by this work
+
+## Threat analysis: trace output boundary
+
+| STRIDE | Threat | Likelihood | Impact | Mitigation |
+|--------|--------|------------|--------|------------|
+| I | Auth tokens leak into span fields via `auth.resolve` instrumentation | Medium | High (credential compromise) | R-16: redact at source. Auth spans log `token_source`, never the value. |
+| I | Memory content leaks into span fields | Medium | Medium (content may be sensitive) | R-17: `content_size` only, never text. Phase 5 will revisit with tiered output. |
+| I | Query text in `recall` spans exposes user search intent | Medium | Medium (queries may contain sensitive phrasing) | Excluded from scaffold spans. Phase 5 will add to audit channel with restricted access. See architecture.md "Design Tension" section. |
+| I | Git credentials leak via remote URL in span fields | Low | High (repo access compromise) | R-18: all URLs pass through existing `redact_url`. |
+| I | OTLP export sends spans to unintended/compromised collector | Low | High (all trace data exfiltrated) | OTLP is opt-in (feature flag). Endpoint is operator-configured. Operational concern, not code mitigation. |
+| D | High-volume operations flood trace output, filling disk | Low | Low (bounded by existing rate limiting) | R-20: appropriate default levels. `session_rate_limit` bounds request volume. |
+| T | Trace data modified in transit to OTLP collector | Low | Low (observational data, not authoritative) | TLS on OTLP transport (standard configuration). |
+
+## Findings
+
+1. **No new requirements needed.** R-16, R-17, R-18, R-20, and R-21 cover
+   the identified threats. The audit content tension (query text, memory
+   content) is documented in `architecture.md` and deferred to Phase 5.
+
+2. **Trace output is sensitive data.** Once the scaffold is in place, trace
+   output contains memory names, scopes, session IDs, and operational
+   patterns. Operators should treat trace output with appropriate access
+   controls. This is an operational guidance concern, not a code change.
+
+3. **Full STRIDE deferred to #115.** The auth framework introduces spoofing,
+   elevation of privilege, and access control threats that don't exist in
+   the current single-user model. Documented on the issue.
+
+## Deferred analysis
+
+| Concern | Deferred to | Rationale |
+|---------|-------------|-----------|
+| Full STRIDE on all trust boundaries | #115 (auth framework) | Multi-user auth introduces the real trust boundary complexity |
+| Audit content vs. privacy resolution | Phase 5 (#110, #111, #112) | Requires tiered output architecture — operational traces vs. audit log |
+| Trace output access controls | Phase 6 (#115, #118) | Meaningful only in multi-user deployment |

--- a/docs/design/tracing/threat-model.md
+++ b/docs/design/tracing/threat-model.md
@@ -6,6 +6,8 @@ phase: 4
 
 # Threat Model: Tracing Scaffold (#52)
 
+*Draft — 2026-04-23*
+
 ## Scope
 
 Lightweight review focused on the trace output boundary — the one area


### PR DESCRIPTION
## Summary

- Design documents for the tracing scaffold (#52), the load-bearing observability piece for Phase 2
- 5 artifacts in `docs/design/tracing/`: problem space, requirements, architecture, threat model, test plan
- Adds #162 (W3C Trace Context propagation) to Phase 5 in the roadmap

## Artifacts

| Document | Contents |
|----------|----------|
| `problem.md` | Current tracing gaps across 6 modules, success criteria, scope boundaries |
| `requirements.md` | 11 use cases, 21 requirements (R-01–R-21), ASVS + ISO 27001:2022 review, full SRTM |
| `architecture.md` | 9 decisions, field dictionary, 5 Mermaid diagrams, audit vs. privacy tension |
| `threat-model.md` | Lightweight review on trace output boundary; full STRIDE deferred to #115 |
| `test-plan.md` | 21 test cases (TC-01–TC-21), CI integration, PR review checklist |

## Key decisions documented

- Span naming: `module.operation` (e.g. `handler.remember`, `embedding.embed`)
- Field naming: flat `snake_case`, canonical dictionary
- Sensitive data: redact at source — tokens, content, credentials never in spans
- OTLP: behind `--features otlp`, zero dep cost for default builds
- Audit content (query text, memory content): excluded from scaffold, deferred to Phase 5 tiered output

## Issues created/updated

- **#162** created — W3C Trace Context propagation (Phase 5)
- **#115** commented — full STRIDE required when auth framework lands
- **#110, #111, #112** commented — breadcrumbs to audit vs. privacy tension

## Review notes

Diagrams render in GitHub's Mermaid support. Architecture decisions and the audit vs. privacy tension section in `architecture.md` are the most important sections to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)