### PR TITLE
docs: OTLP resilience requirements (R-22–R-25)

### DIFF
--- a/docs/design/tracing/architecture.md
+++ b/docs/design/tracing/architecture.md
@@ -21,6 +21,8 @@ phase: 3
 | 7 | OTLP deps | `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `tracing-opentelemetry` all optional behind `otlp` feature | Zero dep cost for default builds |
 | 8 | OTLP endpoint | Standard `OTEL_EXPORTER_OTLP_ENDPOINT` env var (handled by OpenTelemetry SDK) | No custom config; follows OTel conventions. Compatible with Honeycomb, Jaeger, Tempo, etc. |
 | 9 | Default levels | Handler spans at `info`, subsystem spans at `debug`, security events at `warn` | Operators get handler-level flow at defaults; `debug` for detail; security events always visible |
+| 10 | OTLP startup failure | Crash by default; `--otlp-optional` CLI arg enables fallback to fmt-only with a warning | Explicit opt-in to OTLP means failure should be loud. Fallback available for environments where the collector may lag behind the server. |
+| 11 | OTLP runtime resilience | Delegated to OpenTelemetry SDK's `BatchSpanProcessor` — buffers in memory, retries on failure, resumes when collector reconnects, drops oldest spans when buffer fills | SDK handles this well; no custom retry logic needed. Buffer/timeout tunables exposed via standard `OTEL_BSP_*` env vars. |
 
 ## Field Dictionary
 

--- a/docs/design/tracing/requirements.md
+++ b/docs/design/tracing/requirements.md
@@ -19,6 +19,8 @@ phase: 2
 | UC-05 | Operator | Adjust trace verbosity at runtime via `RUST_LOG` without restarting the server | Normal | Should |
 | UC-06 | Developer | Add a new subsystem method and instrument it by following existing conventions | Normal | Must |
 | UC-07 | Developer | Read trace output during local development to understand request flow | Normal | Must |
+| UC-08 | Operator | Start the server when the OTLP collector is temporarily unreachable, with the server continuing to function | Normal | Must |
+| UC-09 | Operator | Have the server automatically resume exporting spans when a disconnected OTLP collector comes back | Normal | Must |
 | AC-01 | Attacker | Read trace output to extract auth tokens, memory content, or git credentials | Abuse | Must-mitigate |
 | AC-02 | Attacker | Trigger operations that produce excessive trace output to fill disk or flood a log aggregator | Abuse | Should-mitigate |
 | SC-01 | System | Redact sensitive fields (tokens, credentials, full memory content) in all trace output regardless of log level | Security | Must |
@@ -93,6 +95,15 @@ phase: 2
 | R-20 | Default log level shall produce useful output without being noisy (info-level for handler spans, debug-level for subsystem internals) | UC-05, AC-02 | V7.1 | Should |
 | R-21 | Security-relevant events (auth failures, invalid inputs, permission denials) shall be logged at `warn` or higher, not gated behind `debug` | SC-01, SC-02 | V7.2, A.8.15 | Must |
 
+### OTLP resilience
+
+| ID | Requirement | Source UC | Security Ref | Priority |
+|----|-------------|-----------|--------------|----------|
+| R-22 | When OTLP is enabled, startup failure to connect to the collector shall crash the server by default with a message indicating the `--otlp-optional` flag | UC-08 | — | Must |
+| R-23 | When `--otlp-optional` is set, OTLP init failure shall log a warning and fall back to fmt-only operation | UC-08 | — | Must |
+| R-24 | During runtime, the OTLP exporter shall buffer spans in memory, retry on export failure, and automatically resume exporting when the collector becomes reachable again | UC-09 | A.8.15 | Must |
+| R-25 | The `--otlp-optional` CLI arg shall only be compiled when the `otlp` feature is active | UC-08 | — | Must |
+
 ## Security Requirements Traceability Matrix (SRTM)
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
@@ -118,3 +129,7 @@ phase: 2
 | R-19 | RUST_LOG per-module control | UC-05 | V7.1 | TC-19: per-module filtering works (existing EnvFilter) |
 | R-20 | Appropriate default levels | UC-05, AC-02 | V7.1 | TC-20: default config — info handler spans, no debug noise |
 | R-21 | Security events at warn+ | SC-01, SC-02 | V7.2, A.8.15 | TC-21: auth failure produces warn-level event |
+| R-22 | OTLP startup failure crashes by default | UC-08 | — | TC-22: without `--otlp-optional`, unreachable collector causes exit |
+| R-23 | `--otlp-optional` enables graceful fallback | UC-08 | — | TC-23: with `--otlp-optional`, unreachable collector logs warning, server starts |
+| R-24 | Runtime OTLP resilience (buffer, retry, reconnect) | UC-09 | A.8.15 | TC-24: SDK BatchSpanProcessor handles disconnection (documented behavior) |
+| R-25 | `--otlp-optional` only with `otlp` feature | UC-08 | — | TC-25: `cargo check` without `otlp` — arg not present in CLI |

--- a/docs/design/tracing/test-plan.md
+++ b/docs/design/tracing/test-plan.md
@@ -51,6 +51,15 @@ as part of this work and can be extended by #146 (integration tests).
 | TC-14 | R-14 | Integration | With `otlp` feature and a local collector, verify spans arrive at configured `OTEL_EXPORTER_OTLP_ENDPOINT` | CI workflow with collector sidecar |
 | TC-15 | R-15 | Build | `cargo tree` without `otlp` feature shows no `opentelemetry` crates | CI workflow |
 
+### OTLP resilience
+
+| Test ID | Requirement | Type | Description | Mechanism |
+|---------|-------------|------|-------------|-----------|
+| TC-22 | R-22 | Integration | With `otlp` feature, no collector running, no `--otlp-optional` — server exits with error message mentioning `--otlp-optional` | Process exit code + stderr check |
+| TC-23 | R-23 | Integration | With `otlp` feature, no collector running, `--otlp-optional` set — server starts, warning logged | Process stderr check |
+| TC-24 | R-24 | Documentation | SDK `BatchSpanProcessor` handles runtime disconnection — buffer, retry, reconnect. Verified by SDK documentation and upstream tests. | Documented behavior (not tested in our suite) |
+| TC-25 | R-25 | Build | `cargo check` without `otlp` — `--otlp-optional` arg is not present in CLI help | CI workflow |
+
 ### Sensitive data protection
 
 | Test ID | Requirement | Type | Description | Mechanism |


### PR DESCRIPTION
## Summary

- Adds OTLP operational resilience requirements identified during implementation planning
- Covers startup failure behavior (`--otlp-optional` flag) and runtime disconnection handling

## Changes

**requirements.md:**
- UC-08, UC-09: operator use cases for collector unavailability and reconnection
- R-22: crash by default on OTLP init failure with message pointing to `--otlp-optional`
- R-23: `--otlp-optional` enables graceful fallback to fmt-only
- R-24: runtime resilience delegated to SDK `BatchSpanProcessor` (buffer, retry, reconnect)
- R-25: `--otlp-optional` only compiled with `otlp` feature
- SRTM entries for TC-22 through TC-25

**architecture.md:**
- Decision 10: OTLP startup failure behavior
- Decision 11: runtime resilience via SDK

**test-plan.md:**
- TC-22 through TC-25 covering startup/runtime resilience

## Context

Gap identified during /develop Phase 1 planning — the approved design covered OTLP export but not what happens when the collector is unreachable at startup or disconnects at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)