### PR TITLE
fix: record count on local span to prevent parent span leak

### DIFF
--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -690,7 +690,7 @@ impl<R: RawIndex> UsearchStoreInner<R> {
             }
         };
         if let Ok(ref r) = results {
-            tracing::Span::current().record("count", r.len());
+            span.record("count", r.len());
         }
         results
     }

--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -641,7 +641,7 @@ impl<R: RawIndex> UsearchStoreInner<R> {
             key_count = self.all.key_count(),
             count = tracing::field::Empty,
         );
-        let _enter = span.entered();
+        let _enter = span.enter();
 
         if query.len() != self.dimensions {
             return Err(MemoryError::InvalidInput {


### PR DESCRIPTION
## Summary
- When the `index.search` `debug_span` is disabled (filtered at INFO level), `Span::current()` returns the caller's `handler.recall` span instead. This causes `count` to be recorded on the wrong span, then recorded again by server.rs, producing `count=5 count=5` in trace output.
- Fix: use the local `span` variable directly instead of `Span::current()`, so the record is a no-op when the debug span is disabled and targets the correct span when it's enabled.

## Test plan
- [ ] Run `memory-mcp serve` at default (INFO) log level, invoke `recall`, confirm trace shows single `count=N` on the `handler.recall` span
- [ ] Run with `RUST_LOG=debug`, confirm `index.search` span correctly shows its own `count` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)