### PR TITLE
docs: design artifacts for Phase 2 quality (#94, #145, #146, #164)

### DIFF
--- a/docs/adr/0024-oauth-device-flow-provider-trait.md
+++ b/docs/adr/0024-oauth-device-flow-provider-trait.md
@@ -1,0 +1,66 @@
+# ADR-0024: OAuthDeviceFlowProvider trait for multi-provider device flow auth
+
+## Status
+Proposed
+
+## Context
+ADR-0012 introduced the OAuth device flow for token acquisition, with the GitHub
+client ID, device code URL, and access token URL hardcoded as constants in
+`auth.rs`. This works for GitHub-only use, but:
+
+1. **Integration tests** cannot exercise the device flow without hitting real
+   GitHub endpoints — there is no way to point the flow at a mock server.
+2. **Alternative providers** (GitLab, Gitea) also support RFC 8628 device flow
+   but use different client IDs, endpoint URLs, and scope formats. Supporting
+   them would require rewriting `device_flow_login()`.
+3. The hardcoded constants mix configuration with logic, making the auth module
+   harder to test and extend.
+
+We considered three abstraction levels:
+
+- **`OAuthProvider`** (general OAuth trait): rejected because the trait methods
+  (`device_code_url`, `access_token_url`) are specific to the device flow grant
+  type. Providers that only support authorization code flow or API keys wouldn't
+  fit this shape, and the name would imply generality the trait doesn't have.
+- **`OAuthDeviceFlowProvider`** (RFC 8628 trait): chosen because it accurately
+  describes the scope — any provider implementing RFC 8628 device authorization
+  grant can implement this trait. GitHub and GitLab both qualify.
+- **`AuthFlow`** (high-level auth strategy trait): deferred. If a future provider
+  needs a fundamentally different grant type, the right move is a higher-level
+  trait where `OAuthDeviceFlowProvider` becomes one implementation strategy.
+  This refactor is mechanical when there's a real second flow to design against.
+
+## Decision
+Define an `OAuthDeviceFlowProvider` trait covering the RFC 8628 device
+authorization grant:
+
+```rust
+trait OAuthDeviceFlowProvider: Send + Sync {
+    fn client_id(&self) -> &str;
+    fn device_code_url(&self) -> &str;
+    fn access_token_url(&self) -> &str;
+    fn scopes(&self) -> &[&str];
+    fn validate(&self) -> Result<(), MemoryError>;
+}
+```
+
+`device_flow_login()` takes `&dyn OAuthDeviceFlowProvider` instead of importing
+constants directly. The current constants become the `GitHubDeviceFlow`
+implementation (zero-sized struct). A `MockDeviceFlow` implementation points at
+an in-process test server for integration tests.
+
+Each provider validates its own parameters (`validate()`) — GitHub checks its
+`Iv1.` client ID format, GitLab would check its own. Endpoint URLs must use
+HTTPS (except localhost for testing).
+
+## Consequences
+- `device_flow_login()` becomes testable against a mock OAuth server
+- GitLab and Gitea support is unblocked — implement the trait, no flow changes
+- Scopes are provider-defined (`"repo"` for GitHub, different for GitLab)
+- The `DeviceCodeResponse` and `AccessTokenResponse` structs remain shared —
+  RFC 8628 standardises the response format across providers
+- If a non-device-flow provider is needed later, introduce a higher-level
+  `AuthFlow` trait — `OAuthDeviceFlowProvider` becomes one strategy, alongside
+  `AuthCodeProvider` or `ApiKeyProvider`
+- Supersedes the hardcoded constants from ADR-0012 but does not invalidate
+  ADR-0012's other decisions (keyring storage, stdout backend, etc.)

--- a/docs/adr/0024-oauth-device-flow-provider-trait.md
+++ b/docs/adr/0024-oauth-device-flow-provider-trait.md
@@ -1,4 +1,4 @@
-# ADR-0024: OAuthDeviceFlowProvider trait for multi-provider device flow auth
+# ADR-0024: `auth::oauth::DeviceFlowProvider` trait for multi-provider device flow auth
 
 ## Status
 Proposed
@@ -22,20 +22,23 @@ We considered three abstraction levels:
   (`device_code_url`, `access_token_url`) are specific to the device flow grant
   type. Providers that only support authorization code flow or API keys wouldn't
   fit this shape, and the name would imply generality the trait doesn't have.
-- **`OAuthDeviceFlowProvider`** (RFC 8628 trait): chosen because it accurately
-  describes the scope — any provider implementing RFC 8628 device authorization
-  grant can implement this trait. GitHub and GitLab both qualify.
+- **`auth::oauth::DeviceFlowProvider`** (RFC 8628 trait): chosen because it
+  accurately describes the scope — any provider implementing RFC 8628 device
+  authorization grant can implement this trait. GitHub and GitLab both qualify.
+  The `auth::oauth` module namespace provides the OAuth context, so the trait
+  name itself doesn't need the `OAuth` prefix.
 - **`AuthFlow`** (high-level auth strategy trait): deferred. If a future provider
   needs a fundamentally different grant type, the right move is a higher-level
-  trait where `OAuthDeviceFlowProvider` becomes one implementation strategy.
+  trait where `DeviceFlowProvider` becomes one implementation strategy.
   This refactor is mechanical when there's a real second flow to design against.
 
 ## Decision
-Define an `OAuthDeviceFlowProvider` trait covering the RFC 8628 device
-authorization grant:
+Introduce an `auth::oauth` module with a `DeviceFlowProvider` trait covering
+the RFC 8628 device authorization grant:
 
 ```rust
-trait OAuthDeviceFlowProvider: Send + Sync {
+// src/auth/oauth/mod.rs
+trait DeviceFlowProvider: Send + Sync {
     fn client_id(&self) -> &str;
     fn device_code_url(&self) -> &str;
     fn access_token_url(&self) -> &str;
@@ -44,14 +47,35 @@ trait OAuthDeviceFlowProvider: Send + Sync {
 }
 ```
 
-`device_flow_login()` takes `&dyn OAuthDeviceFlowProvider` instead of importing
+Module structure:
+
+```
+auth/
+  oauth/
+    mod.rs        — DeviceFlowProvider trait, device_flow_login()
+    github.rs     — GitHubDeviceFlow (zero-sized, compile-time constants)
+  mod.rs          — AuthProvider, token resolution, store backends
+```
+
+`device_flow_login()` takes `&dyn DeviceFlowProvider` instead of importing
 constants directly. The current constants become the `GitHubDeviceFlow`
-implementation (zero-sized struct). A `MockDeviceFlow` implementation points at
-an in-process test server for integration tests.
+implementation. A `MockDeviceFlow` implementation points at an in-process test
+server for integration tests.
 
 Each provider validates its own parameters (`validate()`) — GitHub checks its
 `Iv1.` client ID format, GitLab would check its own. Endpoint URLs must use
 HTTPS (except localhost for testing).
+
+Future auth strategies that aren't OAuth device flow (authorization code,
+API keys) would be sibling modules under `auth/`, not forced into the
+`auth::oauth` module:
+
+```
+auth/
+  oauth/          — DeviceFlowProvider, AuthCodeProvider (future)
+  api_key/        — ApiKeyProvider (future, non-OAuth)
+  mod.rs          — AuthProvider
+```
 
 ## Consequences
 - `device_flow_login()` becomes testable against a mock OAuth server
@@ -60,7 +84,7 @@ HTTPS (except localhost for testing).
 - The `DeviceCodeResponse` and `AccessTokenResponse` structs remain shared —
   RFC 8628 standardises the response format across providers
 - If a non-device-flow provider is needed later, introduce a higher-level
-  `AuthFlow` trait — `OAuthDeviceFlowProvider` becomes one strategy, alongside
-  `AuthCodeProvider` or `ApiKeyProvider`
+  `AuthFlow` trait — `DeviceFlowProvider` becomes one strategy, alongside
+  `AuthCodeProvider` or `ApiKeyProvider`, each in their own module under `auth/`
 - Supersedes the hardcoded constants from ADR-0012 but does not invalidate
   ADR-0012's other decisions (keyring storage, stdout backend, etc.)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,4 +6,4 @@ Each component or feature gets its own subdirectory.
 | Design | Issue | Phase | Date | Status |
 |--------|-------|-------|------|--------|
 | [Tracing Scaffold](tracing/) | #52 | 2 | 2026-04-23 | Approved |
-| [Phase 2 Quality](phase2-quality/) | #94, #145, #146, #164 | 2 | 2026-04-25 | Draft |
+| [Phase 2 Quality](phase2-quality/) | #94, #145, #146, #164 | 2 | 2026-04-25 | Approved |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -6,3 +6,4 @@ Each component or feature gets its own subdirectory.
 | Design | Issue | Phase | Date | Status |
 |--------|-------|-------|------|--------|
 | [Tracing Scaffold](tracing/) | #52 | 2 | 2026-04-23 | Approved |
+| [Phase 2 Quality](phase2-quality/) | #94, #145, #146, #164 | 2 | 2026-04-25 | Draft |

--- a/docs/design/phase2-quality/README.md
+++ b/docs/design/phase2-quality/README.md
@@ -14,9 +14,9 @@ and `/readyz` health endpoint.
 |----------|-------|--------|
 | [Problem Space](problem.md) | 1 | Approved |
 | [Requirements & SRTM](requirements.md) | 2 | Approved |
-| [Architecture](architecture.md) | 3 | Draft |
-| [Threat Model](threat-model.md) | 4 (lightweight) | Draft |
-| [Test Plan](test-plan.md) | 5 | Draft |
+| [Architecture](architecture.md) | 3 | Approved |
+| [Threat Model](threat-model.md) | 4 (lightweight) | Approved |
+| [Test Plan](test-plan.md) | 5 | Approved |
 
 ## Related
 

--- a/docs/design/phase2-quality/README.md
+++ b/docs/design/phase2-quality/README.md
@@ -1,0 +1,37 @@
+# Design: Phase 2 Quality — Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+## Summary
+
+Designs the remaining Phase 2 work as a cohesive unit: vector index trait
+abstraction, OAuth device flow provider abstraction, auth integration tests,
+and `/readyz` health endpoint.
+
+## Artifacts
+
+| Artifact | Phase | Status |
+|----------|-------|--------|
+| [Problem Space](problem.md) | 1 | Approved |
+| [Requirements & SRTM](requirements.md) | 2 | Approved |
+| [Architecture](architecture.md) | 3 | Draft |
+| [Threat Model](threat-model.md) | 4 (lightweight) | Draft |
+| [Test Plan](test-plan.md) | 5 | Draft |
+
+## Related
+
+- [ADR-0024: `auth::oauth::DeviceFlowProvider`](../../adr/0024-oauth-device-flow-provider-trait.md)
+- [ADR-0012: OAuth device flow for token acquisition](../../adr/0012-oauth-device-flow-token-acquisition.md)
+- [Tracing Scaffold Design](../tracing/) (prior Phase 2 work)
+
+## Key Decisions
+
+- **VectorStore trait** at the semantic level (`Box<dyn VectorStore>` in AppState),
+  with usearch as the first concrete implementation
+- **`auth::oauth::DeviceFlowProvider`** trait scoped to RFC 8628 device flow —
+  module namespace provides OAuth context (ADR-0024)
+- **Two testing levels** for the index: private failure injection (rollback mechanics)
+  and public trait-level error behavior
+- **Readiness checks** validate consistency (embedding ↔ index dimensions), not
+  magic numbers — forward-compatible with model upgrades
+- **Remote sync** does not affect readiness by default (opt-in via `--require-remote-sync`)

--- a/docs/design/phase2-quality/architecture.md
+++ b/docs/design/phase2-quality/architecture.md
@@ -1,5 +1,5 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-25
 phase: 3
 -->

--- a/docs/design/phase2-quality/architecture.md
+++ b/docs/design/phase2-quality/architecture.md
@@ -44,11 +44,15 @@ Implementations:
 
 ### 3. /readyz endpoint
 
-A new Axum route alongside `/healthz`. Checks three subsystems via their existing
-APIs — no new network calls, no heavy computation:
-- Git repo: HEAD resolvable
-- Embedding: `dimensions() > 0`
+A new Axum route alongside `/healthz`. Default checks (no network I/O):
+- Git repo: accessible and valid (must pass for empty repos with no commits)
+- Embedding ↔ index consistency: `embedding.dimensions() == index.dimensions()`
+  (validates model-index agreement without hardcoding a magic number)
 - Vector index: `is_ready()` from VectorStore trait
+
+Optional check (enabled by `--require-remote-sync`):
+- Remote sync: git remote is reachable. Off by default — the server is fully
+  functional for local operations without a remote.
 
 Returns 200 + JSON or 503 + JSON with per-subsystem status. Response bodies use a
 fixed vocabulary (`"up"` / `"down"` + a constrained `reason` field on failure) —
@@ -102,6 +106,10 @@ subsystems to assert readiness. The private `RawIndex` trait inside `UsearchStor
 is shown separately — it exists only for failure injection testing.
 
 ```mermaid
+---
+config:
+  layout: elk
+---
 graph TD
     subgraph HTTP["HTTP Layer (Axum 0.8)"]
         healthz["/healthz<br/>liveness probe"]
@@ -336,9 +344,15 @@ sequenceDiagram
 ### Sequence: Readiness Check
 
 `/readyz` is entirely inward-facing: every check is a method call on an
