### PR TITLE
docs: replace vague #52 remainder with concrete Phase 5 issues

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,12 +105,13 @@ Closed issues from original TODO: #60 (cargo-auditable), #62 (Trusted Publishing
 
 | Issue | Title | Effort | Depends on |
 |-------|-------|--------|------------|
-| #52 (remainder) | Complete tracing pass | Medium | Phase 2 scaffold |
-| #110 | Authenticated user identity in log events | Small | Phase 2 scaffold |
-| #111 | Log returned memory names on recall | Small | Phase 2 scaffold |
-| #112 | Log auth events | Small | Phase 2 scaffold |
-| #117 | Git commit SHA in write operation logs | Small | Phase 2 scaffold |
-| #162 | W3C Trace Context propagation | Small | #52, OTLP export |
+| #172 | Complete operational span coverage from #52 | Small | Phase 2 scaffold |
+| #173 | Tiered audit channel infrastructure | Medium | Phase 2 scaffold |
+| #110 | Authenticated user identity in log events | Small | #173 |
+| #111 | Log returned memory names on recall | Small | #173 |
+| #112 | Log auth events | Small | #173 |
+| #117 | Git commit SHA in write operation logs | Small | #173 |
+| #162 | W3C Trace Context propagation | Small | OTLP export |
 
 ---
 
@@ -120,7 +121,7 @@ Closed issues from original TODO: #60 (cargo-auditable), #62 (Trusted Publishing
 
 | Issue | Title | Effort | Depends on |
 |-------|-------|--------|------------|
-| #115 | Authentication & authorization framework | Large | #52 |
+| #115 | Authentication & authorization framework | Large | #173 |
 | #116 | Memory scope isolation | Large | #115 |
 | #113 | Log access denied events | Small | #115 |
 | #119 | Enterprise scope hierarchy (org/team/project/user) | Large | #116 |


### PR DESCRIPTION
## Summary

- Replace the vague "#52 (remainder)" ROADMAP entry with two concrete issues extracted from the gap analysis between #52's scope and PR #170's delivery
- #172: operational span gaps (embedding sub-ops, `repo.diff`, `auth.device_flow`)
- #173: tiered audit channel infrastructure (routing layer that #110–#112, #117 depend on)
- Update dependency chain: audit field issues now depend on #173, not the scaffold directly; Phase 6 #115 updated from #52 → #173

## Test plan

- [x] Verify ROADMAP table renders correctly in GitHub markdown
- [x] Verify issue cross-references (#172, #173) link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)