### PR TITLE
feat: tracing scaffold across all subsystems (#52)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
       - run: cargo clippy --workspace -- -D warnings
       - run: cargo clippy --workspace --features k8s -- -D warnings
       - run: cargo clippy --workspace --features otlp -- -D warnings
+      - run: cargo clippy --workspace --features native-certs -- -D warnings
+      - run: cargo clippy --workspace --all-features -- -D warnings
       - name: Verify no opentelemetry in default build
         run: |
           cargo tree 2>&1 | grep -i opentelemetry && \
@@ -48,6 +50,7 @@ jobs:
       - run: cargo nextest run --workspace --no-fail-fast
       - run: cargo nextest run --workspace --no-fail-fast --features k8s
       - run: cargo nextest run --workspace --no-fail-fast --features otlp
+      - run: cargo nextest run --workspace --no-fail-fast --all-features
 
   # Catch cross-platform compilation failures before they reach the release pipeline.
   # Mirrors the release.yml publish-binaries matrix (minus Windows — see #42).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,15 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --workspace -- -D warnings
       - run: cargo clippy --workspace --features k8s -- -D warnings
+      - run: cargo clippy --workspace --features otlp -- -D warnings
+      - name: Verify no opentelemetry in default build
+        run: |
+          cargo tree 2>&1 | grep -i opentelemetry && \
+            { echo "ERROR: opentelemetry appeared in default build tree" >&2; exit 1; } || \
+            echo "OK: opentelemetry not present in default build"
       - run: cargo nextest run --workspace --no-fail-fast
       - run: cargo nextest run --workspace --no-fail-fast --features k8s
+      - run: cargo nextest run --workspace --no-fail-fast --features otlp
 
   # Catch cross-platform compilation failures before they reach the release pipeline.
   # Mirrors the release.yml publish-binaries matrix (minus Windows — see #42).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,11 +149,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -141,7 +190,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -152,10 +201,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -478,7 +547,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -604,7 +673,7 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
@@ -619,7 +688,7 @@ checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -637,7 +706,7 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1297,6 +1366,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1404,12 @@ dependencies = [
  "rand_distr",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1425,6 +1525,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1484,7 +1585,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1627,6 +1728,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1818,7 +1929,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
 ]
@@ -1997,6 +2108,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2035,7 +2152,7 @@ version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -2044,6 +2161,7 @@ dependencies = [
  "dirs",
  "git2",
  "hf-hub",
+ "http",
  "k8s-openapi",
  "keyring",
  "kube",
@@ -2051,6 +2169,9 @@ dependencies = [
  "libz-sys",
  "mcp-session",
  "openssl",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "rmcp",
  "secrecy",
@@ -2063,6 +2184,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "ureq 2.12.1",
  "usearch",
@@ -2283,6 +2405,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.6",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2596,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +2686,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pulp"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,7 +2744,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2534,7 +2781,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2562,11 +2809,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2583,12 +2841,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2739,7 +3016,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2760,7 +3039,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3164,7 +3443,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3177,7 +3456,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3237,6 +3516,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3527,7 +3816,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3579,6 +3868,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,7 +3949,7 @@ dependencies = [
  "iri-string",
  "mime",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3670,6 +4009,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -4006,7 +4363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4019,7 +4376,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4341,7 +4698,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4372,7 +4729,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4391,7 +4748,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4531,7 +4888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "typed-path",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1804,9 +1804,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1817,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1965,9 +1965,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ k8s = ["dep:kube", "dep:k8s-openapi"]
 # behind corporate TLS-intercepting proxies whose CA is installed in the
 # system trust store but absent from webpki-roots.
 native-certs = ["reqwest/rustls-tls-native-roots", "dep:ureq"]
+# Enable OpenTelemetry OTLP export for structured tracing. Adds BatchSpanProcessor
+# sending spans to an OTLP-compatible collector (e.g. Jaeger, Grafana Tempo).
+otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 
 [dependencies]
 rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server"] }
@@ -45,6 +48,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 async-trait = "0.1"
 dirs = "6"
 mcp-session = "0.1"
+http = "1"
 
 # Candle direct — pure-Rust BERT inference for embeddings.
 candle-core = "0.10"
@@ -66,6 +70,13 @@ ureq = { version = "2", features = ["native-certs"], optional = true }
 kube = { version = "3.1", default-features = false, features = ["client", "rustls-tls"], optional = true }
 k8s-openapi = { version = "0.27", features = ["v1_31"], optional = true }
 secrecy = "0.10.3"
+
+# OpenTelemetry OTLP export (feature = "otlp"). All four crates must be pinned
+# to compatible minor versions: opentelemetry 0.28 ↔ tracing-opentelemetry 0.29.
+opentelemetry = { version = "0.28", optional = true }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"], optional = true }
+tracing-opentelemetry = { version = "0.29", optional = true }
 
 # Vendor native C libraries so the binary statically links its own copies
 # rather than depending on whatever versions the host OS provides at runtime.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -156,9 +156,15 @@ impl AuthProvider {
 
     /// Resolve the token and return both the raw value and which source provided it.
     fn try_resolve_with_source() -> Result<(SecretString, TokenSource), MemoryError> {
+        let span = tracing::debug_span!("auth.resolve", token_source = tracing::field::Empty,);
+        let _enter = span.entered();
+
         // 1. Environment variable.
+        debug!("auth: trying environment variable");
         if let Ok(tok) = std::env::var(ENV_VAR) {
             if !tok.trim().is_empty() {
+                tracing::Span::current().record("token_source", "env_var");
+                info!(token_source = "env_var", "auth token resolved");
                 return Ok((
                     SecretString::from(tok.trim().to_string()),
                     TokenSource::EnvVar,
@@ -167,6 +173,7 @@ impl AuthProvider {
         }
 
         // 2. Token file.
+        debug!("auth: trying token file");
         if let Some(home) = home_dir() {
             let path = home.join(TOKEN_FILE);
             if path.exists() {
@@ -176,16 +183,23 @@ impl AuthProvider {
                 let raw = std::fs::read_to_string(&path)?;
                 let tok = raw.trim().to_string();
                 if !tok.is_empty() {
+                    tracing::Span::current().record("token_source", "file");
+                    info!(token_source = "file", "auth token resolved");
                     return Ok((SecretString::from(tok), TokenSource::File));
                 }
             }
         }
 
         // 3. System keyring (GNOME Keyring / KWallet / macOS Keychain).
+        debug!("auth: trying system keyring");
         match keyring::Entry::new("memory-mcp", "github-token") {
             Ok(entry) => match entry.get_password() {
                 Ok(tok) if !tok.trim().is_empty() => {
-                    info!("resolved GitHub token from system keyring");
+                    tracing::Span::current().record("token_source", "keyring");
+                    info!(
+                        token_source = "keyring",
+                        "resolved GitHub token from system keyring"
+                    );
                     return Ok((
                         SecretString::from(tok.trim().to_string()),
                         TokenSource::Keyring,
@@ -205,6 +219,7 @@ impl AuthProvider {
             }
         }
 
+        warn!("auth token resolution failed — no token found in env var, file, or keyring");
         Err(MemoryError::Auth(
             "no token available; set MEMORY_MCP_GITHUB_TOKEN, add \
              ~/.config/memory-mcp/token, or store a token in the system keyring \

--- a/src/embedding/candle.rs
+++ b/src/embedding/candle.rs
@@ -82,7 +82,20 @@ impl EmbeddingBackend for CandleEmbeddingEngine {
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
         let arc = Arc::clone(&self.inner);
         let texts = texts.to_vec();
+        let batch_size = texts.len();
+        let dim = self.dim;
+
+        // Capture current span before entering spawn_blocking so the
+        // child thread can enter it and keep the span hierarchy intact.
+        let span = tracing::debug_span!(
+            "embedding.embed",
+            batch_size,
+            dimensions = dim,
+            model = MODEL_ID,
+        );
+
         tokio::task::spawn_blocking(move || {
+            let _enter = span.enter();
             let guard = arc.lock().unwrap_or_else(|poisoned| {
                 tracing::warn!("embedding mutex was poisoned — clearing poison and continuing");
                 poisoned.into_inner()
@@ -122,6 +135,8 @@ impl EmbeddingBackend for CandleEmbeddingEngine {
 /// Use the `warmup` subcommand or a k8s init container to pre-populate the
 /// cache and avoid blocking the first server startup.
 fn load_model_files() -> anyhow::Result<(BertConfig, Tokenizer, PathBuf)> {
+    let _span = tracing::info_span!("embedding.load_model", model = MODEL_ID).entered();
+
     let cache = Cache::from_env();
     let hf_repo = Repo::new(MODEL_ID.to_string(), RepoType::Model);
 
@@ -172,6 +187,8 @@ const MAX_BATCH_SIZE: usize = 64;
 /// Splits the input into chunks of at most [`MAX_BATCH_SIZE`] texts and runs
 /// each chunk through [`embed_chunk`], concatenating the results.
 fn embed_batch(inner: &CandleInner, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+    let _span = tracing::debug_span!("embedding.embed_batch", batch_size = texts.len()).entered();
+
     if texts.is_empty() {
         return Ok(Vec::new());
     }
@@ -191,6 +208,7 @@ fn embed_batch(inner: &CandleInner, texts: &[String]) -> Result<Vec<Vec<f32>>, M
 /// CLS pooling extracts the first token's hidden state, which is then
 /// L2-normalised to produce unit vectors.
 fn embed_chunk(inner: &CandleInner, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+    let _span = tracing::debug_span!("embedding.embed_chunk", chunk_size = texts.len()).entered();
     debug_assert!(!texts.is_empty(), "embed_chunk called with empty texts");
 
     let encodings = inner

--- a/src/index.rs
+++ b/src/index.rs
@@ -202,6 +202,15 @@ impl VectorIndex {
         Ok(())
     }
 
+    /// Return the number of entries currently in the key map.
+    pub(crate) fn key_count(&self) -> usize {
+        let state = self
+            .state
+            .lock()
+            .expect("lock poisoned — prior panic corrupted state");
+        state.key_map.len()
+    }
+
     /// Return the commit SHA stored in the index metadata (if any).
     pub fn commit_sha(&self) -> Option<String> {
         let state = self
@@ -375,6 +384,15 @@ impl ScopedIndex {
         vector: &[f32],
         qualified_name: String,
     ) -> Result<u64, MemoryError> {
+        let dimensions = vector.len();
+        let _span = tracing::debug_span!(
+            "index.add",
+            scope = %scope.dir_prefix(),
+            dimensions,
+            key_count = tracing::field::Empty,
+        )
+        .entered();
+
         // Write lock serialises the full find→insert→remove composite so
         // concurrent upserts for the same name cannot interleave. Reads
         // (via `search`) use a read lock and are not blocked by other reads.
@@ -417,6 +435,9 @@ impl ScopedIndex {
             let _ = self.all.remove(key);
         }
 
+        // Record key_count (all-index size) after insertion.
+        tracing::Span::current().record("key_count", self.all.key_count());
+
         Ok(all_key)
     }
 
@@ -426,6 +447,12 @@ impl ScopedIndex {
     /// Both removals are best-effort: an error in one does not prevent the
     /// other from running. Returns `Ok(())` regardless of individual failures.
     pub fn remove(&self, scope: &Scope, qualified_name: &str) -> Result<(), MemoryError> {
+        let _span = tracing::debug_span!(
+            "index.remove",
+            scope = %scope.dir_prefix(),
+        )
+        .entered();
+
         // Write lock serialises with concurrent adds for the same name.
         let scopes = self.scopes.write().expect("scopes lock poisoned");
 
@@ -470,7 +497,21 @@ impl ScopedIndex {
         query: &[f32],
         limit: usize,
     ) -> Result<Vec<(u64, String, f32)>, MemoryError> {
-        match filter {
+        let dimensions = query.len();
+        let scope_str = match filter {
+            ScopeFilter::GlobalOnly => "global".to_owned(),
+            ScopeFilter::All => "all".to_owned(),
+            ScopeFilter::ProjectAndGlobal(p) => format!("project+global:{p}"),
+        };
+        let span = tracing::debug_span!(
+            "index.search",
+            scope = %scope_str,
+            dimensions,
+            count = tracing::field::Empty,
+        );
+        let _enter = span.entered();
+
+        let results = match filter {
             ScopeFilter::All => self.all.search(query, limit),
 
             ScopeFilter::GlobalOnly => {
@@ -505,7 +546,11 @@ impl ScopedIndex {
                 combined.truncate(limit);
                 Ok(combined)
             }
+        };
+        if let Ok(ref r) = results {
+            tracing::Span::current().record("count", r.len());
         }
+        results
     }
 
     /// Find the key for a given qualified name in the **all-index** (not scope-specific).
@@ -538,6 +583,9 @@ impl ScopedIndex {
     ///   projects/foo/index.usearch
     /// ```
     pub fn save(&self, dir: &Path) -> Result<(), MemoryError> {
+        let _span =
+            tracing::debug_span!("index.save", key_count = tracing::field::Empty,).entered();
+
         std::fs::create_dir_all(dir)?;
 
         // Write a dirty marker — if we crash mid-save, the next load will see
@@ -558,6 +606,10 @@ impl ScopedIndex {
             idx.save(&scope_dir.join("index.usearch"))?;
         }
 
+        // Record total key count (all-index is authoritative — it holds every entry).
+        let key_count = self.all.key_count();
+        tracing::Span::current().record("key_count", key_count);
+
         // Remove marker — save completed successfully.
         let _ = std::fs::remove_file(&marker);
 
@@ -569,6 +621,9 @@ impl ScopedIndex {
     /// Missing subdirectories are treated as empty — those scopes will be
     /// rebuilt incrementally on next use.
     pub fn load(dir: &Path, dimensions: usize) -> Result<Self, MemoryError> {
+        let span = tracing::info_span!("index.load", key_count = tracing::field::Empty,);
+        let _enter = span.entered();
+
         // If a previous save was interrupted, the on-disk state may be
         // inconsistent (some indexes from current state, others from prior).
         // Rather than loading mixed data, start fresh — indexes are a cache
@@ -632,6 +687,9 @@ impl ScopedIndex {
                 }
             }
         }
+
+        let key_count = all.key_count();
+        tracing::Span::current().record("key_count", key_count);
 
         Ok(Self {
             scopes: RwLock::new(scopes),

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,7 @@ async fn main() -> anyhow::Result<()> {
     // The otlp feature also returns the provider for graceful shutdown.
     #[cfg(not(feature = "otlp"))]
     init_tracing();
-    #[cfg(feature = "otlp")]
-    let _otlp_provider: Option<OtlpProvider> = None; // initialised per-command below.
+    // otlp: tracing is initialized per-command arm below.
 
     let cli = Cli::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+// The SdkTracerProvider type is used in the otlp feature only.
+#[cfg(feature = "otlp")]
+use opentelemetry_sdk::trace::SdkTracerProvider as OtlpProvider;
+
 use memory_mcp::auth::{self, AuthProvider, StoreBackend};
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend, MODEL_ID};
 use memory_mcp::index::ScopedIndex;
@@ -119,10 +123,108 @@ struct ServeArgs {
         env = "MEMORY_MCP_SESSION_RATE_WINDOW_SECS"
     )]
     session_rate_window_secs: u64,
+
+    /// If set, OTLP exporter initialisation failures fall back to fmt-only
+    /// logging instead of crashing the process.
+    #[cfg(feature = "otlp")]
+    #[arg(long, default_value_t = false, env = "MEMORY_MCP_OTLP_OPTIONAL")]
+    otlp_optional: bool,
 }
 
 #[derive(Args)]
 struct WarmupArgs {}
+
+// ---------------------------------------------------------------------------
+// Tracing initialisation
+// ---------------------------------------------------------------------------
+
+/// Initialise the global tracing subscriber.
+///
+/// Default build: Registry + EnvFilter (`memory_mcp=info` default) + fmt(stderr).
+/// `otlp` feature: same + OpenTelemetry layer with BatchSpanProcessor.
+///
+/// Returns the OTLP tracer provider when the `otlp` feature is enabled, so the
+/// caller can call `provider.shutdown()` after the server exits.
+#[cfg(not(feature = "otlp"))]
+fn init_tracing() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "memory_mcp=info,warn".to_string().into()),
+        )
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+}
+
+/// Initialise fmt-only tracing (no OTLP). Used for non-serve commands
+/// (`warmup`, `auth`) when the `otlp` feature is enabled but OTLP is only
+/// meaningful for the long-running server process.
+#[cfg(feature = "otlp")]
+fn init_tracing_fmt_only() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "memory_mcp=info,warn".to_string().into()),
+        )
+        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
+        .init();
+}
+
+#[cfg(feature = "otlp")]
+fn init_tracing(otlp_optional: bool) -> Option<OtlpProvider> {
+    use opentelemetry_otlp::SpanExporter;
+    use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
+    use tracing_opentelemetry::OpenTelemetryLayer;
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "memory_mcp=info,warn".to_string().into());
+
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+
+    // Attempt to build the OTLP exporter (gRPC via tonic).
+    let otlp_result = SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .map(|exporter| {
+            let batch = BatchSpanProcessor::builder(exporter).build();
+            SdkTracerProvider::builder()
+                .with_span_processor(batch)
+                .build()
+        });
+
+    match otlp_result {
+        Ok(provider) => {
+            let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "memory-mcp");
+            let otel_layer = OpenTelemetryLayer::new(tracer);
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(fmt_layer)
+                .with(otel_layer)
+                .init();
+            Some(provider)
+        }
+        Err(e) => {
+            if otlp_optional {
+                // Fall back to fmt-only; warn after subscriber is set up.
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(fmt_layer)
+                    .init();
+                tracing::warn!(
+                    error = %e,
+                    "OTLP exporter init failed — continuing with fmt-only tracing (--otlp-optional is set)"
+                );
+                None
+            } else {
+                eprintln!(
+                    "error: OTLP exporter init failed: {e}\n\
+                     Hint: pass --otlp-optional to fall back to fmt-only logging."
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Main
@@ -144,13 +246,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Tracing goes to stderr only — stdout must remain clean for MCP.
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info".to_string().into()),
-        )
-        .with(tracing_subscriber::fmt::layer().with_writer(std::io::stderr))
-        .init();
+    // The otlp feature also returns the provider for graceful shutdown.
+    #[cfg(not(feature = "otlp"))]
+    init_tracing();
+    #[cfg(feature = "otlp")]
+    let _otlp_provider: Option<OtlpProvider> = None; // initialised per-command below.
 
     let cli = Cli::parse();
 
@@ -159,36 +259,62 @@ async fn main() -> anyhow::Result<()> {
             // Re-parse as "memory-mcp serve" so clap's env var resolution runs.
             let cli = Cli::parse_from(["memory-mcp", "serve"]);
             match cli.command {
-                Some(Command::Serve(args)) => run_serve(args).await?,
+                Some(Command::Serve(args)) => {
+                    #[cfg(feature = "otlp")]
+                    let _otlp_provider = init_tracing(args.otlp_optional);
+                    let result = run_serve(args).await;
+                    #[cfg(feature = "otlp")]
+                    if let Some(provider) = _otlp_provider {
+                        let _ = provider.shutdown();
+                    }
+                    result?;
+                }
                 _ => unreachable!(),
             }
         }
-        Some(Command::Serve(args)) => run_serve(args).await?,
-        Some(Command::Warmup(args)) => run_warmup(args).await?,
-        Some(Command::Auth(auth_cmd)) => match auth_cmd.action {
-            AuthAction::Login(login_args) => {
-                #[cfg(feature = "k8s")]
-                let k8s_config = if matches!(login_args.store, Some(StoreBackend::K8sSecret)) {
-                    Some(auth::K8sSecretConfig {
-                        namespace: login_args.k8s_namespace.clone(),
-                        secret_name: login_args.k8s_secret_name.clone(),
-                    })
-                } else {
-                    None
-                };
-                auth::device_flow_login(
-                    login_args.store,
+        Some(Command::Serve(args)) => {
+            #[cfg(feature = "otlp")]
+            let _otlp_provider = init_tracing(args.otlp_optional);
+            let result = run_serve(args).await;
+            #[cfg(feature = "otlp")]
+            if let Some(provider) = _otlp_provider {
+                let _ = provider.shutdown();
+            }
+            result?;
+        }
+        Some(Command::Warmup(args)) => {
+            #[cfg(feature = "otlp")]
+            init_tracing_fmt_only();
+            run_warmup(args).await?;
+        }
+        Some(Command::Auth(auth_cmd)) => {
+            #[cfg(feature = "otlp")]
+            init_tracing_fmt_only();
+            match auth_cmd.action {
+                AuthAction::Login(login_args) => {
                     #[cfg(feature = "k8s")]
-                    k8s_config,
-                )
-                .await
-                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                    let k8s_config = if matches!(login_args.store, Some(StoreBackend::K8sSecret)) {
+                        Some(auth::K8sSecretConfig {
+                            namespace: login_args.k8s_namespace.clone(),
+                            secret_name: login_args.k8s_secret_name.clone(),
+                        })
+                    } else {
+                        None
+                    };
+                    auth::device_flow_login(
+                        login_args.store,
+                        #[cfg(feature = "k8s")]
+                        k8s_config,
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                }
+                AuthAction::Status => {
+                    let provider = AuthProvider::default();
+                    auth::print_auth_status(&provider);
+                }
             }
-            AuthAction::Status => {
-                let provider = AuthProvider::default();
-                auth::print_auth_status(&provider);
-            }
-        },
+        }
     }
 
     Ok(())
@@ -211,7 +337,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Filter out empty string to treat MEMORY_MCP_REMOTE_URL="" as unset.
     let remote_url = args.remote_url.filter(|u| !u.is_empty());
 
-    // Initialise subsystems.
+    // Initialise subsystems — each called function creates its own span.
     let repo = MemoryRepo::init_or_open(&repo_path, remote_url.as_deref())
         .with_context(|| format!("failed to open/init repo at {}", repo_path.display()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,14 @@ struct ServeArgs {
     )]
     session_rate_window_secs: u64,
 
-    /// If set, OTLP exporter initialisation failures fall back to fmt-only
-    /// logging instead of crashing the process.
+    /// Enable OTLP span export. The server will crash on startup if the
+    /// collector is unreachable. Use --otlp-optional for graceful fallback.
+    #[cfg(feature = "otlp")]
+    #[arg(long, default_value_t = false, env = "MEMORY_MCP_OTLP_REQUIRED")]
+    otlp_required: bool,
+
+    /// Enable OTLP span export with graceful fallback: if the collector is
+    /// unreachable, log a warning and continue with fmt-only tracing.
     #[cfg(feature = "otlp")]
     #[arg(long, default_value_t = false, env = "MEMORY_MCP_OTLP_OPTIONAL")]
     otlp_optional: bool,
@@ -170,8 +176,16 @@ fn init_tracing_fmt_only() {
         .init();
 }
 
+/// Initialise tracing for the serve command. If `--otlp-required` or
+/// `--otlp-optional` is set, activates OTLP export. Otherwise uses fmt-only
+/// (passive — the feature is compiled in but not activated).
 #[cfg(feature = "otlp")]
-fn init_tracing(otlp_optional: bool) -> Option<OtlpProvider> {
+fn init_tracing_for_serve(args: &ServeArgs) -> Option<OtlpProvider> {
+    if !args.otlp_required && !args.otlp_optional {
+        init_tracing_fmt_only();
+        return None;
+    }
+
     use opentelemetry_otlp::SpanExporter;
     use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
     use tracing_opentelemetry::OpenTelemetryLayer;
@@ -181,7 +195,6 @@ fn init_tracing(otlp_optional: bool) -> Option<OtlpProvider> {
 
     let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
 
-    // Attempt to build the OTLP exporter (gRPC via tonic).
     let otlp_result = SpanExporter::builder()
         .with_tonic()
         .build()
@@ -204,8 +217,7 @@ fn init_tracing(otlp_optional: bool) -> Option<OtlpProvider> {
             Some(provider)
         }
         Err(e) => {
-            if otlp_optional {
-                // Fall back to fmt-only; warn after subscriber is set up.
+            if args.otlp_optional {
                 tracing_subscriber::registry()
                     .with(filter)
                     .with(fmt_layer)
@@ -246,10 +258,10 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Tracing goes to stderr only — stdout must remain clean for MCP.
-    // The otlp feature also returns the provider for graceful shutdown.
     #[cfg(not(feature = "otlp"))]
     init_tracing();
-    // otlp: tracing is initialized per-command arm below.
+    // otlp: tracing is initialized per-command arm below (serve may activate
+    // OTLP export; other commands always use fmt-only).
 
     let cli = Cli::parse();
 
@@ -260,7 +272,7 @@ async fn main() -> anyhow::Result<()> {
             match cli.command {
                 Some(Command::Serve(args)) => {
                     #[cfg(feature = "otlp")]
-                    let _otlp_provider = init_tracing(args.otlp_optional);
+                    let _otlp_provider = init_tracing_for_serve(&args);
                     let result = run_serve(args).await;
                     #[cfg(feature = "otlp")]
                     if let Some(provider) = _otlp_provider {
@@ -273,7 +285,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Command::Serve(args)) => {
             #[cfg(feature = "otlp")]
-            let _otlp_provider = init_tracing(args.otlp_optional);
+            let _otlp_provider = init_tracing_for_serve(&args);
             let result = run_serve(args).await;
             #[cfg(feature = "otlp")]
             if let Some(provider) = _otlp_provider {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use git2::{build::CheckoutBuilder, ErrorCode, MergeOptions, Repository, Signature};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use secrecy::{ExposeSecret, SecretString};
 
@@ -122,6 +122,8 @@ impl MemoryRepo {
     /// If `remote_url` is provided, ensures an `origin` remote exists pointing
     /// at that URL (creating or updating it as necessary).
     pub fn init_or_open(path: &Path, remote_url: Option<&str>) -> Result<Self, MemoryError> {
+        let _span = tracing::info_span!("repo.init").entered();
+
         let repo = if path.join(".git").exists() {
             Repository::open(path)?
         } else {
@@ -200,7 +202,13 @@ impl MemoryRepo {
 
         let arc = Arc::clone(self);
         let memory = memory.clone();
+        let name = memory.name.clone();
+
+        // Capture span before entering spawn_blocking so the child thread can record oid.
+        let span = tracing::debug_span!("repo.save", name = %name, oid = tracing::field::Empty);
+
         tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+            let _enter = span.entered();
             let repo = arc
                 .inner
                 .lock()
@@ -219,6 +227,15 @@ impl MemoryRepo {
                 &file_path,
                 &format!("chore: save memory '{}'", memory.name),
             )?;
+
+            // Record the new HEAD OID after commit.
+            if let Ok(head) = repo.head() {
+                if let Ok(commit) = head.peel_to_commit() {
+                    tracing::Span::current().record("oid", commit.id().to_string().as_str());
+                    debug!(oid = %commit.id(), "memory saved to repo");
+                }
+            }
+
             Ok(())
         })
         .await
@@ -242,7 +259,9 @@ impl MemoryRepo {
         let arc = Arc::clone(self);
         let name = name.to_string();
         let file_path_clone = file_path.clone();
+        let span = tracing::debug_span!("repo.delete", name = %name);
         tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+            let _enter = span.entered();
             let repo = arc
                 .inner
                 .lock()
@@ -314,7 +333,9 @@ impl MemoryRepo {
 
         let arc = Arc::clone(self);
         let name = name.to_string();
+        let span = tracing::debug_span!("repo.read", name = %name);
         tokio::task::spawn_blocking(move || -> Result<Memory, MemoryError> {
+            let _enter = span.entered();
             // Check existence/symlink status before opening.
             match std::fs::symlink_metadata(&file_path) {
                 Err(_) => return Err(MemoryError::NotFound { name }),
@@ -342,8 +363,10 @@ impl MemoryRepo {
     ) -> Result<Vec<Memory>, MemoryError> {
         let root = self.root.clone();
         let scope_clone = scope.cloned();
+        let span = tracing::debug_span!("repo.list", file_count = tracing::field::Empty,);
 
         tokio::task::spawn_blocking(move || -> Result<Vec<Memory>, MemoryError> {
+            let _enter = span.entered();
             let dirs: Vec<PathBuf> = match scope_clone.as_ref() {
                 Some(s) => vec![root.join(s.dir_prefix())],
                 None => {
@@ -402,6 +425,8 @@ impl MemoryRepo {
                 collect_md_files(&dir, &mut memories)?;
             }
 
+            tracing::Span::current().record("file_count", memories.len());
+
             Ok(memories)
         })
         .await
@@ -423,8 +448,10 @@ impl MemoryRepo {
         let token_result = auth.resolve_token();
         let arc = Arc::clone(self);
         let branch = branch.to_string();
+        let span = tracing::debug_span!("repo.push", branch = %branch);
 
         tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+            let _enter = span.entered();
             let repo = arc
                 .inner
                 .lock()
@@ -565,8 +592,10 @@ impl MemoryRepo {
         let token_result = auth.resolve_token();
         let arc = Arc::clone(self);
         let branch = branch.to_string();
+        let span = tracing::debug_span!("repo.pull", branch = %branch);
 
         tokio::task::spawn_blocking(move || -> Result<PullResult, MemoryError> {
+            let _enter = span.entered();
             let repo = arc
                 .inner
                 .lock()

--- a/src/server.rs
+++ b/src/server.rs
@@ -15,12 +15,18 @@ use tracing::{info, warn, Instrument};
 /// Extract the `Mcp-Session-Id` header from HTTP request parts.
 ///
 /// Returns `"unknown"` if the header is absent or not valid UTF-8.
-fn extract_session_id(parts: &http::request::Parts) -> &str {
-    parts
+/// Truncates to 128 chars to bound span field size from untrusted input.
+fn extract_session_id(parts: &http::request::Parts) -> String {
+    let raw = parts
         .headers
         .get("mcp-session-id")
         .and_then(|v: &http::HeaderValue| v.to_str().ok())
-        .unwrap_or("unknown")
+        .unwrap_or("unknown");
+    if raw.len() > 128 {
+        format!("{}…", &raw[..128])
+    } else {
+        raw.to_owned()
+    }
 }
 
 use crate::{
@@ -231,7 +237,7 @@ impl MemoryServer {
                 ),
             }));
         }
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let content_size = args.content.len();
         let span = tracing::info_span!(
             "handler.remember",
@@ -304,7 +310,7 @@ impl MemoryServer {
         Parameters(args): Parameters<RecallArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         // Note: query text is intentionally omitted from the span (R-17 privacy decision).
         let span = tracing::info_span!(
             "handler.recall",
@@ -426,7 +432,7 @@ impl MemoryServer {
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.forget",
             session_id = %session_id,
@@ -497,7 +503,7 @@ impl MemoryServer {
                 }));
             }
         }
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let content_size = args.content.as_ref().map(|c| c.len()).unwrap_or(0);
         let span = tracing::info_span!(
             "handler.edit",
@@ -590,7 +596,7 @@ impl MemoryServer {
         Parameters(args): Parameters<ListArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.list",
             session_id = %session_id,
@@ -674,7 +680,7 @@ impl MemoryServer {
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.read",
             session_id = %session_id,
@@ -731,7 +737,7 @@ impl MemoryServer {
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         let pull_first = args.pull_first.unwrap_or(true);
-        let session_id = extract_session_id(&parts).to_owned();
+        let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.sync",
             session_id = %session_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,7 +23,8 @@ fn extract_session_id(parts: &http::request::Parts) -> String {
         .and_then(|v: &http::HeaderValue| v.to_str().ok())
         .unwrap_or("unknown");
     if raw.len() > 128 {
-        format!("{}…", &raw[..128])
+        let truncated: String = raw.chars().take(128).collect();
+        format!("{truncated}…")
     } else {
         raw.to_owned()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,11 +6,22 @@ const SNIPPET_MAX_CHARS: usize = 500;
 
 use chrono::Utc;
 use rmcp::{
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    handler::server::{router::tool::ToolRouter, tool::Extension, wrapper::Parameters},
     model::{ErrorData, ServerCapabilities, ServerInfo},
     tool, tool_handler, tool_router, ServerHandler,
 };
 use tracing::{info, warn, Instrument};
+
+/// Extract the `Mcp-Session-Id` header from HTTP request parts.
+///
+/// Returns `"unknown"` if the header is absent or not valid UTF-8.
+fn extract_session_id(parts: &http::request::Parts) -> &str {
+    parts
+        .headers
+        .get("mcp-session-id")
+        .and_then(|v: &http::HeaderValue| v.to_str().ok())
+        .unwrap_or("unknown")
+}
 
 use crate::{
     embedding::EmbeddingBackend,
@@ -208,6 +219,7 @@ impl MemoryServer {
     async fn remember(
         &self,
         Parameters(args): Parameters<RememberArgs>,
+        Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
         if args.content.len() > MAX_CONTENT_SIZE {
@@ -219,10 +231,14 @@ impl MemoryServer {
                 ),
             }));
         }
+        let session_id = extract_session_id(&parts).to_owned();
+        let content_size = args.content.len();
         let span = tracing::info_span!(
-            "remember",
+            "handler.remember",
+            session_id = %session_id,
             name = %args.name,
             scope = ?args.scope,
+            content_size,
         );
         let state = Arc::clone(&self.state);
         async move {
@@ -283,12 +299,19 @@ impl MemoryServer {
         Scope: pass 'project:<basename-of-your-cwd>' to search your current project + global memories, \
         'global' for global-only, or 'all' to search everything. Omitting scope defaults to global-only."
     )]
-    async fn recall(&self, Parameters(args): Parameters<RecallArgs>) -> Result<String, ErrorData> {
+    async fn recall(
+        &self,
+        Parameters(args): Parameters<RecallArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
+        let session_id = extract_session_id(&parts).to_owned();
+        // Note: query text is intentionally omitted from the span (R-17 privacy decision).
         let span = tracing::info_span!(
-            "recall",
-            query = %args.query,
+            "handler.recall",
+            session_id = %session_id,
             scope = ?args.scope,
             limit = ?args.limit,
+            count = tracing::field::Empty,
         );
         let state = Arc::clone(&self.state);
         async move {
@@ -368,14 +391,13 @@ impl MemoryServer {
                 }));
             }
 
-            info!(
-                returned = results_vec.len(),
-                skipped_errors, "recall complete"
-            );
+            let count = results_vec.len();
+            tracing::Span::current().record("count", count);
+            info!(returned = count, skipped_errors, "recall complete");
 
             Ok(serde_json::json!({
                 "results": results_vec,
-                "count": results_vec.len(),
+                "count": count,
                 "limit": limit,
                 "pre_filter_count": pre_filter_count,
                 "skipped_errors": skipped_errors,
@@ -398,10 +420,16 @@ impl MemoryServer {
         memories or omit for global. Removes the file from git and the vector from the search index. \
         Returns 'ok' on success."
     )]
-    async fn forget(&self, Parameters(args): Parameters<ForgetArgs>) -> Result<String, ErrorData> {
+    async fn forget(
+        &self,
+        Parameters(args): Parameters<ForgetArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
+        let session_id = extract_session_id(&parts).to_owned();
         let span = tracing::info_span!(
-            "forget",
+            "handler.forget",
+            session_id = %session_id,
             name = %args.name,
             scope = ?args.scope,
         );
@@ -452,7 +480,11 @@ impl MemoryServer {
         IMPORTANT: Never store credentials, API keys, tokens, passwords, or other secrets — \
         memories are plaintext files in a git repo and may be synced to a remote."
     )]
-    async fn edit(&self, Parameters(args): Parameters<EditArgs>) -> Result<String, ErrorData> {
+    async fn edit(
+        &self,
+        Parameters(args): Parameters<EditArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
         if let Some(ref content) = args.content {
             if content.len() > MAX_CONTENT_SIZE {
@@ -465,10 +497,14 @@ impl MemoryServer {
                 }));
             }
         }
+        let session_id = extract_session_id(&parts).to_owned();
+        let content_size = args.content.as_ref().map(|c| c.len()).unwrap_or(0);
         let span = tracing::info_span!(
-            "edit",
+            "handler.edit",
+            session_id = %session_id,
             name = %args.name,
             scope = ?args.scope,
+            content_size,
         );
         let state = Arc::clone(&self.state);
         async move {
@@ -549,8 +585,18 @@ impl MemoryServer {
         'global' for global-only, or 'all' for everything. Omitting scope defaults to global-only. \
         Returns a JSON array of memory summaries without full content."
     )]
-    async fn list(&self, Parameters(args): Parameters<ListArgs>) -> Result<String, ErrorData> {
-        let span = tracing::info_span!("list", scope = ?args.scope);
+    async fn list(
+        &self,
+        Parameters(args): Parameters<ListArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
+        let session_id = extract_session_id(&parts).to_owned();
+        let span = tracing::info_span!(
+            "handler.list",
+            session_id = %session_id,
+            scope = ?args.scope,
+            count = tracing::field::Empty,
+        );
         let state = Arc::clone(&self.state);
         async move {
             let scope_filter =
@@ -584,11 +630,9 @@ impl MemoryServer {
                     global
                 }
             };
-            info!(
-                ms = start.elapsed().as_millis(),
-                count = memories.len(),
-                "listed memories"
-            );
+            let count = memories.len();
+            tracing::Span::current().record("count", count);
+            info!(ms = start.elapsed().as_millis(), count, "listed memories");
 
             let summaries: Vec<serde_json::Value> = memories
                 .into_iter()
@@ -606,7 +650,7 @@ impl MemoryServer {
 
             Ok(serde_json::json!({
                 "memories": summaries,
-                "count": summaries.len(),
+                "count": count,
             })
             .to_string())
         }
@@ -624,9 +668,19 @@ impl MemoryServer {
         project-scoped memories or omit for global. Returns the full markdown content and metadata \
         (id, scope, tags, timestamps) as a JSON object."
     )]
-    async fn read(&self, Parameters(args): Parameters<ReadArgs>) -> Result<String, ErrorData> {
+    async fn read(
+        &self,
+        Parameters(args): Parameters<ReadArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
-        let span = tracing::info_span!("read", name = %args.name, scope = ?args.scope);
+        let session_id = extract_session_id(&parts).to_owned();
+        let span = tracing::info_span!(
+            "handler.read",
+            session_id = %session_id,
+            name = %args.name,
+            scope = ?args.scope,
+        );
         let state = Arc::clone(&self.state);
         async move {
             let scope = parse_scope(args.scope.as_deref()).map_err(ErrorData::from)?;
@@ -671,9 +725,18 @@ impl MemoryServer {
         description = "Sync the memory repo with the git remote (push/pull). Requires \
         MEMORY_MCP_GITHUB_TOKEN or a token file. Returns a status message."
     )]
-    async fn sync(&self, Parameters(args): Parameters<SyncArgs>) -> Result<String, ErrorData> {
+    async fn sync(
+        &self,
+        Parameters(args): Parameters<SyncArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
         let pull_first = args.pull_first.unwrap_or(true);
-        let span = tracing::info_span!("sync", pull_first);
+        let session_id = extract_session_id(&parts).to_owned();
+        let span = tracing::info_span!(
+            "handler.sync",
+            session_id = %session_id,
+            pull_first,
+        );
         let state = Arc::clone(&self.state);
         async move {
             let start = Instant::now();
@@ -730,6 +793,7 @@ impl MemoryServer {
                             &state.index,
                             &changes,
                         )
+                        .instrument(tracing::info_span!("server.incremental_reindex"))
                         .await;
                         info!(
                             added = stats.added,

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -134,10 +134,12 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
                 }
                 // Update the corresponding SpanRecord in the store.
                 let span_name = span.name().to_string();
-                let updated_kv = kv.clone();
                 drop(ext);
                 let mut store = self.store.lock().unwrap();
                 // Find the last span with this name and update its fields.
+                // Note: name-based lookup means multi-call tests for the same
+                // operation will update the wrong SpanRecord. Sufficient for
+                // current tests (one call per operation per with_capturing scope).
                 if let Some(rec) = store.spans.iter_mut().rev().find(|s| s.name == span_name) {
                     for (new_key, new_val) in &new_kv {
                         if let Some(existing) = rec.fields.iter_mut().find(|(k, _)| k == new_key) {
@@ -146,7 +148,6 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
                             rec.fields.push((new_key.clone(), new_val.clone()));
                         }
                     }
-                    let _ = updated_kv; // suppress unused warning
                 }
             }
         }
@@ -579,11 +580,18 @@ fn repo_init_url_is_redacted_in_logs() {
 fn auth_failure_produces_warn_event() {
     use memory_mcp::auth::AuthProvider;
 
+    // Override HOME to an empty temp directory so resolve_token cannot
+    // find ~/.config/memory-mcp/token (which may exist on dev machines).
+    let fake_home = tempfile::tempdir().expect("tempdir for fake HOME");
     let (_, store) = with_capturing(|| {
-        // Clear env var so resolution must fall back to keyring / fail.
         std::env::remove_var("MEMORY_MCP_GITHUB_TOKEN");
-        let provider = AuthProvider::new(); // may or may not have keyring
-        let _ = provider.resolve_token(); // keyring absent in CI → warn
+        std::env::set_var("HOME", fake_home.path());
+        let provider = AuthProvider::new();
+        let _ = provider.resolve_token(); // no env, no file, no keyring → warn
+                                          // Restore HOME so other tests are unaffected.
+        if let Some(real_home) = dirs::home_dir() {
+            std::env::set_var("HOME", real_home);
+        }
     });
     let store = store.lock().unwrap();
 

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -1,0 +1,784 @@
+//! Tracing scaffold integration tests.
+//!
+//! These tests verify:
+//! - TC-01/TC-02: Span names follow the `module.operation` pattern.
+//! - TC-04:       Span field names are from the canonical allowlist.
+//! - TC-06–TC-09: Subsystem spans carry the correct fields.
+//! - TC-16–TC-18: No sensitive data (tokens, content text, raw URLs) in spans.
+//! - TC-20:       Default filter passes handler info spans, suppresses debug spans.
+//! - TC-21:       Auth failure produces a warn-level event.
+//!
+//! The in-memory subscriber collects span/event metadata so we can assert on
+//! it without touching real networking or the file system (where possible).
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use tracing::{subscriber::with_default, Subscriber};
+use tracing_subscriber::{
+    layer::{Context, Layer, SubscriberExt},
+    Registry,
+};
+
+// ---------------------------------------------------------------------------
+// In-memory span / event record
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct SpanRecord {
+    /// Span name.
+    name: String,
+    /// tracing::Level (used by TC-20 to filter debug spans)
+    #[allow(dead_code)]
+    level: tracing::Level,
+    /// Field key-value pairs present on the span (key, value as Display string).
+    fields: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+struct EventRecord {
+    /// Message / event target.
+    message: String,
+    level: tracing::Level,
+    /// Key=value fields as strings (values are formatted via Display).
+    fields: Vec<(String, String)>,
+}
+
+#[derive(Default)]
+struct RecordStore {
+    spans: Vec<SpanRecord>,
+    events: Vec<EventRecord>,
+}
+
+/// A `tracing_subscriber::Layer` that records spans and events.
+struct CapturingLayer {
+    store: Arc<Mutex<RecordStore>>,
+}
+
+/// Visitor that collects field (name, value) pairs from spans.
+struct KvVisitor(Vec<(String, String)>);
+
+impl tracing::field::Visit for KvVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, val: &dyn std::fmt::Debug) {
+        self.0.push((field.name().to_string(), format!("{val:?}")));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, val: &str) {
+        self.0.push((field.name().to_string(), val.to_string()));
+    }
+    fn record_i64(&mut self, field: &tracing::field::Field, val: i64) {
+        self.0.push((field.name().to_string(), val.to_string()));
+    }
+    fn record_u64(&mut self, field: &tracing::field::Field, val: u64) {
+        self.0.push((field.name().to_string(), val.to_string()));
+    }
+    fn record_bool(&mut self, field: &tracing::field::Field, val: bool) {
+        self.0.push((field.name().to_string(), val.to_string()));
+    }
+}
+
+impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer<S>
+    for CapturingLayer
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let mut visitor = KvVisitor(Vec::new());
+        attrs.record(&mut visitor);
+        let mut kv = visitor.0;
+
+        // Also capture field names that are declared Empty (no value yet).
+        for field in attrs.fields() {
+            let n = field.name().to_string();
+            if !kv.iter().any(|(k, _)| k == &n) {
+                kv.push((n, String::new()));
+            }
+        }
+
+        let record = SpanRecord {
+            name: attrs.metadata().name().to_string(),
+            level: *attrs.metadata().level(),
+            fields: kv.clone(),
+        };
+        self.store.lock().unwrap().spans.push(record);
+
+        // Store the kv pairs as span extensions so on_record can update them.
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(kv);
+        }
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        ctx: Context<'_, S>,
+    ) {
+        let mut visitor = KvVisitor(Vec::new());
+        values.record(&mut visitor);
+        let new_kv = visitor.0;
+
+        if let Some(span) = ctx.span(id) {
+            let mut ext = span.extensions_mut();
+            if let Some(kv) = ext.get_mut::<Vec<(String, String)>>() {
+                for (new_key, new_val) in &new_kv {
+                    if let Some(existing) = kv.iter_mut().find(|(k, _)| k == new_key) {
+                        existing.1 = new_val.clone();
+                    } else {
+                        kv.push((new_key.clone(), new_val.clone()));
+                    }
+                }
+                // Update the corresponding SpanRecord in the store.
+                let span_name = span.name().to_string();
+                let updated_kv = kv.clone();
+                drop(ext);
+                let mut store = self.store.lock().unwrap();
+                // Find the last span with this name and update its fields.
+                if let Some(rec) = store.spans.iter_mut().rev().find(|s| s.name == span_name) {
+                    for (new_key, new_val) in &new_kv {
+                        if let Some(existing) = rec.fields.iter_mut().find(|(k, _)| k == new_key) {
+                            existing.1 = new_val.clone();
+                        } else {
+                            rec.fields.push((new_key.clone(), new_val.clone()));
+                        }
+                    }
+                    let _ = updated_kv; // suppress unused warning
+                }
+            }
+        }
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut kv: Vec<(String, String)> = Vec::new();
+        let mut message = String::new();
+
+        struct EventVisitor<'a> {
+            kv: &'a mut Vec<(String, String)>,
+            message: &'a mut String,
+        }
+        impl<'a> tracing::field::Visit for EventVisitor<'a> {
+            fn record_debug(&mut self, field: &tracing::field::Field, val: &dyn std::fmt::Debug) {
+                let s = format!("{val:?}");
+                if field.name() == "message" {
+                    *self.message = s;
+                } else {
+                    self.kv.push((field.name().to_string(), s));
+                }
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, val: &str) {
+                if field.name() == "message" {
+                    *self.message = val.to_string();
+                } else {
+                    self.kv.push((field.name().to_string(), val.to_string()));
+                }
+            }
+            fn record_i64(&mut self, field: &tracing::field::Field, val: i64) {
+                self.kv.push((field.name().to_string(), val.to_string()));
+            }
+            fn record_u64(&mut self, field: &tracing::field::Field, val: u64) {
+                self.kv.push((field.name().to_string(), val.to_string()));
+            }
+            fn record_bool(&mut self, field: &tracing::field::Field, val: bool) {
+                self.kv.push((field.name().to_string(), val.to_string()));
+            }
+        }
+
+        event.record(&mut EventVisitor {
+            kv: &mut kv,
+            message: &mut message,
+        });
+
+        self.store.lock().unwrap().events.push(EventRecord {
+            message,
+            level: *event.metadata().level(),
+            fields: kv,
+        });
+    }
+}
+
+/// Build a subscriber with the capturing layer installed and run `f` inside it.
+fn with_capturing<F, R>(f: F) -> (R, Arc<Mutex<RecordStore>>)
+where
+    F: FnOnce() -> R,
+{
+    let store = Arc::new(Mutex::new(RecordStore::default()));
+    let layer = CapturingLayer {
+        store: Arc::clone(&store),
+    };
+    let subscriber = Registry::default().with(layer);
+    let result = with_default(subscriber, f);
+    (result, store)
+}
+
+// ---------------------------------------------------------------------------
+// Canonical field allowlist (TC-04)
+// ---------------------------------------------------------------------------
+
+fn canonical_fields() -> HashSet<&'static str> {
+    [
+        "session_id",
+        "name",
+        "scope",
+        "content_size",
+        "batch_size",
+        "chunk_size",
+        "dimensions",
+        "model",
+        "count",
+        "key_count",
+        "branch",
+        "file_count",
+        "oid",
+        "token_source",
+        "duration_ms",
+        // These are tracing internal / log fields we allow through:
+        "message",
+        "error",
+        "pull_first",
+        "limit",
+        // tracing instrumentation fields
+        "log.target",
+        "log.module_path",
+        "log.file",
+        "log.line",
+    ]
+    .into_iter()
+    .collect()
+}
+
+// ---------------------------------------------------------------------------
+// TC-01/TC-02: Span names follow `module.operation` pattern
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_add_span_has_correct_name() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc01-test".to_string());
+    });
+    let spans = store.lock().unwrap();
+    let names: Vec<&str> = spans.spans.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"index.add"),
+        "expected 'index.add' span, got: {names:?}"
+    );
+}
+
+#[test]
+fn index_remove_span_has_correct_name() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc01-remove".to_string());
+        let _ = idx.remove(&Scope::Global, "global/tc01-remove");
+    });
+    let spans = store.lock().unwrap();
+    let names: Vec<&str> = spans.spans.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"index.remove"),
+        "expected 'index.remove' span, got: {names:?}"
+    );
+}
+
+#[test]
+fn index_search_span_has_correct_name() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::{Scope, ScopeFilter};
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc01-search".to_string());
+        let _ = idx.search(&ScopeFilter::GlobalOnly, &v, 5);
+    });
+    let spans = store.lock().unwrap();
+    let names: Vec<&str> = spans.spans.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"index.search"),
+        "expected 'index.search' span, got: {names:?}"
+    );
+}
+
+#[test]
+fn index_save_load_spans_have_correct_names() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc01-save".to_string());
+        let _ = idx.save(dir.path());
+        let _ = ScopedIndex::load(dir.path(), 4);
+    });
+    let spans = store.lock().unwrap();
+    let names: Vec<&str> = spans.spans.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"index.save"),
+        "expected 'index.save' span, got: {names:?}"
+    );
+    assert!(
+        names.contains(&"index.load"),
+        "expected 'index.load' span, got: {names:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-04: Fields on index spans are in canonical allowlist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_spans_only_use_canonical_fields() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::{Scope, ScopeFilter};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let allowed = canonical_fields();
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc04-test".to_string());
+        let _ = idx.remove(&Scope::Global, "global/tc04-test");
+        let _ = idx.search(&ScopeFilter::All, &v, 5);
+        let _ = idx.save(dir.path());
+        let _ = ScopedIndex::load(dir.path(), 4);
+    });
+    let spans = store.lock().unwrap();
+    // Only check index.* spans.
+    let index_spans: Vec<&SpanRecord> = spans
+        .spans
+        .iter()
+        .filter(|s| s.name.starts_with("index."))
+        .collect();
+    assert!(
+        !index_spans.is_empty(),
+        "expected at least one index.* span"
+    );
+    for span in &index_spans {
+        for (field_name, _) in &span.fields {
+            assert!(
+                allowed.contains(field_name.as_str()),
+                "span '{}' has field '{}' not in canonical allowlist",
+                span.name,
+                field_name
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TC-06: index.add carries scope, key_count, dimensions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_add_span_has_scope_and_dimensions_fields() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(8).expect("create index");
+        let v = vec![0.0_f32; 8];
+        let _ = idx.add(&Scope::Global, &v, "global/tc06-test".to_string());
+    });
+    let spans = store.lock().unwrap();
+    let add_span = spans
+        .spans
+        .iter()
+        .find(|s| s.name == "index.add")
+        .expect("index.add span not found");
+
+    assert!(
+        add_span.fields.iter().any(|(k, _)| k == "scope"),
+        "index.add missing 'scope' field"
+    );
+    assert!(
+        add_span.fields.iter().any(|(k, _)| k == "dimensions"),
+        "index.add missing 'dimensions' field"
+    );
+    assert!(
+        add_span.fields.iter().any(|(k, _)| k == "key_count"),
+        "index.add missing 'key_count' field"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-07: index.search carries scope, count, dimensions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_search_span_has_required_fields() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::{Scope, ScopeFilter};
+
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc07".to_string());
+        let _ = idx.search(&ScopeFilter::GlobalOnly, &v, 5);
+    });
+    let spans = store.lock().unwrap();
+    let search_span = spans
+        .spans
+        .iter()
+        .find(|s| s.name == "index.search")
+        .expect("index.search span not found");
+
+    assert!(
+        search_span.fields.iter().any(|(k, _)| k == "scope"),
+        "index.search missing 'scope' field"
+    );
+    assert!(
+        search_span.fields.iter().any(|(k, _)| k == "dimensions"),
+        "index.search missing 'dimensions' field"
+    );
+    assert!(
+        search_span.fields.iter().any(|(k, _)| k == "count"),
+        "index.search missing 'count' field"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-09: index.save carries key_count
+// ---------------------------------------------------------------------------
+
+#[test]
+fn index_save_span_has_key_count_field() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (_, store) = with_capturing(|| {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc09-save".to_string());
+        let _ = idx.save(dir.path());
+    });
+    let spans = store.lock().unwrap();
+    let save_span = spans
+        .spans
+        .iter()
+        .find(|s| s.name == "index.save")
+        .expect("index.save span not found");
+
+    assert!(
+        save_span.fields.iter().any(|(k, _)| k == "key_count"),
+        "index.save missing 'key_count' field"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-16: No token values in any span field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auth_resolution_never_logs_token_value() {
+    use memory_mcp::auth::AuthProvider;
+
+    let token_value = "ghp_super_secret_test_token_12345";
+    let (_, store) = with_capturing(|| {
+        // Set env var with a "secret" token and attempt resolution.
+        std::env::set_var("MEMORY_MCP_GITHUB_TOKEN", token_value);
+        let provider = AuthProvider::new();
+        let _ = provider.resolve_token();
+        std::env::remove_var("MEMORY_MCP_GITHUB_TOKEN");
+    });
+    let store = store.lock().unwrap();
+
+    // Check no span field VALUE contains the raw token value.
+    for span in &store.spans {
+        for (field_name, field_value) in &span.fields {
+            assert!(
+                !field_value.contains(token_value),
+                "span '{}' field '{}' value contains raw token: {field_value}",
+                span.name,
+                field_name
+            );
+        }
+    }
+
+    // Check no event field value contains the raw token value.
+    for event in &store.events {
+        for (k, v) in &event.fields {
+            assert!(
+                !v.contains(token_value),
+                "event field {k}={v:?} contains raw token"
+            );
+        }
+        assert!(
+            !event.message.contains(token_value),
+            "event message contains raw token: {:?}",
+            event.message
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TC-18: URLs are redacted (no userinfo in repo spans)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_init_url_is_redacted_in_logs() {
+    use memory_mcp::repo::MemoryRepo;
+
+    // Use a URL containing a fake credential.
+    // git2 file:// URLs don't contain userinfo, but let's verify our
+    // redact_url logic: the logs from init_or_open go through redact_url.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let fake_url = "https://x-access-token:ghp_faketoken@github.com/owner/repo.git";
+
+    let (_, store) = with_capturing(|| {
+        // This will fail (no real GitHub), but log the URL via redact_url.
+        // We just need to verify the token doesn't appear in traces.
+        let _result = MemoryRepo::init_or_open(dir.path(), Some(fake_url));
+    });
+    let store = store.lock().unwrap();
+
+    for event in &store.events {
+        assert!(
+            !event.message.contains("ghp_faketoken"),
+            "event message contains raw token in URL: {:?}",
+            event.message
+        );
+        for (k, v) in &event.fields {
+            assert!(
+                !v.contains("ghp_faketoken"),
+                "event field {k}={v:?} contains raw token in URL"
+            );
+        }
+    }
+    for span in &store.spans {
+        for (field_name, field_value) in &span.fields {
+            assert!(
+                !field_value.contains("ghp_faketoken"),
+                "span '{}' field '{}' value contains raw token in URL: {field_value}",
+                span.name,
+                field_name
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TC-21: Auth failure produces warn-level event
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auth_failure_produces_warn_event() {
+    use memory_mcp::auth::AuthProvider;
+
+    let (_, store) = with_capturing(|| {
+        // Clear env var so resolution must fall back to keyring / fail.
+        std::env::remove_var("MEMORY_MCP_GITHUB_TOKEN");
+        let provider = AuthProvider::new(); // may or may not have keyring
+        let _ = provider.resolve_token(); // keyring absent in CI → warn
+    });
+    let store = store.lock().unwrap();
+
+    let warn_events: Vec<&EventRecord> = store
+        .events
+        .iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .collect();
+
+    // In CI there is no keyring daemon, so resolution fails and at least one
+    // warn event must be emitted.
+    assert!(
+        !warn_events.is_empty(),
+        "expected at least one warn event from auth failure (no keyring in CI)"
+    );
+
+    // The warn from auth failure should not contain any secret data.
+    for event in &warn_events {
+        for (k, v) in &event.fields {
+            assert!(
+                !v.starts_with("ghp_") && !v.starts_with("github_pat_"),
+                "warn event field {k}={v:?} looks like a raw GitHub token"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TC-20: Default filter — index.* debug spans should be suppressible
+// ---------------------------------------------------------------------------
+
+#[test]
+fn debug_spans_are_filtered_when_only_info_enabled() {
+    use memory_mcp::index::ScopedIndex;
+    use memory_mcp::types::Scope;
+
+    // --- Baseline: verify index.* spans DO appear under DEBUG filter ---
+    let baseline_store = Arc::new(Mutex::new(RecordStore::default()));
+    {
+        let layer = CapturingLayer {
+            store: Arc::clone(&baseline_store),
+        };
+        let filter = tracing_subscriber::EnvFilter::new("debug");
+        let subscriber = Registry::default().with(layer).with(filter);
+        with_default(subscriber, || {
+            let idx = ScopedIndex::new(4).expect("create index");
+            let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+            let _ = idx.add(&Scope::Global, &v, "global/tc20-baseline".to_string());
+        });
+    }
+    {
+        let spans = baseline_store.lock().unwrap();
+        let index_spans: Vec<&SpanRecord> = spans
+            .spans
+            .iter()
+            .filter(|s| s.name.starts_with("index."))
+            .collect();
+        assert!(
+            !index_spans.is_empty(),
+            "baseline: expected index.* spans to appear under DEBUG filter"
+        );
+    }
+
+    // --- Main assertion: index.* debug spans suppressed under INFO filter ---
+    let store = Arc::new(Mutex::new(RecordStore::default()));
+    let layer = CapturingLayer {
+        store: Arc::clone(&store),
+    };
+    let filter = tracing_subscriber::EnvFilter::new("info");
+    let subscriber = Registry::default().with(layer).with(filter);
+
+    with_default(subscriber, || {
+        let idx = ScopedIndex::new(4).expect("create index");
+        let v = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let _ = idx.add(&Scope::Global, &v, "global/tc20-filter".to_string());
+    });
+
+    let spans = store.lock().unwrap();
+    // Under INFO filter, index.add (debug level) should NOT be recorded.
+    let debug_spans: Vec<&SpanRecord> = spans
+        .spans
+        .iter()
+        .filter(|s| s.name.starts_with("index."))
+        .collect();
+    assert!(
+        debug_spans.is_empty(),
+        "debug-level index.* spans should be filtered under INFO: {debug_spans:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-08: repo.* spans have correct field names
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_save_span_has_name_and_oid_fields() {
+    use memory_mcp::repo::MemoryRepo;
+    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let (_, store) = with_capturing(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let repo = Arc::new(MemoryRepo::init_or_open(dir.path(), None).expect("init repo"));
+            let meta = MemoryMetadata {
+                tags: vec![],
+                scope: Scope::Global,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                source: None,
+            };
+            let mem = Memory::new("tc08-memory".to_string(), "test content".to_string(), meta);
+            let _ = repo.save_memory(&mem).await;
+        });
+    });
+    let spans = store.lock().unwrap();
+    let save_span = spans
+        .spans
+        .iter()
+        .find(|s| s.name == "repo.save")
+        .expect("repo.save span not found");
+
+    assert!(
+        save_span.fields.iter().any(|(k, _)| k == "name"),
+        "repo.save missing 'name' field; fields: {:?}",
+        save_span.fields
+    );
+    assert!(
+        save_span.fields.iter().any(|(k, _)| k == "oid"),
+        "repo.save missing 'oid' field; fields: {:?}",
+        save_span.fields
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TC-17: content text not in any span field
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repo_save_does_not_log_content_text() {
+    use memory_mcp::repo::MemoryRepo;
+    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let secret_content = "top_secret_content_abc123";
+
+    let (_, store) = with_capturing(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let repo = Arc::new(MemoryRepo::init_or_open(dir.path(), None).expect("init repo"));
+            let meta = MemoryMetadata {
+                tags: vec![],
+                scope: Scope::Global,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                source: None,
+            };
+            let mem = Memory::new("tc17-memory".to_string(), secret_content.to_string(), meta);
+            let _ = repo.save_memory(&mem).await;
+        });
+    });
+    let store = store.lock().unwrap();
+
+    // Verify no span field VALUE contains the secret content text.
+    for span in &store.spans {
+        for (field_name, field_value) in &span.fields {
+            assert!(
+                !field_value.contains(secret_content),
+                "span '{}' field '{}' value contains content text: {field_value}",
+                span.name,
+                field_name
+            );
+        }
+    }
+    // Verify no event message or field value contains the secret content text.
+    for event in &store.events {
+        assert!(
+            !event.message.contains(secret_content),
+            "event message contains content text: {:?}",
+            event.message
+        );
+        for (k, v) in &event.fields {
+            assert!(
+                !v.contains(secret_content),
+                "event field {k}={v:?} contains content text"
+            );
+        }
+    }
+}

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -580,17 +580,23 @@ fn repo_init_url_is_redacted_in_logs() {
 fn auth_failure_produces_warn_event() {
     use memory_mcp::auth::AuthProvider;
 
-    // Override HOME to an empty temp directory so resolve_token cannot
-    // find ~/.config/memory-mcp/token (which may exist on dev machines).
+    // Capture real env before overriding, then restore after.
+    let real_home = std::env::var_os("HOME");
+    let saved_token = std::env::var_os("MEMORY_MCP_GITHUB_TOKEN");
     let fake_home = tempfile::tempdir().expect("tempdir for fake HOME");
     let (_, store) = with_capturing(|| {
         std::env::remove_var("MEMORY_MCP_GITHUB_TOKEN");
         std::env::set_var("HOME", fake_home.path());
         let provider = AuthProvider::new();
-        let _ = provider.resolve_token(); // no env, no file, no keyring → warn
-                                          // Restore HOME so other tests are unaffected.
-        if let Some(real_home) = dirs::home_dir() {
-            std::env::set_var("HOME", real_home);
+        let _ = provider.resolve_token();
+        // Restore env vars so other tests are unaffected.
+        match &real_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        match &saved_token {
+            Some(t) => std::env::set_var("MEMORY_MCP_GITHUB_TOKEN", t),
+            None => {} // already removed above
         }
     });
     let store = store.lock().unwrap();


### PR DESCRIPTION
## Summary

- Comprehensive structured tracing spans across all 6 subsystems per approved design in `docs/design/tracing/`
- OTLP export behind `--features otlp` with `--otlp-optional` graceful fallback
- 14 automated tests covering span conventions, field validation, and sensitive data protection
- CI: otlp feature clippy/tests, dependency tree assertion

## Changes

| Module | Spans added |
|--------|-------------|
| MCP handlers (`server.rs`) | `handler.{remember,recall,forget,edit,list,read,sync}` + `server.incremental_reindex` — all with `session_id`, relevant fields |
| Embedding (`candle.rs`) | `embedding.{embed,embed_batch,embed_chunk,load_model}` — batch_size, dimensions, model |
| Vector index (`index.rs`) | `index.{add,remove,search,save,load}` — scope, key_count, dimensions, count |
| Git repo (`repo.rs`) | `repo.{init,save,delete,read,list,push,pull}` — name, branch, oid, file_count |
| Auth (`auth.rs`) | `auth.resolve` — token_source (never token value), per-source debug events, warn on failure |
| Startup (`main.rs`) | Timed spans for repo init, model load, index load |

## Design decisions

- Span naming: `module.operation` (R-02)
- Field naming: flat `snake_case` canonical dictionary (R-04)
- Sensitive data: redact at source — tokens, content text, credentials never in spans (R-16–R-18)
- Default filter: `memory_mcp=info,warn` — preserves dependency warnings (R-19, R-20)
- OTLP startup: crash by default, `--otlp-optional` for fallback (R-22, R-23)
- OTLP runtime: SDK BatchSpanProcessor handles disconnection/reconnection (R-24)

## Test coverage

14 tests in `tests/tracing.rs` using in-memory span/event subscriber:
- TC-01/02: span naming conventions
- TC-04: canonical field allowlist
- TC-06–09: subsystem span fields
- TC-16–18: no tokens, no content text, no raw URLs in spans
- TC-20: debug spans filtered under info level
- TC-21: auth failure produces warn event

## Review findings addressed

Code review found 5 P2 and 6 P3 findings, all fixed:
- OTLP provider shutdown on error path
- `key_count` accuracy on upserts
- Test infrastructure capturing field values (not just names)
- Warning message clarity
- Default log filter preserving dependency warnings
- Duplicate startup spans removed
- `incremental_reindex` span added
- Test robustness improvements

Closes #52 (scaffold portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)