-already-initialised subsystem. No network I/O occurs. The handler aggregates
-per-subsystem status into structured JSON and returns 503 if any check fails,
-200 if all pass, without exposing internal details.
+already-initialised subsystem. No network I/O occurs by default. The handler
+aggregates per-subsystem status into structured JSON and returns 503 if any
+check fails, 200 if all pass, without exposing internal details.
+
+The git repo check validates accessibility and validity, not commit history —
+a freshly initialised empty repo is ready. The embedding check verifies
+dimensional consistency with the vector index rather than checking for a
+magic number, so model upgrades (e.g., ModernBERT) don't break readiness.
+Remote sync reachability is only checked when `--require-remote-sync` is set.
 
 ```mermaid
 sequenceDiagram
@@ -350,25 +364,34 @@ sequenceDiagram
     participant VS as «trait» VectorStore
 
     K8s->>Router: GET /readyz
-    Router->>RH: readyz_handler(AppState)
+    Router->>RH: readyz_handler(AppState, config)
 
-    Note over RH,Repo: Check 1: git repo
-    RH->>Repo: head_resolvable()
-    Repo-->>RH: Ok / Err
+    Note over RH,Repo: Check 1: git repo accessible and valid
+    RH->>Repo: is_accessible()
+    Repo-->>RH: Ok (works even with no commits)
 
-    Note over RH,Embed: Check 2: embedding model
+    Note over RH,VS: Check 2: embedding ↔ index dimensional consistency
     RH->>Embed: dimensions()
-    Embed-->>RH: 384 (or 0 if not loaded)
+    Embed-->>RH: 384
+    RH->>VS: dimensions()
+    VS-->>RH: 384
+    RH->>RH: assert embedding dims == index dims
 
-    Note over RH,VS: Check 3: vector index
+    Note over RH,VS: Check 3: vector index ready
     RH->>VS: is_ready()
     VS-->>RH: ReadyStatus
 
+    opt --require-remote-sync enabled
+        Note over RH,Repo: Check 4: remote reachable
+        RH->>Repo: remote_reachable()
+        Repo-->>RH: Ok / Err
+    end
+
     RH->>RH: aggregate: all up → 200, any down → 503
 
-    alt all subsystems up
+    alt all checks pass
         RH-->>Router: 200 {"status":"ready","checks":{"git_repo":{"status":"up"},...}}
-    else any subsystem down
+    else any check fails
         RH-->>Router: 503 {"status":"not_ready","checks":{...,"reason":"..."}}
     end
 

--- a/docs/design/phase2-quality/architecture.md
+++ b/docs/design/phase2-quality/architecture.md
@@ -1,0 +1,374 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-25
+phase: 3
+-->
+
+# Architecture — Phase 2 Quality: Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+## Architectural Decisions
+
+### 1. VectorStore trait (public, semantic-level)
+
+`AppState.index` changes from `ScopedIndex` to `Box<dyn VectorStore>`. The trait
+defines what the rest of the system needs from vector storage — add, remove, search
+by name and scope, persist, report health. This matches the existing pattern where
+`AppState.embedding` is already `Box<dyn EmbeddingBackend>`.
+
+**Dynamic dispatch** (`Box<dyn>`) rather than generics on `AppState`. This avoids
+generic parameter proliferation through the server stack and keeps the trait
+object-safe.
+
+Implementations:
+- **`UsearchStore`** — wraps existing `ScopedIndex`/`VectorIndex` logic. Internally
+  uses a private `RawIndex` trait for failure injection in tests.
+- **`InMemoryStore`** — `HashMap`-based, for fast deterministic tests at the trait
+  level.
+
+### 2. OAuthDeviceFlowProvider trait (RFC 8628)
+
+The hardcoded GitHub OAuth constants become a trait covering the RFC 8628 device
+authorization grant specifically. See [ADR-0024](../../../docs/adr/0024-oauth-device-flow-provider-trait.md)
+for the full analysis of why this is scoped to device flow, not all OAuth.
+
+`device_flow_login()` takes `&dyn OAuthDeviceFlowProvider` instead of importing
+constants directly.
+
+Implementations:
+- **`GitHubDeviceFlow`** — zero-sized struct, compile-time constants.
+- **`MockDeviceFlow`** — points at an in-process test server for integration tests.
+
+### 3. /readyz endpoint
+
+A new Axum route alongside `/healthz`. Checks three subsystems via their existing
+APIs — no new network calls, no heavy computation:
+- Git repo: HEAD resolvable
+- Embedding: `dimensions() > 0`
+- Vector index: `is_ready()` from VectorStore trait
+
+Returns 200 + JSON or 503 + JSON with per-subsystem status. Response bodies use a
+fixed vocabulary (`"up"` / `"down"` + a constrained `reason` field on failure) —
+no internal paths, versions, or stack traces.
+
+No auth required — this is an infrastructure endpoint, same as `/healthz`.
+
+### 4. Integration test architecture
+
+In-process mock OAuth server (small Axum app started per test) implementing the
+device code and token endpoints. All tests use ephemeral ports to avoid conflicts
+in parallel runs.
+
+Tests are `#[tokio::test]`, calling the same entry points with injected config
+rather than spawning the binary.
+
+## Diagrams
+
+### System Context
+
+memory-mcp sits between four external relationships: AI agents drive it over
+HTTP/MCP, a Kubernetes orchestrator probes its health endpoints, a git remote
+backs its storage, and an OAuth provider handles credential issuance. All network
+traffic crosses a single ingress point (the Axum router), and the git and OAuth
+relationships are outbound-only.
+
+```mermaid
+graph TB
+    agent["🤖 MCP Client / AI Agent<br/><i>Calls remember, recall, read,<br/>edit, forget, list, sync</i>"]
+    ops["☸ Kubernetes Orchestrator<br/><i>Probes /healthz and /readyz</i>"]
+
+    subgraph server["memory-mcp"]
+        mcp["Rust MCP Server<br/>Semantic memory storage<br/>with git backing + HNSW vector search"]
+    end
+
+    git_remote["Git Remote (GitHub / GitLab)<br/><i>Stores serialised memory objects</i>"]
+    oauth["OAuth Provider (GitHub / GitLab)<br/><i>Issues device-flow tokens (RFC 8628)</i>"]
+
+    agent -->|"HTTP POST /mcp<br/>(JSON-RPC)"| mcp
+    ops -->|"HTTP GET<br/>/healthz  /readyz"| mcp
+    mcp -->|"git push / fetch<br/>(HTTPS, token auth)"| git_remote
+    mcp -->|"device_code + token poll<br/>(HTTPS POST)"| oauth
+```
+
+### Component Diagram
+
+Internal structure after the Phase 2 refactor, wired through `AppState`. Three
+trait-abstracted subsystems: `EmbeddingBackend` (existing), `VectorStore` (new),
+and `OAuthDeviceFlowProvider` (new). The `/readyz` endpoint reaches into all three
+subsystems to assert readiness. The private `RawIndex` trait inside `UsearchStore`
+is shown separately — it exists only for failure injection testing.
+
+```mermaid
+graph TB
+    subgraph HTTP["HTTP Layer (Axum 0.8)"]
+        healthz["/healthz<br/>liveness probe"]
+        readyz["/readyz<br/>readiness probe"]
+        mcppath["/mcp<br/>MCP JSON-RPC"]
+    end
+
+    subgraph Handlers["MCP Handlers (src/server.rs)"]
+        remember["remember"]
+        recall["recall"]
+        read_h["read"]
+        edit_h["edit"]
+        forget_h["forget"]
+        list_h["list"]
+        sync_h["sync"]
+    end
+
+    subgraph State["AppState (src/types.rs)"]
+        repo["repo: Arc‹MemoryRepo›"]
+        embedding_field["embedding: Box‹dyn EmbeddingBackend›"]
+        index_field["index: Box‹dyn VectorStore›"]
+        auth_field["auth: AuthProvider"]
+    end
+
+    subgraph EmbeddingSub["Embedding Subsystem"]
+        EB["«trait» EmbeddingBackend<br/>embed() / embed_one() / dimensions()"]
+        Candle["CandleEmbeddingEngine<br/>(BGE-small-en-v1.5)"]
+    end
+
+    subgraph VectorSub["Vector Index Subsystem"]
+        VS["«trait» VectorStore<br/>add / remove / search<br/>save / load / is_ready"]
+        UStore["UsearchStore<br/>(ScopedIndex + VectorIndex)"]
+        IMStore["InMemoryStore<br/>(HashMap, tests)"]
+        subgraph RawIdx["Private: RawIndex (failure injection)"]
+            URaw["UsearchRawIndex"]
+            FRaw["FailingRawIndex<br/>(test double)"]
+        end
+    end
+
+    subgraph AuthSub["Auth Subsystem"]
+        AP["AuthProvider<br/>env var → keyring → token file"]
+        DFP["«trait» OAuthDeviceFlowProvider<br/>client_id / device_code_url<br/>access_token_url / scopes / validate"]
+        GDF["GitHubDeviceFlow<br/>(zero-sized, constants)"]
+        MDF["MockDeviceFlow<br/>(test server)"]
+    end
+
+    subgraph RepoSub["Git Repo Subsystem"]
+        MR["MemoryRepo<br/>(git-backed CRUD)"]
+    end
+
+    mcppath --> Handlers
+    Handlers --> State
+    readyz --> State
+
+    embedding_field -.-> EB
+    Candle -.->|implements| EB
+
+    index_field -.-> VS
+    UStore -.->|implements| VS
+    IMStore -.->|implements| VS
+    UStore --> URaw
+    UStore --> FRaw
+
+    repo --> MR
+    auth_field --> AP
+    AP -.-> DFP
+    GDF -.->|implements| DFP
+    MDF -.->|implements| DFP
+```
+
+### Data Flow Diagram with Trust Boundaries
+
+Three network trust boundaries: external HTTP ingress, outbound OAuth, and outbound
+git. Inside the server, the abstraction boundary between MCP handlers and
+`VectorStore` is a design seam (not a security boundary) that enables test
+substitution. The `/readyz` handler is entirely within the server boundary — no
+external calls, only introspecting subsystem state through trait methods.
+
+```mermaid
+graph LR
+    subgraph external_in["TRUST BOUNDARY: External Network (inbound)"]
+        client["MCP Client<br/>/ AI Agent"]
+        k8s["k8s Orchestrator"]
+    end
+
+    subgraph server["TRUST BOUNDARY: memory-mcp Process"]
+        router["Axum Router"]
+
+        subgraph readiness["Readiness (internal only)"]
+            readyz_h["/readyz handler"]
+            repo_check["MemoryRepo<br/>HEAD resolvable?"]
+            embed_check["EmbeddingBackend<br/>dimensions > 0?"]
+            index_check["VectorStore<br/>is_ready()?"]
+        end
+
+        subgraph abstraction["ABSTRACTION BOUNDARY: Trait Contracts"]
+            mcp_handlers["MCP Handlers<br/>(remember / recall / read<br/>edit / forget / list / sync)"]
+            embedding_trait["«trait» EmbeddingBackend"]
+            vector_trait["«trait» VectorStore"]
+        end
+
+        subgraph impls["Concrete Implementations"]
+            candle["CandleEmbeddingEngine"]
+            usearch["UsearchStore"]
+            memrepo["MemoryRepo"]
+            auth_prov["AuthProvider"]
+        end
+    end
+
+    subgraph oauth_out["TRUST BOUNDARY: External Network (outbound — OAuth)"]
+        gh_oauth["OAuth Provider<br/>device_code + token endpoints"]
+    end
+
+    subgraph git_out["TRUST BOUNDARY: External Network (outbound — git)"]
+        gh_git["Git Remote<br/>(push / fetch)"]
+    end
+
+    client -->|"HTTP POST /mcp<br/>(JSON-RPC)"| router
+    k8s -->|"HTTP GET<br/>/healthz  /readyz"| router
+
+    router --> readyz_h
+    router --> mcp_handlers
+
+    readyz_h --> repo_check
+    readyz_h --> embed_check
+    readyz_h --> index_check
+    repo_check -.-> memrepo
+    embed_check -.-> candle
+    index_check -.-> usearch
+
+    mcp_handlers --> embedding_trait
+    mcp_handlers --> vector_trait
+    mcp_handlers --> memrepo
+    mcp_handlers --> auth_prov
+
+    embedding_trait --> candle
+    vector_trait --> usearch
+
+    auth_prov -->|"device flow"| gh_oauth
+    memrepo -->|"git push / fetch<br/>(HTTPS + token)"| gh_git
+```
+
+### Sequence: Memory Recall Flow
+
+The full path of a `recall` call, making the trait boundary explicit: the handler
+calls methods on `VectorStore`, never on `UsearchStore` directly. The embedding
+step is a separate round-trip through `EmbeddingBackend` before vector search.
+
+```mermaid
+sequenceDiagram
+    actor Client as MCP Client
+    participant Router as Axum Router
+    participant Handler as recall handler
+    participant Embed as «trait» EmbeddingBackend
+    participant Candle as CandleEmbeddingEngine
+    participant VS as «trait» VectorStore
+    participant UStore as UsearchStore
+    participant Repo as MemoryRepo
+
+    Client->>Router: POST /mcp {tool: "recall", query, scope?, limit?}
+    Router->>Handler: dispatch recall(AppState, params)
+
+    Note over Handler,Candle: Abstraction boundary: EmbeddingBackend
+    Handler->>Embed: embed_one(query_text)
+    Embed->>Candle: tokenise + forward pass
+    Candle-->>Embed: f32 vector [384]
+    Embed-->>Handler: Ok(query_vector)
+
+    Note over Handler,UStore: Abstraction boundary: VectorStore
+    Handler->>VS: search(query_vector, scope_filter, limit)
+    VS->>UStore: delegate
+    UStore->>UStore: HNSW ANN search
+    UStore-->>VS: Vec‹SearchResult›
+    VS-->>Handler: Ok(results)
+
+    Handler->>Repo: read each matched memory
+    Repo-->>Handler: Vec‹Memory›
+
+    Handler-->>Router: JSON-RPC result
+    Router-->>Client: 200 OK {memories: [...]}
+```
+
+### Sequence: Device Flow Login
+
+The `OAuthDeviceFlowProvider` abstraction insulates login orchestration from
+hardcoded constants. `GitHubDeviceFlow` supplies all endpoint URLs and scopes.
+`MockDeviceFlow` can substitute in integration tests by pointing at a local test
+server without any change to the flow driver.
+
+```mermaid
+sequenceDiagram
+    actor CLI as CLI / Operator
+    participant Login as device_flow_login()
+    participant DFP as «trait» OAuthDeviceFlowProvider
+    participant GDF as GitHubDeviceFlow
+    participant GHDevice as OAuth device_code endpoint
+    participant GHToken as OAuth access_token endpoint
+    participant AP as AuthProvider
+
+    CLI->>Login: login(provider: &dyn OAuthDeviceFlowProvider)
+
+    Note over Login,GDF: Provider abstraction: config injection
+    Login->>DFP: validate()
+    DFP->>GDF: check client_id format, URL schemes
+    GDF-->>Login: Ok(())
+
+    Login->>DFP: client_id() / device_code_url() / scopes()
+    DFP-->>Login: "Iv1.…" / URL / ["repo"]
+
+    Note over Login,GHDevice: Network boundary: outbound OAuth
+    Login->>GHDevice: POST {client_id, scope}
+    GHDevice-->>Login: {device_code, user_code, verification_uri}
+
+    Login-->>CLI: "Visit URL — enter code XXXX-YYYY"
+
+    loop Poll until granted or expired
+        Login->>DFP: access_token_url()
+        DFP-->>Login: URL
+        Login->>GHToken: POST {client_id, device_code, grant_type}
+        alt authorization_pending
+            GHToken-->>Login: {error: "authorization_pending"}
+        else granted
+            GHToken-->>Login: {access_token}
+        end
+    end
+
+    Login->>AP: store_token(access_token)
+    AP-->>Login: Ok(())
+    Login-->>CLI: Ok(())
+```
+
+### Sequence: Readiness Check
+
+`/readyz` is entirely inward-facing: every check is a method call on an
+already-initialised subsystem. No network I/O occurs. The handler aggregates
+per-subsystem status into structured JSON and returns 503 if any check fails,
+200 if all pass, without exposing internal details.
+
+```mermaid
+sequenceDiagram
+    actor K8s as k8s Orchestrator
+    participant Router as Axum Router
+    participant RH as /readyz handler
+    participant Repo as MemoryRepo
+    participant Embed as «trait» EmbeddingBackend
+    participant VS as «trait» VectorStore
+
+    K8s->>Router: GET /readyz
+    Router->>RH: readyz_handler(AppState)
+
+    Note over RH,Repo: Check 1: git repo
+    RH->>Repo: head_resolvable()
+    Repo-->>RH: Ok / Err
+
+    Note over RH,Embed: Check 2: embedding model
+    RH->>Embed: dimensions()
+    Embed-->>RH: 384 (or 0 if not loaded)
+
+    Note over RH,VS: Check 3: vector index
+    RH->>VS: is_ready()
+    VS-->>RH: ReadyStatus
+
+    RH->>RH: aggregate: all up → 200, any down → 503
+
+    alt all subsystems up
+        RH-->>Router: 200 {"status":"ready","checks":{"git_repo":{"status":"up"},...}}
+    else any subsystem down
+        RH-->>Router: 503 {"status":"not_ready","checks":{...,"reason":"..."}}
+    end
+
+    Router-->>K8s: HTTP response
+```

--- a/docs/design/phase2-quality/architecture.md
+++ b/docs/design/phase2-quality/architecture.md
@@ -102,7 +102,7 @@ subsystems to assert readiness. The private `RawIndex` trait inside `UsearchStor
 is shown separately — it exists only for failure injection testing.
 
 ```mermaid
-graph TB
+graph TD
     subgraph HTTP["HTTP Layer (Axum 0.8)"]
         healthz["/healthz<br/>liveness probe"]
         readyz["/readyz<br/>readiness probe"]
@@ -110,6 +110,7 @@ graph TB
     end
 
     subgraph Handlers["MCP Handlers (src/server.rs)"]
+        direction LR
         remember["remember"]
         recall["recall"]
         read_h["read"]
@@ -120,56 +121,55 @@ graph TB
     end
 
     subgraph State["AppState (src/types.rs)"]
+        direction LR
         repo["repo: Arc‹MemoryRepo›"]
         embedding_field["embedding: Box‹dyn EmbeddingBackend›"]
         index_field["index: Box‹dyn VectorStore›"]
         auth_field["auth: AuthProvider"]
     end
 
+    mcppath --> Handlers
+    readyz --> State
+    Handlers --> State
+
+    subgraph RepoSub["Git Repo Subsystem"]
+        MR["MemoryRepo<br/>(git-backed CRUD)"]
+    end
+
     subgraph EmbeddingSub["Embedding Subsystem"]
         EB["«trait» EmbeddingBackend<br/>embed() / embed_one() / dimensions()"]
         Candle["CandleEmbeddingEngine<br/>(BGE-small-en-v1.5)"]
+        Candle -.->|implements| EB
     end
 
     subgraph VectorSub["Vector Index Subsystem"]
         VS["«trait» VectorStore<br/>add / remove / search<br/>save / load / is_ready"]
         UStore["UsearchStore<br/>(ScopedIndex + VectorIndex)"]
         IMStore["InMemoryStore<br/>(HashMap, tests)"]
+        UStore -.->|implements| VS
+        IMStore -.->|implements| VS
         subgraph RawIdx["Private: RawIndex (failure injection)"]
             URaw["UsearchRawIndex"]
             FRaw["FailingRawIndex<br/>(test double)"]
         end
+        UStore --> URaw
+        UStore --> FRaw
     end
 
-    subgraph AuthSub["Auth Subsystem"]
+    subgraph AuthSub["Auth Subsystem (auth::oauth)"]
         AP["AuthProvider<br/>env var → keyring → token file"]
         DFP["«trait» DeviceFlowProvider<br/>client_id / device_code_url<br/>access_token_url / scopes / validate"]
         GDF["GitHubDeviceFlow<br/>(zero-sized, constants)"]
         MDF["MockDeviceFlow<br/>(test server)"]
+        GDF -.->|implements| DFP
+        MDF -.->|implements| DFP
+        AP -.-> DFP
     end
-
-    subgraph RepoSub["Git Repo Subsystem"]
-        MR["MemoryRepo<br/>(git-backed CRUD)"]
-    end
-
-    mcppath --> Handlers
-    Handlers --> State
-    readyz --> State
-
-    embedding_field -.-> EB
-    Candle -.->|implements| EB
-
-    index_field -.-> VS
-    UStore -.->|implements| VS
-    IMStore -.->|implements| VS
-    UStore --> URaw
-    UStore --> FRaw
 
     repo --> MR
+    embedding_field -.-> EB
+    index_field -.-> VS
     auth_field --> AP
-    AP -.-> DFP
-    GDF -.->|implements| DFP
-    MDF -.->|implements| DFP
 ```
 
 ### Data Flow Diagram with Trust Boundaries

--- a/docs/design/phase2-quality/architecture.md
+++ b/docs/design/phase2-quality/architecture.md
@@ -27,14 +27,16 @@ Implementations:
 - **`InMemoryStore`** — `HashMap`-based, for fast deterministic tests at the trait
   level.
 
-### 2. OAuthDeviceFlowProvider trait (RFC 8628)
+### 2. `auth::oauth::DeviceFlowProvider` trait (RFC 8628)
 
-The hardcoded GitHub OAuth constants become a trait covering the RFC 8628 device
-authorization grant specifically. See [ADR-0024](../../../docs/adr/0024-oauth-device-flow-provider-trait.md)
+The hardcoded GitHub OAuth constants move into a new `auth::oauth` module with a
+trait covering the RFC 8628 device authorization grant. The module namespace
+provides the OAuth context, so the trait name doesn't need an `OAuth` prefix.
+See [ADR-0024](../../adr/0024-oauth-device-flow-provider-trait.md)
 for the full analysis of why this is scoped to device flow, not all OAuth.
 
-`device_flow_login()` takes `&dyn OAuthDeviceFlowProvider` instead of importing
-constants directly.
+`device_flow_login()` moves into `auth::oauth` and takes `&dyn DeviceFlowProvider`
+instead of importing constants directly.
 
 Implementations:
 - **`GitHubDeviceFlow`** — zero-sized struct, compile-time constants.
@@ -95,7 +97,7 @@ graph TB
 
 Internal structure after the Phase 2 refactor, wired through `AppState`. Three
 trait-abstracted subsystems: `EmbeddingBackend` (existing), `VectorStore` (new),
-and `OAuthDeviceFlowProvider` (new). The `/readyz` endpoint reaches into all three
+and `DeviceFlowProvider` (new). The `/readyz` endpoint reaches into all three
 subsystems to assert readiness. The private `RawIndex` trait inside `UsearchStore`
 is shown separately — it exists only for failure injection testing.
 
@@ -141,7 +143,7 @@ graph TB
 
     subgraph AuthSub["Auth Subsystem"]
         AP["AuthProvider<br/>env var → keyring → token file"]
-        DFP["«trait» OAuthDeviceFlowProvider<br/>client_id / device_code_url<br/>access_token_url / scopes / validate"]
+        DFP["«trait» DeviceFlowProvider<br/>client_id / device_code_url<br/>access_token_url / scopes / validate"]
         GDF["GitHubDeviceFlow<br/>(zero-sized, constants)"]
         MDF["MockDeviceFlow<br/>(test server)"]
     end
@@ -284,7 +286,7 @@ sequenceDiagram
 
 ### Sequence: Device Flow Login
 
-The `OAuthDeviceFlowProvider` abstraction insulates login orchestration from
+The `DeviceFlowProvider` abstraction insulates login orchestration from
 hardcoded constants. `GitHubDeviceFlow` supplies all endpoint URLs and scopes.
 `MockDeviceFlow` can substitute in integration tests by pointing at a local test
 server without any change to the flow driver.
@@ -293,13 +295,13 @@ server without any change to the flow driver.
 sequenceDiagram
     actor CLI as CLI / Operator
     participant Login as device_flow_login()
-    participant DFP as «trait» OAuthDeviceFlowProvider
+    participant DFP as «trait» DeviceFlowProvider
     participant GDF as GitHubDeviceFlow
     participant GHDevice as OAuth device_code endpoint
     participant GHToken as OAuth access_token endpoint
     participant AP as AuthProvider
 
-    CLI->>Login: login(provider: &dyn OAuthDeviceFlowProvider)
+    CLI->>Login: login(provider: &dyn DeviceFlowProvider)
 
     Note over Login,GDF: Provider abstraction: config injection
     Login->>DFP: validate()

--- a/docs/design/phase2-quality/problem.md
+++ b/docs/design/phase2-quality/problem.md
@@ -1,5 +1,5 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-24
 phase: 1
 -->
@@ -35,11 +35,13 @@ health) — with `VectorIndex`/`ScopedIndex` becoming implementation details of
 a usearch-backed concrete type. A separate, private low-level trait inside the
 usearch implementation enables failure injection for rollback testing.
 
-### 2. Hardcoded OAuth client ID (#145)
+### 2. Hardcoded, GitHub-specific OAuth constants (#145)
 
-`GITHUB_CLIENT_ID` is a `const` in `auth.rs`. This prevents:
-- Testing the OAuth device flow against a mock server (different client ID)
-- Using an alternative OAuth app without recompilation
+`GITHUB_CLIENT_ID`, `GITHUB_DEVICE_CODE_URL`, and `GITHUB_ACCESS_TOKEN_URL` are
+constants in `auth.rs`. The auth flow is shaped entirely around GitHub's OAuth
+device flow with no abstraction for alternative providers. This prevents:
+- Testing the OAuth device flow against a mock server (different client ID/URLs)
+- Supporting alternative OAuth providers (GitLab, etc.) without rewriting auth
 - Integration tests that exercise the full auth path
 
 ### 3. No integration tests for auth CLI or bind address (#146)
@@ -55,8 +57,8 @@ These paths are exercised only manually.
 ### 4. No readiness signal for orchestrators (#164)
 
 `/healthz` returns 200 if the process is alive. It says nothing about whether
-the server can serve requests. In the goddess cluster (or any deployment behind
-a gateway), traffic can be routed to an instance where the repo is inaccessible,
+the server can serve requests. In any deployment behind
+a gateway, traffic can be routed to an instance where the repo is inaccessible,
 the embedding model failed to load, or the vector index is corrupt.
 
 A `/readyz` endpoint should check subsystem health and return structured results:
@@ -98,7 +100,8 @@ against a well-defined index abstraction.
 - Public trait for vector storage at the semantic level (name + scope operations)
 - Private trait inside usearch implementation for failure injection testing
 - Usearch-backed implementation of the public trait (refactoring existing code)
-- Config extraction for OAuth client ID
+- OAuth provider abstraction with GitHub as the default concrete implementation
+- Config extraction for provider-specific OAuth parameters (client ID, URLs)
 - Integration test harness for auth CLI subcommands and bind address
 - `/readyz` endpoint with subsystem health checks
 - Health-check capability on the vector storage trait (supports /readyz)
@@ -106,6 +109,8 @@ against a well-defined index abstraction.
 ### Out of scope
 - Alternative index backend implementations beyond test mocks
 - Full config framework (TOML/YAML config files)
+- Non-GitHub OAuth provider implementations (GitLab, etc.) — the abstraction
+  must support them, but only GitHub is built now
 - `/metrics` endpoint (#165) — separate design surface
 - Auth framework redesign (#79, Phase 6)
 - W3C Trace Context (#162, Phase 5)
@@ -127,6 +132,6 @@ against a well-defined index abstraction.
 3. Auth integration tests cover device flow (mocked), status reporting, and
    bind-address override — all run in CI
 4. `/readyz` returns structured health for git repo, embedding model, and vector
-   index; the goddess deployment can adopt it as a readiness probe
+   index; any k8s or gateway deployment can adopt it as a readiness probe
 5. All four items ship cohesively without requiring architectural rework in
    later phases

--- a/docs/design/phase2-quality/problem.md
+++ b/docs/design/phase2-quality/problem.md
@@ -1,0 +1,132 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-24
+phase: 1
+-->
+
+# Problem Space — Phase 2 Quality: Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+## What problem exists today?
+
+memory-mcp has four interconnected quality and operational gaps remaining in
+Phase 2:
+
+### 1. No abstraction boundary for the vector index (#94)
+
+`VectorIndex` and `ScopedIndex` call usearch's `Index` directly. This creates
+two problems:
+
+- **Untestable rollback path.** `ScopedIndex::add` performs a dual-index write
+  (scope index, then all-index). If the all-index insert fails after the scope
+  insert succeeds, it rolls back the scope insert. This rollback is the primary
+  correctness guarantee for the dual-index write pattern, but usearch allocation
+  failures are not injectable — so the path has zero test coverage.
+
+- **No backend substitutability.** The rest of the system (server, MCP handlers,
+  embedding pipeline) is coupled to usearch's API shape. Alternative backends
+  (SQLite-backed, remote vector DB, in-memory for testing) would require
+  rewriting every consumer.
+
+The right fix is a **public trait at the semantic level** — what the system needs
+from "vector storage" (add/remove/search by name and scope, persist, report
+health) — with `VectorIndex`/`ScopedIndex` becoming implementation details of
+a usearch-backed concrete type. A separate, private low-level trait inside the
+usearch implementation enables failure injection for rollback testing.
+
+### 2. Hardcoded OAuth client ID (#145)
+
+`GITHUB_CLIENT_ID` is a `const` in `auth.rs`. This prevents:
+- Testing the OAuth device flow against a mock server (different client ID)
+- Using an alternative OAuth app without recompilation
+- Integration tests that exercise the full auth path
+
+### 3. No integration tests for auth CLI or bind address (#146)
+
+The auth tests in `auth.rs` are unit-level: env var resolution, token file
+storage. They don't cover:
+- `auth login` end-to-end (device flow against a mock OAuth server)
+- `auth status` output correctness
+- `MEMORY_MCP_BIND` environment variable honored by the server
+
+These paths are exercised only manually.
+
+### 4. No readiness signal for orchestrators (#164)
+
+`/healthz` returns 200 if the process is alive. It says nothing about whether
+the server can serve requests. In the goddess cluster (or any deployment behind
+a gateway), traffic can be routed to an instance where the repo is inaccessible,
+the embedding model failed to load, or the vector index is corrupt.
+
+A `/readyz` endpoint should check subsystem health and return structured results:
+- Git repo: working directory accessible, HEAD resolvable
+- Embedding model: loaded, able to produce vectors
+- Vector index: loaded, non-zero dimensions
+
+## Who experiences these problems?
+
+| Actor | Impact |
+|-------|--------|
+| Developers | Cannot test rollback correctness, cannot integration-test auth, cannot confidently refactor the index layer |
+| Operators | Cannot distinguish "process alive" from "service ready" in k8s/gateway deployments |
+| CI pipeline | Has no way to catch auth regressions, bind-address issues, or index abstraction breaks |
+
+## Why now?
+
+Phase 2 is the quality phase. The tracing scaffold landed in v0.8.0, providing
+structured observability across all subsystems. These four items complete the
+"testability and operational readiness" story before Phase 3 (transport) and
+Phase 4 (search improvements).
+
+The index trait (#94) is also a prerequisite for Phase 4 work — ModernBERT
+upgrade (#141) and memory chunking (#140) will be easier to develop and test
+against a well-defined index abstraction.
+
+## Inputs and outputs
+
+| Item | Inputs | Outputs |
+|------|--------|---------|
+| #94 index trait | Embedding vectors, memory names, scopes | Search results, add/remove/save — same operations, behind a trait |
+| #145 config | Config source (env var, CLI flag, compile-time default) | OAuth client ID available to auth module |
+| #146 integration tests | Test harness with mock OAuth server | Pass/fail assertions on auth login, auth status, bind address |
+| #164 /readyz | HTTP GET from orchestrator/gateway | 200 + JSON (ready) or 503 + JSON (which subsystem failed) |
+
+## Boundaries
+
+### In scope
+- Public trait for vector storage at the semantic level (name + scope operations)
+- Private trait inside usearch implementation for failure injection testing
+- Usearch-backed implementation of the public trait (refactoring existing code)
+- Config extraction for OAuth client ID
+- Integration test harness for auth CLI subcommands and bind address
+- `/readyz` endpoint with subsystem health checks
+- Health-check capability on the vector storage trait (supports /readyz)
+
+### Out of scope
+- Alternative index backend implementations beyond test mocks
+- Full config framework (TOML/YAML config files)
+- `/metrics` endpoint (#165) — separate design surface
+- Auth framework redesign (#79, Phase 6)
+- W3C Trace Context (#162, Phase 5)
+
+### Constraints
+- The usearch index path must continue working — the trait is additive
+- `/readyz` must not introduce new dependencies
+- Integration tests must run in CI without real GitHub OAuth
+- The public trait must not preclude fundamentally different backends (SQLite,
+  remote vector DB) — design for substitutability, not just usearch's shape
+- Both testing levels needed: private failure injection for usearch rollback
+  mechanics, and public trait-level error behavior tests
+
+## Success criteria
+
+1. `ScopedIndex::add` rollback path has a direct test via injected failure
+2. The rest of the codebase (server, MCP handlers) programs against the public
+   vector storage trait, not usearch types
+3. Auth integration tests cover device flow (mocked), status reporting, and
+   bind-address override — all run in CI
+4. `/readyz` returns structured health for git repo, embedding model, and vector
+   index; the goddess deployment can adopt it as a readiness probe
+5. All four items ship cohesively without requiring architectural rework in
+   later phases

--- a/docs/design/phase2-quality/requirements.md
+++ b/docs/design/phase2-quality/requirements.md
@@ -61,7 +61,7 @@ Issues: #94, #145, #146, #164
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
 |--------|-------------|-----------|--------------|-----------|
-| R-08 | OAuth device flow parameters (client ID, device code URL, access token URL, scopes) shall be sourced from a `OAuthDeviceFlowProvider` trait, with GitHub as the default implementation | UC-08, UC-13, AC-03 | V14.2 | TC-08 (pending) |
+| R-08 | OAuth device flow parameters (client ID, device code URL, access token URL, scopes) shall be sourced from a `DeviceFlowProvider` trait, with GitHub as the default implementation | UC-08, UC-13, AC-03 | V14.2 | TC-08 (pending) |
 | R-09 | Each provider implementation shall validate its own parameters before use in the auth flow (e.g., client ID format, URL scheme) | AC-03 | V5.1, V14.3 | TC-09 (pending) |
 | R-10 | OAuth device flow endpoint URLs shall only permit HTTPS scheme (except localhost for development/testing) | AC-03 | V5.1, V14.3 | TC-10 (pending) |
 
@@ -119,14 +119,16 @@ Issues: #94, #145, #146, #164
 
 ## Design Notes
 
-- **Provider abstraction scope:** The `OAuthDeviceFlowProvider` trait covers RFC 8628
-  device authorization grant specifically — not all OAuth grant types. This is
-  deliberate: device flow is the right choice for CLI tools, and both GitHub and
-  GitLab support it. If a future provider needs a different grant type (authorization
-  code, API keys), the path is a higher-level `AuthFlow` trait with
-  `OAuthDeviceFlowProvider` as one strategy. See [ADR-0024](../../adr/0024-oauth-device-flow-provider-trait.md)
-  for full analysis. We are implementing the GitHub provider now; GitLab and others
-  are future implementations.
+- **Provider abstraction scope:** The `auth::oauth::DeviceFlowProvider` trait
+  covers RFC 8628 device authorization grant specifically — not all OAuth grant
+  types. The `auth::oauth` module namespace provides the OAuth context, so the
+  trait name doesn't need an `OAuth` prefix. Device flow is the right choice for
+  CLI tools, and both GitHub and GitLab support it. If a future provider needs a
+  different grant type, the path is a higher-level `AuthFlow` trait with
+  `DeviceFlowProvider` as one strategy, alongside sibling modules under `auth/`.
+  See [ADR-0024](../../adr/0024-oauth-device-flow-provider-trait.md) for full
+  analysis. We are implementing the GitHub provider now; GitLab and others are
+  future implementations.
 - **R-09 validation:** GitHub OAuth client IDs follow a known format (`Iv1.` prefix +
   hex characters). GitLab uses a different format. Provider-specific validation belongs
   in each provider's implementation, not in a universal rule.

--- a/docs/design/phase2-quality/requirements.md
+++ b/docs/design/phase2-quality/requirements.md
@@ -49,44 +49,44 @@ Issues: #94, #145, #146, #164
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
 |--------|-------------|-----------|--------------|-----------|
-| R-01 | System shall define a public `VectorStore` trait with operations: add (name, scope, vector), remove (name, scope), search (query, scope filter, limit), save, load, health check | UC-01, UC-02, UC-03 | V1.1 | TC-01 (pending) |
-| R-02 | The usearch-backed implementation shall preserve all existing behavior — add, remove, search, scoped retrieval, save/load round-trip, upsert semantics | UC-01, UC-02, UC-03 | — | TC-02 (pending) |
-| R-03 | The usearch implementation shall use a private internal trait for raw index operations to allow failure injection | UC-11 | V1.1 | TC-03 (pending) |
-| R-04 | When the all-index insert fails after a scope-index insert succeeds, the scope insert shall be rolled back, restoring the index to its pre-call state | UC-04, UC-11 | V7.1 | TC-04 (pending) |
-| R-05 | Errors from the vector storage trait shall propagate as typed errors without exposing backend-specific details to callers | UC-04 | V7.2, A.8.11 | TC-05 (pending) |
-| R-06 | The `VectorStore` trait shall include a readiness method that reports whether the backend can serve queries | UC-05, UC-12 | V13.1 | TC-06 (pending) |
-| R-07 | Consumer code (server, MCP handlers) shall program against the `VectorStore` trait, not concrete usearch types | UC-03 | V1.1 | TC-07 (pending) |
+| R-01 | System shall define a public `VectorStore` trait with operations: add (name, scope, vector), remove (name, scope), search (query, scope filter, limit), save, load, health check | UC-01, UC-02, UC-03 | V1.1 | TC-01 |
+| R-02 | The usearch-backed implementation shall preserve all existing behavior — add, remove, search, scoped retrieval, save/load round-trip, upsert semantics | UC-01, UC-02, UC-03 | — | TC-02a–e |
+| R-03 | The usearch implementation shall use a private internal trait for raw index operations to allow failure injection | UC-11 | V1.1 | TC-03 |
+| R-04 | When the all-index insert fails after a scope-index insert succeeds, the scope insert shall be rolled back, restoring the index to its pre-call state | UC-04, UC-11 | V7.1 | TC-04a–b |
+| R-05 | Errors from the vector storage trait shall propagate as typed errors without exposing backend-specific details to callers | UC-04 | V7.2, A.8.11 | TC-05a–c |
+| R-06 | The `VectorStore` trait shall include a readiness method that reports whether the backend can serve queries | UC-05, UC-12 | V13.1 | TC-06a–b |
+| R-07 | Consumer code (server, MCP handlers) shall program against the `VectorStore` trait, not concrete usearch types | UC-03 | V1.1 | TC-07 |
 
 ### OAuth device flow provider abstraction (#145)
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
 |--------|-------------|-----------|--------------|-----------|
-| R-08 | OAuth device flow parameters (client ID, device code URL, access token URL, scopes) shall be sourced from a `DeviceFlowProvider` trait, with GitHub as the default implementation | UC-08, UC-13, AC-03 | V14.2 | TC-08 (pending) |
-| R-09 | Each provider implementation shall validate its own parameters before use in the auth flow (e.g., client ID format, URL scheme) | AC-03 | V5.1, V14.3 | TC-09 (pending) |
-| R-10 | OAuth device flow endpoint URLs shall only permit HTTPS scheme (except localhost for development/testing) | AC-03 | V5.1, V14.3 | TC-10 (pending) |
+| R-08 | OAuth device flow parameters (client ID, device code URL, access token URL, scopes) shall be sourced from a `DeviceFlowProvider` trait, with GitHub as the default implementation | UC-08, UC-13, AC-03 | V14.2 | TC-08a–b |
+| R-09 | Each provider implementation shall validate its own parameters before use in the auth flow (e.g., client ID format, URL scheme) | AC-03 | V5.1, V14.3 | TC-09a–c |
+| R-10 | OAuth device flow endpoint URLs shall only permit HTTPS scheme (except localhost for development/testing) | AC-03 | V5.1, V14.3 | TC-10a–c |
 
 ### Integration tests (#146)
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
 |--------|-------------|-----------|--------------|-----------|
-| R-11 | Integration tests shall exercise `auth login` against a mock OAuth server that implements the device flow protocol | UC-08 | — | TC-11 (pending) |
-| R-12 | Integration tests shall verify `auth status` reports correct token source and provenance | UC-09 | — | TC-12 (pending) |
-| R-13 | Integration tests shall verify the server binds to the address specified by `MEMORY_MCP_BIND` | UC-10 | — | TC-13 (pending) |
-| R-14 | Integration tests shall run in CI without real OAuth credentials from any provider | UC-08, UC-11 | — | TC-14 (pending) |
+| R-11 | Integration tests shall exercise `auth login` against a mock OAuth server that implements the device flow protocol | UC-08 | — | TC-11a–c |
+| R-12 | Integration tests shall verify `auth status` reports correct token source and provenance | UC-09 | — | TC-12a–b |
+| R-13 | Integration tests shall verify the server binds to the address specified by `MEMORY_MCP_BIND` | UC-10 | — | TC-13 |
+| R-14 | Integration tests shall run in CI without real OAuth credentials from any provider | UC-08, UC-11 | — | TC-14 |
 
 ### Health endpoint (#164)
 
 | Req ID | Requirement | Source UC | Security Ref | Test Case |
 |--------|-------------|-----------|--------------|-----------|
-| R-15 | `/readyz` shall return 200 with a JSON body when all subsystems are healthy | UC-05, UC-07 | V13.1 | TC-15 (pending) |
-| R-16 | `/readyz` shall return 503 with a JSON body identifying which subsystem(s) failed when any check fails | UC-06, UC-07 | V13.1, A.8.16 | TC-16 (pending) |
-| R-17 | `/readyz` shall check: git repo accessible and valid (must work for empty repos with no commits), embedding-index dimensional consistency (`embedding.dimensions() == index.dimensions()`), vector index ready (via trait readiness method) | UC-05, UC-06 | A.8.16 | TC-17 (pending) |
-| R-18 | `/readyz` response shall not include internal file paths, version strings, error stack traces, or backend-specific details | AC-01, SC-01 | V7.4, A.8.11 | TC-18 (pending) |
-| R-19 | `/readyz` health checks shall be lightweight — status queries only, no embedding generation, no index scans | AC-02, SC-02 | V13.4 | TC-19 (pending) |
-| R-20 | `/readyz` failures shall be logged at warn level with subsystem detail via the existing tracing infrastructure | UC-06 | V7.1, A.8.15 | TC-20 (pending) |
-| R-21 | Remote sync unavailability shall not affect readiness by default; an opt-in flag (e.g., `--require-remote-sync`) shall make remote reachability a readiness condition | UC-05, UC-07 | V14.2 | TC-21 (pending) |
-| R-22 | `/readyz` shall be protected against sustained flooding — either via an in-process rate limiter or documented operator responsibility for network-level rate limiting | AC-02 | V13.4 | TC-22 (pending) |
-| R-23 | When `--require-remote-sync` is enabled, the remote reachability check shall cache its result with a short TTL (5–30 seconds) rather than making a fresh outbound call per request | AC-02 | V13.4 | TC-23 (pending) |
+| R-15 | `/readyz` shall return 200 with a JSON body when all subsystems are healthy | UC-05, UC-07 | V13.1 | TC-15 |
+| R-16 | `/readyz` shall return 503 with a JSON body identifying which subsystem(s) failed when any check fails | UC-06, UC-07 | V13.1, A.8.16 | TC-16a–c |
+| R-17 | `/readyz` shall check: git repo accessible and valid (must work for empty repos with no commits), embedding-index dimensional consistency (`embedding.dimensions() == index.dimensions()`), vector index ready (via trait readiness method) | UC-05, UC-06 | A.8.16 | TC-17a–c |
+| R-18 | `/readyz` response shall not include internal file paths, version strings, error stack traces, or backend-specific details | AC-01, SC-01 | V7.4, A.8.11 | TC-18a–b |
+| R-19 | `/readyz` health checks shall be lightweight — status queries only, no embedding generation, no index scans | AC-02, SC-02 | V13.4 | TC-19 |
+| R-20 | `/readyz` failures shall be logged at warn level with subsystem detail via the existing tracing infrastructure | UC-06 | V7.1, A.8.15 | TC-20 |
+| R-21 | Remote sync unavailability shall not affect readiness by default; an opt-in flag (e.g., `--require-remote-sync`) shall make remote reachability a readiness condition | UC-05, UC-07 | V14.2 | TC-21a–b |
+| R-22 | `/readyz` shall be protected against sustained flooding — either via an in-process rate limiter or documented operator responsibility for network-level rate limiting | AC-02 | V13.4 | TC-22 |
+| R-23 | When `--require-remote-sync` is enabled, the remote reachability check shall cache its result with a short TTL (5–30 seconds) rather than making a fresh outbound call per request | AC-02 | V13.4 | TC-23 |
 
 ## ASVS & ISO 27001 Review
 

--- a/docs/design/phase2-quality/requirements.md
+++ b/docs/design/phase2-quality/requirements.md
@@ -85,6 +85,8 @@ Issues: #94, #145, #146, #164
 | R-19 | `/readyz` health checks shall be lightweight — status queries only, no embedding generation, no index scans | AC-02, SC-02 | V13.4 | TC-19 (pending) |
 | R-20 | `/readyz` failures shall be logged at warn level with subsystem detail via the existing tracing infrastructure | UC-06 | V7.1, A.8.15 | TC-20 (pending) |
 | R-21 | Remote sync unavailability shall not affect readiness by default; an opt-in flag (e.g., `--require-remote-sync`) shall make remote reachability a readiness condition | UC-05, UC-07 | V14.2 | TC-21 (pending) |
+| R-22 | `/readyz` shall be protected against sustained flooding — either via an in-process rate limiter or documented operator responsibility for network-level rate limiting | AC-02 | V13.4 | TC-22 (pending) |
+| R-23 | When `--require-remote-sync` is enabled, the remote reachability check shall cache its result with a short TTL (5–30 seconds) rather than making a fresh outbound call per request | AC-02 | V13.4 | TC-23 (pending) |
 
 ## ASVS & ISO 27001 Review
 

--- a/docs/design/phase2-quality/requirements.md
+++ b/docs/design/phase2-quality/requirements.md
@@ -1,0 +1,139 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-04-25
+phase: 2
+-->
+
+# Requirements — Phase 2 Quality: Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+## Use Cases
+
+### Actors
+
+| Actor | Description |
+|-------|-------------|
+| MCP Client | AI agent or tool calling memory operations via MCP |
+| Operator | Person or system deploying/monitoring memory-mcp |
+| Developer | Contributor writing or running tests against the codebase |
+| Attacker | Malicious actor with network access to the HTTP endpoint |
+
+### Use case table
+
+| ID | Actor | Use Case | Type | Priority |
+|----|-------|----------|------|----------|
+| UC-01 | MCP Client | Store a memory and retrieve it by semantic similarity | Normal | Must |
+| UC-02 | MCP Client | Remove a memory and have it disappear from search results | Normal | Must |
+| UC-03 | MCP Client | Get correct results regardless of which backend implements the index | Normal | Must |
+| UC-04 | MCP Client | Receive a meaningful error when a vector operation fails | Normal | Must |
+| UC-05 | Operator | Query /readyz to determine if the service can handle requests | Normal | Must |
+| UC-06 | Operator | See which specific subsystem is unhealthy when /readyz returns 503 | Normal | Must |
+| UC-07 | Operator | Use /readyz as a k8s readiness probe (HTTP GET, status code contract) | Normal | Must |
+| UC-08 | Developer | Run integration tests for auth login against a mock OAuth server | Normal | Must |
+| UC-09 | Developer | Run integration tests for auth status reporting | Normal | Must |
+| UC-10 | Developer | Run integration tests for MEMORY_MCP_BIND override | Normal | Must |
+| UC-11 | Developer | Inject index backend failures to test rollback correctness | Normal | Must |
+| UC-12 | Developer | Substitute the index backend for fast, deterministic tests | Normal | Should |
+| UC-13 | Operator | Configure an alternative device flow provider (e.g., GitLab) for auth | Normal | Should |
+| AC-01 | Attacker | Probe /readyz to fingerprint subsystem versions or internal state | Abuse | Must-mitigate |
+| AC-02 | Attacker | Flood /readyz to cause resource exhaustion via expensive health checks | Abuse | Must-mitigate |
+| AC-03 | Attacker | Supply a crafted device flow provider config to redirect auth flow | Abuse | Must-mitigate |
+| SC-01 | System | Health checks must not expose internal paths, versions, or error details | Security | Must |
+| SC-02 | System | Health checks must be lightweight — no full index scans or embedding runs | Security | Must |
+| SC-03 | System | OAuth device flow provider config must validate parameters before use | Security | Should |
+
+## Requirements
+
+### Vector storage trait (#94)
+
+| Req ID | Requirement | Source UC | Security Ref | Test Case |
+|--------|-------------|-----------|--------------|-----------|
+| R-01 | System shall define a public `VectorStore` trait with operations: add (name, scope, vector), remove (name, scope), search (query, scope filter, limit), save, load, health check | UC-01, UC-02, UC-03 | V1.1 | TC-01 (pending) |
+| R-02 | The usearch-backed implementation shall preserve all existing behavior — add, remove, search, scoped retrieval, save/load round-trip, upsert semantics | UC-01, UC-02, UC-03 | — | TC-02 (pending) |
+| R-03 | The usearch implementation shall use a private internal trait for raw index operations to allow failure injection | UC-11 | V1.1 | TC-03 (pending) |
+| R-04 | When the all-index insert fails after a scope-index insert succeeds, the scope insert shall be rolled back, restoring the index to its pre-call state | UC-04, UC-11 | V7.1 | TC-04 (pending) |
+| R-05 | Errors from the vector storage trait shall propagate as typed errors without exposing backend-specific details to callers | UC-04 | V7.2, A.8.11 | TC-05 (pending) |
+| R-06 | The `VectorStore` trait shall include a readiness method that reports whether the backend can serve queries | UC-05, UC-12 | V13.1 | TC-06 (pending) |
+| R-07 | Consumer code (server, MCP handlers) shall program against the `VectorStore` trait, not concrete usearch types | UC-03 | V1.1 | TC-07 (pending) |
+
+### OAuth device flow provider abstraction (#145)
+
+| Req ID | Requirement | Source UC | Security Ref | Test Case |
+|--------|-------------|-----------|--------------|-----------|
+| R-08 | OAuth device flow parameters (client ID, device code URL, access token URL, scopes) shall be sourced from a `OAuthDeviceFlowProvider` trait, with GitHub as the default implementation | UC-08, UC-13, AC-03 | V14.2 | TC-08 (pending) |
+| R-09 | Each provider implementation shall validate its own parameters before use in the auth flow (e.g., client ID format, URL scheme) | AC-03 | V5.1, V14.3 | TC-09 (pending) |
+| R-10 | OAuth device flow endpoint URLs shall only permit HTTPS scheme (except localhost for development/testing) | AC-03 | V5.1, V14.3 | TC-10 (pending) |
+
+### Integration tests (#146)
+
+| Req ID | Requirement | Source UC | Security Ref | Test Case |
+|--------|-------------|-----------|--------------|-----------|
+| R-11 | Integration tests shall exercise `auth login` against a mock OAuth server that implements the device flow protocol | UC-08 | — | TC-11 (pending) |
+| R-12 | Integration tests shall verify `auth status` reports correct token source and provenance | UC-09 | — | TC-12 (pending) |
+| R-13 | Integration tests shall verify the server binds to the address specified by `MEMORY_MCP_BIND` | UC-10 | — | TC-13 (pending) |
+| R-14 | Integration tests shall run in CI without real OAuth credentials from any provider | UC-08, UC-11 | — | TC-14 (pending) |
+
+### Health endpoint (#164)
+
+| Req ID | Requirement | Source UC | Security Ref | Test Case |
+|--------|-------------|-----------|--------------|-----------|
+| R-15 | `/readyz` shall return 200 with a JSON body when all subsystems are healthy | UC-05, UC-07 | V13.1 | TC-15 (pending) |
+| R-16 | `/readyz` shall return 503 with a JSON body identifying which subsystem(s) failed when any check fails | UC-06, UC-07 | V13.1, A.8.16 | TC-16 (pending) |
+| R-17 | `/readyz` shall check: git repo accessible (HEAD resolvable), embedding model loaded, vector index ready (via trait readiness method) | UC-05, UC-06 | A.8.16 | TC-17 (pending) |
+| R-18 | `/readyz` response shall not include internal file paths, version strings, error stack traces, or backend-specific details | AC-01, SC-01 | V7.4, A.8.11 | TC-18 (pending) |
+| R-19 | `/readyz` health checks shall be lightweight — status queries only, no embedding generation, no index scans | AC-02, SC-02 | V13.4 | TC-19 (pending) |
+| R-20 | `/readyz` failures shall be logged at warn level with subsystem detail via the existing tracing infrastructure | UC-06 | V7.1, A.8.15 | TC-20 (pending) |
+
+## ASVS & ISO 27001 Review
+
+### Applicable categories
+
+| Framework | Category | Relevance |
+|-----------|----------|-----------|
+| ASVS V1 | Architecture, design, threat modeling | The public trait boundary is a trust boundary between consumers and backend internals |
+| ASVS V5 | Validation, sanitization, encoding | Provider config input validation, /readyz response sanitization |
+| ASVS V7 | Error handling, logging | Error propagation through the trait, health check failure reporting and logging |
+| ASVS V13 | API and web services | /readyz is a new HTTP endpoint with a status code contract |
+| ASVS V14 | Configuration | OAuth provider config extraction and validation |
+| ISO A.8.11 | Data masking | /readyz must not leak internal paths or state details |
+| ISO A.8.15 | Logging | Health check failures logged for operational awareness |
+| ISO A.8.16 | Monitoring activities | /readyz is the monitoring surface itself |
+
+### Not applicable
+
+| Framework | Category | Rationale |
+|-----------|----------|-----------|
+| ASVS V2 | Authentication | Not changing auth mechanics — extracting config and adding provider abstraction |
+| ASVS V3 | Session management | No session changes |
+| ASVS V6 | Stored cryptography | No crypto changes |
+| ASVS V8 | Data protection | No new sensitive data handling |
+| ASVS V9 | Communication | No transport changes |
+| ASVS V10 | Malicious code / supply chain | No new dependencies |
+| ASVS V11 | Business logic | No business logic changes |
+| ASVS V12 | Files and resources | No file upload or resource handling changes |
+| ISO A.5.33 | Protection of records | No new audit/log record types beyond existing tracing |
+| ISO A.8.10 | Information deletion | No data lifecycle changes |
+| ISO A.8.12 | Data leakage prevention | Covered by A.8.11 for /readyz |
+| ISO A.8.17 | Clock synchronization | No timestamp changes |
+
+## Design Notes
+
+- **Provider abstraction scope:** The `OAuthDeviceFlowProvider` trait covers RFC 8628
+  device authorization grant specifically — not all OAuth grant types. This is
+  deliberate: device flow is the right choice for CLI tools, and both GitHub and
+  GitLab support it. If a future provider needs a different grant type (authorization
+  code, API keys), the path is a higher-level `AuthFlow` trait with
+  `OAuthDeviceFlowProvider` as one strategy. See [ADR-0024](../../adr/0024-oauth-device-flow-provider-trait.md)
+  for full analysis. We are implementing the GitHub provider now; GitLab and others
+  are future implementations.
+- **R-09 validation:** GitHub OAuth client IDs follow a known format (`Iv1.` prefix +
+  hex characters). GitLab uses a different format. Provider-specific validation belongs
+  in each provider's implementation, not in a universal rule.
+- **R-06 as the bridge:** The trait's readiness method is how /readyz checks vector
+  index health without reaching into usearch internals. This is the key connection
+  between #94 and #164.
+- **Rollback testing at two levels:** R-03 enables private failure injection to test
+  the usearch implementation's internal rollback mechanics. R-05 enables public
+  trait-level tests to verify error behavior regardless of backend — both are needed
+  and test different things.

--- a/docs/design/phase2-quality/requirements.md
+++ b/docs/design/phase2-quality/requirements.md
@@ -80,10 +80,11 @@ Issues: #94, #145, #146, #164
 |--------|-------------|-----------|--------------|-----------|
 | R-15 | `/readyz` shall return 200 with a JSON body when all subsystems are healthy | UC-05, UC-07 | V13.1 | TC-15 (pending) |
 | R-16 | `/readyz` shall return 503 with a JSON body identifying which subsystem(s) failed when any check fails | UC-06, UC-07 | V13.1, A.8.16 | TC-16 (pending) |
-| R-17 | `/readyz` shall check: git repo accessible (HEAD resolvable), embedding model loaded, vector index ready (via trait readiness method) | UC-05, UC-06 | A.8.16 | TC-17 (pending) |
+| R-17 | `/readyz` shall check: git repo accessible and valid (must work for empty repos with no commits), embedding-index dimensional consistency (`embedding.dimensions() == index.dimensions()`), vector index ready (via trait readiness method) | UC-05, UC-06 | A.8.16 | TC-17 (pending) |
 | R-18 | `/readyz` response shall not include internal file paths, version strings, error stack traces, or backend-specific details | AC-01, SC-01 | V7.4, A.8.11 | TC-18 (pending) |
 | R-19 | `/readyz` health checks shall be lightweight — status queries only, no embedding generation, no index scans | AC-02, SC-02 | V13.4 | TC-19 (pending) |
 | R-20 | `/readyz` failures shall be logged at warn level with subsystem detail via the existing tracing infrastructure | UC-06 | V7.1, A.8.15 | TC-20 (pending) |
+| R-21 | Remote sync unavailability shall not affect readiness by default; an opt-in flag (e.g., `--require-remote-sync`) shall make remote reachability a readiness condition | UC-05, UC-07 | V14.2 | TC-21 (pending) |
 
 ## ASVS & ISO 27001 Review
 

--- a/docs/design/phase2-quality/test-plan.md
+++ b/docs/design/phase2-quality/test-plan.md
@@ -1,5 +1,5 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-25
 phase: 5
 -->
@@ -24,68 +24,68 @@ real git remote, no network access).
 
 ### Vector storage trait (#94)
 
-| Test ID | Req | Type | Description | Automated |
-|---------|-----|------|-------------|-----------|
-| TC-01 | R-01 | Compile-time | `VectorStore` trait is public, object-safe, and defines all required methods (add, remove, search, save, load, is_ready, find_by_name, dimensions, commit_sha/set_commit_sha). Verified by compiling `Box<dyn VectorStore>` in AppState. | Yes |
-| TC-02a | R-02 | Unit | `UsearchStore::add` followed by `search` returns the added entry with correct name and scope | Yes |
-| TC-02b | R-02 | Unit | `UsearchStore::remove` makes the entry unreachable via `search` and `find_by_name` | Yes |
-| TC-02c | R-02 | Unit | `UsearchStore::add` with an existing name replaces the old entry (upsert semantics) | Yes |
-| TC-02d | R-02 | Unit | `UsearchStore::search` with scope filter returns only entries matching that scope plus global | Yes |
-| TC-02e | R-02 | Integration | `UsearchStore::save` then `UsearchStore::load` round-trips all entries, names, scopes, and commit SHA | Yes |
-| TC-03 | R-03 | Unit | `UsearchStore` can be constructed with a `FailingRawIndex` that implements the private `RawIndex` trait. The test compiles and the failing backend is injectable. | Yes |
-| TC-04a | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: `UsearchStore::add` returns an error, and the scope index is unchanged (entry count before == entry count after) | Yes |
-| TC-04b | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: a previously existing entry with the same name is not corrupted by the failed upsert | Yes |
-| TC-05a | R-05 | Unit | When `UsearchStore::add` fails, the returned error is a `MemoryError` variant, not a usearch-specific type | Yes |
-| TC-05b | R-05 | Unit | Error `Display` output does not contain usearch crate paths, internal key IDs, or file system paths | Yes |
-| TC-05c | R-05 | Unit | `InMemoryStore` returns the same `MemoryError` variants for equivalent failure conditions | Yes |
-| TC-06a | R-06 | Unit | `UsearchStore::is_ready()` returns ready after successful construction and load | Yes |
-| TC-06b | R-06 | Unit | `InMemoryStore::is_ready()` returns ready after construction | Yes |
-| TC-07 | R-07 | Compile-time | `AppState.index` is `Box<dyn VectorStore>`. MCP handler code in `server.rs` references only `VectorStore` trait methods — no direct import of `UsearchStore`, `ScopedIndex`, or `VectorIndex`. Verified by grep + compilation. | Yes |
+| Test ID | Req | Type | Description |
+|---------|-----|------|-------------|
+| TC-01 | R-01 | Compile-time | `VectorStore` trait is public, object-safe, and defines all required methods (add, remove, search, save, load, is_ready, find_by_name, dimensions, commit_sha/set_commit_sha). Verified by compiling `Box<dyn VectorStore>` in AppState. |
+| TC-02a | R-02 | Unit | `UsearchStore::add` followed by `search` returns the added entry with correct name and scope |
+| TC-02b | R-02 | Unit | `UsearchStore::remove` makes the entry unreachable via `search` and `find_by_name` |
+| TC-02c | R-02 | Unit | `UsearchStore::add` with an existing name replaces the old entry (upsert semantics) |
+| TC-02d | R-02 | Unit | `UsearchStore::search` with scope filter returns only entries matching that scope plus global |
+| TC-02e | R-02 | Integration | `UsearchStore::save` then `UsearchStore::load` round-trips all entries, names, scopes, and commit SHA |
+| TC-03 | R-03 | Unit | `UsearchStore` can be constructed with a `FailingRawIndex` that implements the private `RawIndex` trait. The test compiles and the failing backend is injectable. |
+| TC-04a | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: `UsearchStore::add` returns an error, and the scope index is unchanged (entry count before == entry count after) |
+| TC-04b | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: a previously existing entry with the same name is not corrupted by the failed upsert |
+| TC-05a | R-05 | Unit | When `UsearchStore::add` fails, the returned error is a `MemoryError` variant, not a usearch-specific type |
+| TC-05b | R-05 | Unit | Error `Display` output does not contain usearch crate paths, internal key IDs, or file system paths |
+| TC-05c | R-05 | Unit | `InMemoryStore` returns the same `MemoryError` variants for equivalent failure conditions |
+| TC-06a | R-06 | Unit | `UsearchStore::is_ready()` returns ready after successful construction and load |
+| TC-06b | R-06 | Unit | `InMemoryStore::is_ready()` returns ready after construction |
+| TC-07 | R-07 | Compile-time | `AppState.index` is `Box<dyn VectorStore>`. MCP handler code in `server.rs` references only `VectorStore` trait methods — no direct import of `UsearchStore`, `ScopedIndex`, or `VectorIndex`. Verified by grep + compilation. |
 
 ### Device flow provider abstraction (#145)
 
-| Test ID | Req | Type | Description | Automated |
-|---------|-----|------|-------------|-----------|
-| TC-08a | R-08 | Unit | `GitHubDeviceFlow` implements `DeviceFlowProvider` and returns expected client ID, URLs, and scopes | Yes |
-| TC-08b | R-08 | Unit | `device_flow_login()` accepts `&dyn DeviceFlowProvider` — compiles with both `GitHubDeviceFlow` and `MockDeviceFlow` | Yes |
-| TC-09a | R-09 | Unit | `GitHubDeviceFlow::validate()` returns `Ok(())` (its constants are valid) | Yes |
-| TC-09b | R-09 | Unit | A `DeviceFlowProvider` with an empty client ID fails `validate()` | Yes |
-| TC-09c | R-09 | Unit | A `DeviceFlowProvider` with a malformed client ID (wrong format for the provider) fails `validate()` | Yes |
-| TC-10a | R-10 | Unit | A `DeviceFlowProvider` with `http://` device code URL fails `validate()` | Yes |
-| TC-10b | R-10 | Unit | A `DeviceFlowProvider` with `http://localhost` device code URL passes `validate()` (dev exception) | Yes |
-| TC-10c | R-10 | Unit | A `DeviceFlowProvider` with `https://` URLs passes `validate()` | Yes |
+| Test ID | Req | Type | Description |
+|---------|-----|------|-------------|
+| TC-08a | R-08 | Unit | `GitHubDeviceFlow` implements `DeviceFlowProvider` and returns expected client ID, URLs, and scopes |
+| TC-08b | R-08 | Unit | `device_flow_login()` accepts `&dyn DeviceFlowProvider` — compiles with both `GitHubDeviceFlow` and `MockDeviceFlow` |
+| TC-09a | R-09 | Unit | `GitHubDeviceFlow::validate()` returns `Ok(())` (its constants are valid) |
+| TC-09b | R-09 | Unit | A `DeviceFlowProvider` with an empty client ID fails `validate()` |
+| TC-09c | R-09 | Unit | A `DeviceFlowProvider` with a malformed client ID (wrong format for the provider) fails `validate()` |
+| TC-10a | R-10 | Unit | A `DeviceFlowProvider` with `http://` device code URL fails `validate()` |
+| TC-10b | R-10 | Unit | A `DeviceFlowProvider` with `http://localhost` device code URL passes `validate()` (dev exception) |
+| TC-10c | R-10 | Unit | A `DeviceFlowProvider` with `https://` URLs passes `validate()` |
 
 ### Integration tests (#146)
 
-| Test ID | Req | Type | Description | Automated |
-|---------|-----|------|-------------|-----------|
-| TC-11a | R-11 | Integration | Start a mock OAuth server on an ephemeral port. Create a `MockDeviceFlow` pointing at it. Call `device_flow_login()` with the mock provider. The mock server receives the device code request with the mock client ID and scopes, returns a device code response, then returns an access token on the next poll. Verify the token is stored. | Yes |
-| TC-11b | R-11 | Integration | Mock OAuth server returns `authorization_pending` for 2 polls, then returns the token. Verify `device_flow_login()` retries and succeeds. | Yes |
-| TC-11c | R-11 | Integration | Mock OAuth server returns `access_denied`. Verify `device_flow_login()` returns an appropriate error. | Yes |
-| TC-12a | R-12 | Integration | Set `MEMORY_MCP_GITHUB_TOKEN` env var, call `auth status` logic, verify output reports token source as environment variable | Yes |
-| TC-12b | R-12 | Integration | Write a token to the token file path, call `auth status` logic, verify output reports token source as file | Yes |
-| TC-13 | R-13 | Integration | Set `MEMORY_MCP_BIND=127.0.0.1:<ephemeral>`, start the server, verify it listens on the specified address by connecting to it | Yes |
-| TC-14 | R-14 | Compile-time + CI | All integration tests in this group pass in CI without `MEMORY_MCP_GITHUB_TOKEN` set and without network access to github.com. Verified by CI environment configuration. | Yes |
+| Test ID | Req | Type | Description |
+|---------|-----|------|-------------|
+| TC-11a | R-11 | Integration | Start a mock OAuth server on an ephemeral port. Create a `MockDeviceFlow` pointing at it. Call `device_flow_login()` with the mock provider. The mock server receives the device code request with the mock client ID and scopes, returns a device code response, then returns an access token on the next poll. Verify the token is stored. |
+| TC-11b | R-11 | Integration | Mock OAuth server returns `authorization_pending` for 2 polls, then returns the token. Verify `device_flow_login()` retries and succeeds. |
+| TC-11c | R-11 | Integration | Mock OAuth server returns `access_denied`. Verify `device_flow_login()` returns an appropriate error. |
+| TC-12a | R-12 | Integration | Set `MEMORY_MCP_GITHUB_TOKEN` env var, call `auth status` logic, verify output reports token source as environment variable |
+| TC-12b | R-12 | Integration | Write a token to the token file path, call `auth status` logic, verify output reports token source as file |
+| TC-13 | R-13 | Integration | Set `MEMORY_MCP_BIND=127.0.0.1:<ephemeral>`, start the server, verify it listens on the specified address by connecting to it |
+| TC-14 | R-14 | Compile-time + CI | All integration tests in this group pass in CI without `MEMORY_MCP_GITHUB_TOKEN` set and without network access to github.com. Verified by CI environment configuration. |
 
 ### Health endpoint (#164)
 
-| Test ID | Req | Type | Description | Automated |
-|---------|-----|------|-------------|-----------|
-| TC-15 | R-15 | Integration | Start server with healthy subsystems. `GET /readyz` returns 200 with JSON body containing `"status":"ready"` and per-subsystem `"status":"up"` | Yes |
-| TC-16a | R-16 | Integration | Start server with a `VectorStore` that reports not-ready. `GET /readyz` returns 503 with JSON body containing `"status":"not_ready"` and the vector index check showing `"status":"down"` with a reason string | Yes |
-| TC-16b | R-16 | Integration | Start server with an inaccessible git repo. `GET /readyz` returns 503 with the git repo check showing `"status":"down"` | Yes |
-| TC-16c | R-16 | Integration | Start server with mismatched embedding/index dimensions. `GET /readyz` returns 503 with embedding check showing `"status":"down"` | Yes |
-| TC-17a | R-17 | Integration | Start server with a freshly initialized empty git repo (no commits). `GET /readyz` returns 200 — the git repo check passes for empty repos | Yes |
-| TC-17b | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 384. `GET /readyz` shows embedding check as `"up"` | Yes |
-| TC-17c | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 768. `GET /readyz` shows embedding check as `"down"` with dimensional mismatch reason | Yes |
-| TC-18a | R-18 | Integration | `GET /readyz` response body (both 200 and 503 cases) does not contain any absolute file path patterns (`/home/`, `/var/`, `/tmp/`) | Yes |
-| TC-18b | R-18 | Integration | `GET /readyz` 503 response body reason fields match a known allowlist of strings (no free-form error messages) | Yes |
-| TC-19 | R-19 | Unit | The readyz handler calls only `is_accessible()` on repo, `dimensions()` on embedding and index, and `is_ready()` on VectorStore. Verified by inspection + mock implementations that panic if embed() or search() are called during a readyz check. | Yes |
-| TC-20 | R-20 | Integration | Start server with a failing subsystem. `GET /readyz` returns 503. Captured tracing events include a warn-level event naming the failed subsystem. Uses in-memory span capture from the tracing test infrastructure. | Yes |
-| TC-21a | R-21 | Integration | Start server without `--require-remote-sync`, with no git remote configured. `GET /readyz` returns 200. | Yes |
-| TC-21b | R-21 | Integration | Start server with `--require-remote-sync`, with no reachable git remote. `GET /readyz` returns 503 with remote sync check showing `"down"`. | Yes |
-| TC-22 | R-22 | Integration | Send 100 rapid `GET /readyz` requests. If in-process rate limiting is chosen: verify that requests beyond the limit receive 429 or are dropped. If operator-documented: verify the documentation exists and the endpoint functions normally (test serves as a baseline performance assertion). | Yes |
-| TC-23 | R-23 | Integration | Start server with `--require-remote-sync` and a mock git remote. Send two `GET /readyz` requests within 1 second. Verify the mock remote received at most one connection attempt (second request used cached result). | Yes |
+| Test ID | Req | Type | Description |
+|---------|-----|------|-------------|
+| TC-15 | R-15 | Integration | Start server with healthy subsystems. `GET /readyz` returns 200 with JSON body containing `"status":"ready"` and per-subsystem `"status":"up"` |
+| TC-16a | R-16 | Integration | Start server with a `VectorStore` that reports not-ready. `GET /readyz` returns 503 with JSON body containing `"status":"not_ready"` and the vector index check showing `"status":"down"` with a reason string |
+| TC-16b | R-16 | Integration | Start server with an inaccessible git repo. `GET /readyz` returns 503 with the git repo check showing `"status":"down"` |
+| TC-16c | R-16 | Integration | Start server with mismatched embedding/index dimensions. `GET /readyz` returns 503 with embedding check showing `"status":"down"` |
+| TC-17a | R-17 | Integration | Start server with a freshly initialized empty git repo (no commits). `GET /readyz` returns 200 — the git repo check passes for empty repos |
+| TC-17b | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 384. `GET /readyz` shows embedding check as `"up"` |
+| TC-17c | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 768. `GET /readyz` shows embedding check as `"down"` with dimensional mismatch reason |
+| TC-18a | R-18 | Integration | `GET /readyz` response body (both 200 and 503 cases) does not contain any absolute file path patterns (`/home/`, `/var/`, `/tmp/`) |
+| TC-18b | R-18 | Integration | `GET /readyz` 503 response body reason fields match a known allowlist of strings (no free-form error messages) |
+| TC-19 | R-19 | Unit | The readyz handler calls only `is_accessible()` on repo, `dimensions()` on embedding and index, and `is_ready()` on VectorStore. Verified by inspection + mock implementations that panic if embed() or search() are called during a readyz check. |
+| TC-20 | R-20 | Integration | Start server with a failing subsystem. `GET /readyz` returns 503. Captured tracing events include a warn-level event naming the failed subsystem. Uses in-memory span capture from the tracing test infrastructure. |
+| TC-21a | R-21 | Integration | Start server without `--require-remote-sync`, with no git remote configured. `GET /readyz` returns 200. |
+| TC-21b | R-21 | Integration | Start server with `--require-remote-sync`, with no reachable git remote. `GET /readyz` returns 503 with remote sync check showing `"down"`. |
+| TC-22 | R-22 | Integration | Send 100 rapid `GET /readyz` requests. If in-process rate limiting is chosen: verify that requests beyond the limit receive 429 or are dropped. If operator-documented: verify the documentation exists and the endpoint functions normally (test serves as a baseline performance assertion). |
+| TC-23 | R-23 | Integration | Start server with `--require-remote-sync` and a mock git remote. Send two `GET /readyz` requests within 1 second. Verify the mock remote received at most one connection attempt (second request used cached result). |
 
 ## Test Infrastructure
 

--- a/docs/design/phase2-quality/test-plan.md
+++ b/docs/design/phase2-quality/test-plan.md
@@ -1,0 +1,141 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-25
+phase: 5
+-->
+
+# Test Plan — Phase 2 Quality: Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+## Test Strategy
+
+Tests are organized in three layers:
+
+1. **Unit tests** — in-module `#[cfg(test)]` blocks, fast, no I/O
+2. **Integration tests** — `tests/` directory, may start servers or use tempdir,
+   `#[tokio::test]`
+3. **Compile-time checks** — verified by the type system (trait bounds, visibility)
+
+All tests must pass in CI without external services (no real GitHub OAuth, no
+real git remote, no network access).
+
+## Test Cases
+
+### Vector storage trait (#94)
+
+| Test ID | Req | Type | Description | Automated |
+|---------|-----|------|-------------|-----------|
+| TC-01 | R-01 | Compile-time | `VectorStore` trait is public, object-safe, and defines all required methods (add, remove, search, save, load, is_ready, find_by_name, dimensions, commit_sha/set_commit_sha). Verified by compiling `Box<dyn VectorStore>` in AppState. | Yes |
+| TC-02a | R-02 | Unit | `UsearchStore::add` followed by `search` returns the added entry with correct name and scope | Yes |
+| TC-02b | R-02 | Unit | `UsearchStore::remove` makes the entry unreachable via `search` and `find_by_name` | Yes |
+| TC-02c | R-02 | Unit | `UsearchStore::add` with an existing name replaces the old entry (upsert semantics) | Yes |
+| TC-02d | R-02 | Unit | `UsearchStore::search` with scope filter returns only entries matching that scope plus global | Yes |
+| TC-02e | R-02 | Integration | `UsearchStore::save` then `UsearchStore::load` round-trips all entries, names, scopes, and commit SHA | Yes |
+| TC-03 | R-03 | Unit | `UsearchStore` can be constructed with a `FailingRawIndex` that implements the private `RawIndex` trait. The test compiles and the failing backend is injectable. | Yes |
+| TC-04a | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: `UsearchStore::add` returns an error, and the scope index is unchanged (entry count before == entry count after) | Yes |
+| TC-04b | R-04 | Unit | With `FailingRawIndex` configured to fail on the all-index insert: a previously existing entry with the same name is not corrupted by the failed upsert | Yes |
+| TC-05a | R-05 | Unit | When `UsearchStore::add` fails, the returned error is a `MemoryError` variant, not a usearch-specific type | Yes |
+| TC-05b | R-05 | Unit | Error `Display` output does not contain usearch crate paths, internal key IDs, or file system paths | Yes |
+| TC-05c | R-05 | Unit | `InMemoryStore` returns the same `MemoryError` variants for equivalent failure conditions | Yes |
+| TC-06a | R-06 | Unit | `UsearchStore::is_ready()` returns ready after successful construction and load | Yes |
+| TC-06b | R-06 | Unit | `InMemoryStore::is_ready()` returns ready after construction | Yes |
+| TC-07 | R-07 | Compile-time | `AppState.index` is `Box<dyn VectorStore>`. MCP handler code in `server.rs` references only `VectorStore` trait methods — no direct import of `UsearchStore`, `ScopedIndex`, or `VectorIndex`. Verified by grep + compilation. | Yes |
+
+### Device flow provider abstraction (#145)
+
+| Test ID | Req | Type | Description | Automated |
+|---------|-----|------|-------------|-----------|
+| TC-08a | R-08 | Unit | `GitHubDeviceFlow` implements `DeviceFlowProvider` and returns expected client ID, URLs, and scopes | Yes |
+| TC-08b | R-08 | Unit | `device_flow_login()` accepts `&dyn DeviceFlowProvider` — compiles with both `GitHubDeviceFlow` and `MockDeviceFlow` | Yes |
+| TC-09a | R-09 | Unit | `GitHubDeviceFlow::validate()` returns `Ok(())` (its constants are valid) | Yes |
+| TC-09b | R-09 | Unit | A `DeviceFlowProvider` with an empty client ID fails `validate()` | Yes |
+| TC-09c | R-09 | Unit | A `DeviceFlowProvider` with a malformed client ID (wrong format for the provider) fails `validate()` | Yes |
+| TC-10a | R-10 | Unit | A `DeviceFlowProvider` with `http://` device code URL fails `validate()` | Yes |
+| TC-10b | R-10 | Unit | A `DeviceFlowProvider` with `http://localhost` device code URL passes `validate()` (dev exception) | Yes |
+| TC-10c | R-10 | Unit | A `DeviceFlowProvider` with `https://` URLs passes `validate()` | Yes |
+
+### Integration tests (#146)
+
+| Test ID | Req | Type | Description | Automated |
+|---------|-----|------|-------------|-----------|
+| TC-11a | R-11 | Integration | Start a mock OAuth server on an ephemeral port. Create a `MockDeviceFlow` pointing at it. Call `device_flow_login()` with the mock provider. The mock server receives the device code request with the mock client ID and scopes, returns a device code response, then returns an access token on the next poll. Verify the token is stored. | Yes |
+| TC-11b | R-11 | Integration | Mock OAuth server returns `authorization_pending` for 2 polls, then returns the token. Verify `device_flow_login()` retries and succeeds. | Yes |
+| TC-11c | R-11 | Integration | Mock OAuth server returns `access_denied`. Verify `device_flow_login()` returns an appropriate error. | Yes |
+| TC-12a | R-12 | Integration | Set `MEMORY_MCP_GITHUB_TOKEN` env var, call `auth status` logic, verify output reports token source as environment variable | Yes |
+| TC-12b | R-12 | Integration | Write a token to the token file path, call `auth status` logic, verify output reports token source as file | Yes |
+| TC-13 | R-13 | Integration | Set `MEMORY_MCP_BIND=127.0.0.1:<ephemeral>`, start the server, verify it listens on the specified address by connecting to it | Yes |
+| TC-14 | R-14 | Compile-time + CI | All integration tests in this group pass in CI without `MEMORY_MCP_GITHUB_TOKEN` set and without network access to github.com. Verified by CI environment configuration. | Yes |
+
+### Health endpoint (#164)
+
+| Test ID | Req | Type | Description | Automated |
+|---------|-----|------|-------------|-----------|
+| TC-15 | R-15 | Integration | Start server with healthy subsystems. `GET /readyz` returns 200 with JSON body containing `"status":"ready"` and per-subsystem `"status":"up"` | Yes |
+| TC-16a | R-16 | Integration | Start server with a `VectorStore` that reports not-ready. `GET /readyz` returns 503 with JSON body containing `"status":"not_ready"` and the vector index check showing `"status":"down"` with a reason string | Yes |
+| TC-16b | R-16 | Integration | Start server with an inaccessible git repo. `GET /readyz` returns 503 with the git repo check showing `"status":"down"` | Yes |
+| TC-16c | R-16 | Integration | Start server with mismatched embedding/index dimensions. `GET /readyz` returns 503 with embedding check showing `"status":"down"` | Yes |
+| TC-17a | R-17 | Integration | Start server with a freshly initialized empty git repo (no commits). `GET /readyz` returns 200 — the git repo check passes for empty repos | Yes |
+| TC-17b | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 384. `GET /readyz` shows embedding check as `"up"` | Yes |
+| TC-17c | R-17 | Integration | Start server where `embedding.dimensions()` returns 384 and `index.dimensions()` returns 768. `GET /readyz` shows embedding check as `"down"` with dimensional mismatch reason | Yes |
+| TC-18a | R-18 | Integration | `GET /readyz` response body (both 200 and 503 cases) does not contain any absolute file path patterns (`/home/`, `/var/`, `/tmp/`) | Yes |
+| TC-18b | R-18 | Integration | `GET /readyz` 503 response body reason fields match a known allowlist of strings (no free-form error messages) | Yes |
+| TC-19 | R-19 | Unit | The readyz handler calls only `is_accessible()` on repo, `dimensions()` on embedding and index, and `is_ready()` on VectorStore. Verified by inspection + mock implementations that panic if embed() or search() are called during a readyz check. | Yes |
+| TC-20 | R-20 | Integration | Start server with a failing subsystem. `GET /readyz` returns 503. Captured tracing events include a warn-level event naming the failed subsystem. Uses in-memory span capture from the tracing test infrastructure. | Yes |
+| TC-21a | R-21 | Integration | Start server without `--require-remote-sync`, with no git remote configured. `GET /readyz` returns 200. | Yes |
+| TC-21b | R-21 | Integration | Start server with `--require-remote-sync`, with no reachable git remote. `GET /readyz` returns 503 with remote sync check showing `"down"`. | Yes |
+| TC-22 | R-22 | Integration | Send 100 rapid `GET /readyz` requests. If in-process rate limiting is chosen: verify that requests beyond the limit receive 429 or are dropped. If operator-documented: verify the documentation exists and the endpoint functions normally (test serves as a baseline performance assertion). | Yes |
+| TC-23 | R-23 | Integration | Start server with `--require-remote-sync` and a mock git remote. Send two `GET /readyz` requests within 1 second. Verify the mock remote received at most one connection attempt (second request used cached result). | Yes |
+
+## Test Infrastructure
+
+### New test utilities needed
+
+- **`InMemoryStore`** — `VectorStore` implementation backed by `HashMap`. Supports
+  configurable `is_ready()` return value and optional dimensional override for
+  testing mismatch scenarios.
+- **`FailingRawIndex`** — private `RawIndex` implementation that errors on
+  configurable operations (e.g., "fail on the Nth add to the all-index").
+- **`MockDeviceFlow`** — `DeviceFlowProvider` implementation with configurable
+  URLs pointing at a test server.
+- **Mock OAuth server** — minimal Axum app implementing `/device/code` and
+  `/access_token` endpoints with configurable response sequences (pending,
+  denied, success).
+- **`MockEmbeddingBackend`** — `EmbeddingBackend` implementation with configurable
+  `dimensions()` return value and `embed()`/`embed_one()` that panic if called
+  during health checks (TC-19).
+
+### Existing test infrastructure reused
+
+- **In-memory span capture** from tracing scaffold (#52) — used for TC-20 to verify
+  warn-level log events on readyz failure.
+- **`tempfile::tempdir()`** — used for git repo and index persistence tests.
+- **`AuthProvider::with_token()`** — existing test constructor for auth.
+
+## Traceability Summary
+
+| Req | Test Cases | Coverage |
+|-----|------------|----------|
+| R-01 | TC-01 | Compile-time trait verification |
+| R-02 | TC-02a–e | Behavioral parity across 5 operations |
+| R-03 | TC-03 | Failure injection compiles |
+| R-04 | TC-04a–b | Rollback on failure + no corruption |
+| R-05 | TC-05a–c | Typed errors, no backend leakage, consistency across impls |
+| R-06 | TC-06a–b | Readiness for both implementations |
+| R-07 | TC-07 | No concrete type imports in consumer code |
+| R-08 | TC-08a–b | Trait implementation + polymorphic dispatch |
+| R-09 | TC-09a–c | Valid, empty, and malformed client ID |
+| R-10 | TC-10a–c | HTTP rejected, localhost exception, HTTPS accepted |
+| R-11 | TC-11a–c | Happy path, retry, and denial |
+| R-12 | TC-12a–b | Env var and file token sources |
+| R-13 | TC-13 | Bind address override |
+| R-14 | TC-14 | CI-safe (no real credentials) |
+| R-15 | TC-15 | Healthy response |
+| R-16 | TC-16a–c | Per-subsystem failure reporting |
+| R-17 | TC-17a–c | Empty repo, matching dims, mismatched dims |
+| R-18 | TC-18a–b | No path leakage, allowlisted reasons |
+| R-19 | TC-19 | No heavy operations during health check |
+| R-20 | TC-20 | Warn-level tracing on failure |
+| R-21 | TC-21a–b | Default off, opt-in on |
+| R-22 | TC-22 | Rate limiting or baseline |
+| R-23 | TC-23 | Cached remote check |

--- a/docs/design/phase2-quality/threat-model.md
+++ b/docs/design/phase2-quality/threat-model.md
@@ -1,0 +1,95 @@
+<!-- design-meta
+status: draft
+last-updated: 2026-04-25
+phase: 4
+-->
+
+# Threat Model — Phase 2 Quality: Config, Testability, Index Abstraction & Health
+
+Issues: #94, #145, #146, #164
+
+**Depth:** Lightweight — focused on new attack surface only. Existing flows
+(`/mcp`, git remote, OAuth protocol) were covered by the tracing design's
+full STRIDE analysis.
+
+## Scope
+
+Two new attack surfaces analyzed:
+1. `/readyz` endpoint — unauthenticated HTTP GET, new external surface
+2. `DeviceFlowProvider` trait — config injection surface for OAuth parameters
+
+Excluded:
+- `VectorStore` trait — internal refactoring, no new network flows or external
+  surface. Consumer-visible behavior unchanged.
+- Integration test infrastructure — test-only, no production exposure.
+
+## /readyz Endpoint
+
+### STRIDE Analysis
+
+| STRIDE | Threat | Likelihood | Impact | Mitigation |
+|--------|--------|------------|--------|------------|
+| S | Not applicable. Read-only status endpoint with no identity claims. No actor to impersonate. | — | — | — |
+| T | On-path attacker modifies response in transit, causing orchestrator to misroute traffic. | Low | Medium | K8s probes travel over pod network. External probes use TLS at ingress. Deployment concern, not application-level. |
+| R | Unauthenticated endpoint leaves no caller identity. | Low | Low | Expected for infrastructure probes — no state change to repudiate. R-20 logs failures. Access logs provide request-level audit. |
+| I | Attacker probes `/readyz` to learn which subsystems are running and their health state. Subsystem names confirm architecture (git-backed storage, embedding model, vector index). | Medium | Low | R-18 prohibits internal paths, versions, stack traces, backend details. Subsystem names are generic — confirm architecture but not exploitable details. |
+| D | Sustained flooding of `/readyz` consumes CPU and file descriptors. Git repo check acquires a lock on the git2 repository object — high rates could cause lock contention with concurrent MCP operations. | Medium | Medium | R-19 ensures checks are lightweight. **New R-22** adds rate limiting. |
+| D | When `--require-remote-sync` is enabled, each probe triggers an outbound connection to the git remote. Flooding amplifies into outbound connection storms, potentially triggering rate limits on the remote. | Medium | Medium | **New R-23** caches remote reachability with a short TTL. |
+| E | Not applicable. Read-only endpoint, no interaction with auth/write paths. | Low | Low | — |
+
+## DeviceFlowProvider Config
+
+### STRIDE Analysis
+
+| STRIDE | Threat | Likelihood | Impact | Mitigation |
+|--------|--------|------------|--------|------------|
+| S | Malicious `DeviceFlowProvider` points URLs at attacker-controlled server mimicking the real OAuth provider. User enters device code on fake site; attacker captures token. | Low | High | Currently not exploitable: `GitHubDeviceFlow` uses compile-time constants, `MockDeviceFlow` is test-only, no user-facing mechanism to inject custom URLs. R-09 (self-validation) and R-10 (HTTPS enforcement) are the foundation. See forward-looking constraint below. |
+| T | Compromised build alters compile-time constants to point at malicious OAuth server. | Low | High | Supply-chain attack, out of scope for application-level modeling. Project uses `deny.toml`, SHA-pinned CI actions, signed releases. |
+| T | Attacker with test env write access modifies mock server to capture test tokens. | Low | Low | Test tokens have no production value. R-14 ensures no real credentials in CI. |
+| R | No structured audit log of which provider was used for login. A silently injected provider would be indistinguishable from legitimate use. | Low | Low | Existing tracing logs `token_source` on resolution. Adding provider identity to the login span would close this gap — minor improvement, not blocking. |
+| I | `client_id()` exposes the OAuth app client ID. | Low | Low | Client IDs are inherently public for device flow (RFC 8628 public clients). Not a secret. |
+| D | Not applicable to the trait. Network calls using trait URLs are bounded by existing `connect_timeout(10s)`, `timeout(30s)`, and `expires_in.min(1800)` deadline cap. | Low | Low | — |
+| E | Custom `DeviceFlowProvider` could request broader OAuth scopes than intended (e.g., `admin:org` instead of `repo`), resulting in elevated token permissions. | Low | High | R-09 requires provider self-validation. `GitHubDeviceFlow` hardcodes `"repo"`. See forward-looking constraint below. |
+
+## New Requirements
+
+| Req ID | Requirement | Source | Security Ref | Test Case |
+|--------|-------------|--------|--------------|-----------|
+| R-22 | `/readyz` shall be protected against sustained flooding — either via an in-process rate limiter or documented operator responsibility for network-level rate limiting | /readyz DoS | V13.4 | TC-22 (pending) |
+| R-23 | When `--require-remote-sync` is enabled, the remote reachability check shall cache its result with a short TTL (5–30 seconds) rather than making a fresh outbound call per request | /readyz amplification | V13.4 | TC-23 (pending) |
+
+## Forward-Looking Constraints
+
+These are not requirements for the current implementation — they constrain future
+work that introduces user-configurable OAuth providers.
+
+**Constraint 1: Endpoint allowlisting.** If a user-facing mechanism for specifying
+custom OAuth endpoints is added (CLI flags, config file, environment variables),
+the accepted `device_code_url` and `access_token_url` values shall be validated
+against an allowlist of known providers (e.g., `github.com`, `gitlab.com`) or
+require explicit operator opt-in for custom endpoints (e.g.,
+`--allow-custom-oauth-endpoint`). Prevents environment variable injection from
+silently redirecting the auth flow. (ASVS V14.3)
+
+**Constraint 2: Scope restriction.** When a `DeviceFlowProvider` implementation
+allows configurable OAuth scopes, the requested scopes shall be validated against
+a maximum allowlist. For GitHub, the maximum allowed scope is `repo`;
+`admin:*`, `delete_repo`, and `write:org` shall be rejected. (ASVS V14.2)
+
+## Summary
+
+Overall risk posture: **low**.
+
+The design's existing mitigations (R-18, R-19, R-09, R-10) address the primary
+threats. Two new requirements emerged:
+
+1. **Rate limiting on `/readyz`** (R-22) — the highest-priority gap. Each probe
+   acquires the git2 repo lock, so sustained flooding could degrade MCP handler
+   responsiveness.
+2. **Cached remote check** (R-23) — prevents `--require-remote-sync` from
+   amplifying probe traffic into outbound connection storms.
+
+The `DeviceFlowProvider` trait introduces minimal current risk because both
+implementations are compile-time-fixed or test-only. The spoofing and scope
+escalation threats become real only if user-configurable providers are added —
+captured as forward-looking constraints rather than immediate requirements.

--- a/docs/design/phase2-quality/threat-model.md
+++ b/docs/design/phase2-quality/threat-model.md
@@ -1,5 +1,5 @@
 <!-- design-meta
-status: draft
+status: approved
 last-updated: 2026-04-25
 phase: 4
 -->


### PR DESCRIPTION
## Summary
- Design artifacts for the remaining Phase 2 work:
  - Vector index trait abstraction (#94)
  - OAuth device flow provider abstraction (#145)
  - Auth integration tests (#146)
  - /readyz health endpoint (#164)
- ADR-0024: `auth::oauth::DeviceFlowProvider` for multi-provider device flow auth
- 23 requirements, 40 test cases, lightweight STRIDE threat model

## Issues
Closes: none (design only — implementation PRs will reference these artifacts)
Related: #94, #145, #146, #164

## Current state
- [x] Phase 1: Problem space
- [x] Phase 2: Requirements & use cases
- [x] Phase 3: Architecture
- [x] Phase 4: Threat model (lightweight)
- [x] Phase 5: Test plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)