### PR TITLE
fix: embed timeout with self-healing worker + startup reindex after crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+## [0.10.0] - 2026-05-10
+
+### Added
+- Startup reindex: compare persisted index SHA against repo HEAD, rebuild from scratch on mismatch (#193)
+- `full_reindex` public function for crash recovery and startup freshness checks
+- `MemoryRepo::head_sha()` async method for reading HEAD commit SHA
+- `--embed-timeout-secs` CLI arg (default 30, env `MEMORY_MCP_EMBED_TIMEOUT_SECS`)
+- `--embed-queue-size` CLI arg (default 64, env `MEMORY_MCP_EMBED_QUEUE_SIZE`)
+- `parse_nonzero_u64` validator with tests
+- Worker thread `Drop` impl that closes channel and joins thread
+
+### Changed
+- **Breaking:** `CandleEmbeddingEngine::new()` now takes `(Duration, usize)` parameters
+- **Breaking:** `CandleEmbeddingEngine` no longer implements `UnwindSafe`/`RefUnwindSafe`
+- Replace mutex+spawn_blocking embedding design with dedicated worker thread + bounded channel (#192)
+- Embed calls self-heal after timeouts — worker continues processing next request
+- `catch_unwind` in worker loop survives panics with tokenizer state recovery
+- `head_sha()` uses `spawn_blocking` consistent with other `MemoryRepo` methods
+- Startup reindex discards loaded index to prevent ghost entries from deleted memories
+- SHA stamped on shutdown save and after sync pulls to prevent spurious reindexes
+- Upgrade OpenTelemetry stack to 0.31 and tokenizers to 0.23
+- Bump the rust-dependencies group with 2 updates
+
+### Fixed
+- Embedding timeout: hung candle inference no longer blocks all future embed calls (#192)
+- Crash recovery: index rebuilt automatically after kill -9, no more empty recall results (#193)
+- IPv6 localhost exception and review findings from #178
+- Record count on local span to prevent parent span leak
+- Pre-existing clippy lints from Rust 1.95 (`manual_contains`, `single_match`)
+
 ## [0.7.1] - 2026-04-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1293,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1651,7 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1674,16 +1674,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1742,9 +1732,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1884,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.4+1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
@@ -2046,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2486,18 +2476,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3687,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3750,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3776,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -3806,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "base64 0.22.1",
  "bitflags",
@@ -3816,13 +3806,13 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "mime",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4161,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4174,9 +4164,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4184,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4194,9 +4184,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4207,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4250,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/embedding/candle.rs
+++ b/src/embedding/candle.rs
@@ -1,12 +1,14 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc;
 
 use candle_core::{Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{BertModel, Config as BertConfig};
 use hf_hub::{api::sync::ApiBuilder, Cache, Repo, RepoType};
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
+use tokio::sync::oneshot;
+use tokio::time::{timeout, Duration};
 
 use super::EmbeddingBackend;
 use crate::error::MemoryError;
@@ -14,13 +16,30 @@ use crate::error::MemoryError;
 /// HuggingFace model ID. Only BGE-small-en-v1.5 is supported currently.
 pub const MODEL_ID: &str = "BAAI/bge-small-en-v1.5";
 
+// ---------------------------------------------------------------------------
+// Worker thread
+// ---------------------------------------------------------------------------
+
+type EmbedRequest = (
+    Vec<String>,
+    oneshot::Sender<Result<Vec<Vec<f32>>, MemoryError>>,
+);
+
 /// Pure-Rust embedding engine using candle for BERT inference.
 ///
 /// Uses candle-transformers' BERT implementation with tokenizers for
 /// tokenisation. No C/C++ FFI dependencies — compiles on all platforms.
+///
+/// A dedicated OS thread owns the model exclusively. Async callers send work
+/// via a channel and await a oneshot reply. If a call times out, the caller
+/// gets an error immediately; the worker finishes its current task, discards
+/// the stale reply channel, and picks up the next request — no restart needed.
 pub struct CandleEmbeddingEngine {
-    inner: Arc<Mutex<CandleInner>>,
+    // Option so Drop can take ownership of tx to close it before joining.
+    tx: Option<mpsc::SyncSender<EmbedRequest>>,
+    worker: Option<std::thread::JoinHandle<()>>,
     dim: usize,
+    embed_timeout: Duration,
 }
 
 struct CandleInner {
@@ -34,7 +53,15 @@ impl CandleEmbeddingEngine {
     ///
     /// Downloads model weights from HuggingFace Hub on first use (cached
     /// in the standard HF cache directory, respects `HF_HOME`).
-    pub fn new() -> Result<Self, MemoryError> {
+    ///
+    /// `embed_timeout` caps how long a single [`embed`](Self::embed) call may
+    /// block. If the worker is still running when the timeout fires, the caller
+    /// gets an error but the engine recovers automatically — no restart needed.
+    ///
+    /// `queue_size` sets the bounded channel capacity — how many requests can
+    /// queue behind the one being processed. Extra callers get an immediate
+    /// "busy" error.
+    pub fn new(embed_timeout: Duration, queue_size: usize) -> Result<Self, MemoryError> {
         let device = Device::Cpu;
 
         let (config, mut tokenizer, weights_path) =
@@ -66,57 +93,140 @@ impl CandleEmbeddingEngine {
 
         let dim = config.hidden_size;
 
+        let (tx, rx) = mpsc::sync_channel::<EmbedRequest>(queue_size);
+
+        let worker = std::thread::Builder::new()
+            .name("embed-worker".into())
+            .spawn(move || {
+                let inner = CandleInner {
+                    model,
+                    tokenizer,
+                    device,
+                };
+                worker_loop(inner, dim, rx);
+            })
+            .map_err(|e| MemoryError::Embedding(format!("failed to spawn embed worker: {e}")))?;
+
         Ok(Self {
-            inner: Arc::new(Mutex::new(CandleInner {
-                model,
-                tokenizer,
-                device,
-            })),
+            tx: Some(tx),
+            worker: Some(worker),
             dim,
+            embed_timeout,
         })
+    }
+
+    /// Construct an engine backed by a caller-supplied worker sender.
+    ///
+    /// Bypasses model loading entirely. The caller is responsible for spawning
+    /// a thread that reads from the other end of the channel. Used only in
+    /// tests to exercise the channel mechanics (timeout, disconnect, busy)
+    /// without needing the HuggingFace model cache.
+    #[cfg(test)]
+    fn with_worker(
+        tx: mpsc::SyncSender<EmbedRequest>,
+        dim: usize,
+        embed_timeout: Duration,
+    ) -> Self {
+        Self {
+            tx: Some(tx),
+            worker: None,
+            dim,
+            embed_timeout,
+        }
+    }
+}
+
+impl Drop for CandleEmbeddingEngine {
+    fn drop(&mut self) {
+        // Close the channel first so the worker's `for ... in rx` loop exits.
+        drop(self.tx.take());
+        if let Some(handle) = self.worker.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Main loop for the dedicated embedding worker thread.
+///
+/// Receives `(texts, reply_tx)` pairs, runs inference, and sends the result
+/// back on `reply_tx`. If the receiver was dropped (the async caller timed
+/// out), the send fails silently and the loop continues — this is the
+/// self-healing path.
+fn worker_loop(mut inner: CandleInner, dim: usize, rx: mpsc::Receiver<EmbedRequest>) {
+    for (texts, reply_tx) in rx {
+        let span = tracing::debug_span!(
+            "embedding.embed",
+            batch_size = texts.len(),
+            dimensions = dim,
+            model = MODEL_ID,
+        );
+        let _enter = span.enter();
+
+        let mut panicked = false;
+        let result = catch_unwind(AssertUnwindSafe(|| embed_batch(&inner, &texts))).unwrap_or_else(
+            |panic_payload| {
+                panicked = true;
+                let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                    (*s).to_string()
+                } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "unknown panic in embedding engine".to_string()
+                };
+                tracing::warn!(error = %msg, "embedding engine panicked — recovering");
+                Err(MemoryError::Embedding(format!(
+                    "embedding engine panicked: {msg}"
+                )))
+            },
+        );
+
+        let _ = reply_tx.send(result);
+
+        if panicked {
+            inner.tokenizer.with_padding(Some(PaddingParams {
+                strategy: tokenizers::PaddingStrategy::BatchLongest,
+                ..Default::default()
+            }));
+            let _ = inner.tokenizer.with_truncation(Some(TruncationParams {
+                max_length: 512,
+                ..Default::default()
+            }));
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl EmbeddingBackend for CandleEmbeddingEngine {
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
-        let arc = Arc::clone(&self.inner);
-        let texts = texts.to_vec();
-        let batch_size = texts.len();
-        let dim = self.dim;
+        let (reply_tx, reply_rx) = oneshot::channel();
 
-        // Capture current span before entering spawn_blocking so the
-        // child thread can enter it and keep the span hierarchy intact.
-        let span = tracing::debug_span!(
-            "embedding.embed",
-            batch_size,
-            dimensions = dim,
-            model = MODEL_ID,
-        );
+        let tx = self
+            .tx
+            .as_ref()
+            .ok_or_else(|| MemoryError::Embedding("embedding engine has been shut down".into()))?;
 
-        tokio::task::spawn_blocking(move || {
-            let _enter = span.enter();
-            let guard = arc.lock().unwrap_or_else(|poisoned| {
-                tracing::warn!("embedding mutex was poisoned — clearing poison and continuing");
-                poisoned.into_inner()
-            });
-            catch_unwind(AssertUnwindSafe(|| embed_batch(&guard, &texts))).unwrap_or_else(
-                |panic_payload| {
-                    let msg = if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                        (*s).to_string()
-                    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-                        s.clone()
-                    } else {
-                        "unknown panic in embedding engine".to_string()
-                    };
-                    Err(MemoryError::Embedding(format!(
-                        "embedding engine panicked: {msg}"
-                    )))
-                },
-            )
-        })
-        .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        tx.try_send((texts.to_vec(), reply_tx))
+            .map_err(|e| match e {
+                mpsc::TrySendError::Full(_) => {
+                    MemoryError::Embedding("embedding worker is busy — try again".into())
+                }
+                mpsc::TrySendError::Disconnected(_) => {
+                    MemoryError::Embedding("embedding worker has exited — restart required".into())
+                }
+            })?;
+
+        match timeout(self.embed_timeout, reply_rx).await {
+            Ok(Ok(result)) => result,
+            // Fires if the worker drops reply_tx without sending (e.g. a
+            // double-panic that escapes catch_unwind, or a panic in span setup).
+            Ok(Err(_)) => Err(MemoryError::Embedding(
+                "embedding worker dropped the reply channel unexpectedly".into(),
+            )),
+            Err(_elapsed) => Err(MemoryError::Embedding(format!(
+                "embedding timed out after {:.1}s — the worker will recover automatically",
+                self.embed_timeout.as_secs_f64(),
+            ))),
+        }
     }
 
     fn dimensions(&self) -> usize {
@@ -290,4 +400,139 @@ fn embed_chunk(inner: &CandleInner, texts: &[String]) -> Result<Vec<Vec<f32>>, M
     }
 
     Ok(results)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Build a fake engine whose worker applies `handler` to every request.
+    ///
+    /// `handler` receives the texts and the reply sender; it can sleep, panic,
+    /// drop the sender, or send any result — enabling controlled fault injection
+    /// without touching the model loading path.
+    fn fake_engine<F>(timeout: Duration, handler: F) -> CandleEmbeddingEngine
+    where
+        F: Fn(Vec<String>, oneshot::Sender<Result<Vec<Vec<f32>>, MemoryError>>) + Send + 'static,
+    {
+        let (tx, rx) = mpsc::sync_channel::<EmbedRequest>(1);
+        std::thread::spawn(move || {
+            for (texts, reply_tx) in rx {
+                handler(texts, reply_tx);
+            }
+        });
+        CandleEmbeddingEngine::with_worker(tx, 4, timeout)
+    }
+
+    /// Worker that immediately returns a fixed-size zero vector per input.
+    fn ok_handler(
+        texts: Vec<String>,
+        reply_tx: oneshot::Sender<Result<Vec<Vec<f32>>, MemoryError>>,
+    ) {
+        let vecs = texts.iter().map(|_| vec![0.0f32; 4]).collect();
+        let _ = reply_tx.send(Ok(vecs));
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_vectors() {
+        let engine = fake_engine(Duration::from_secs(5), ok_handler);
+        let result = engine
+            .embed(&["hello".to_string(), "world".to_string()])
+            .await;
+        let vecs = result.expect("embed should succeed");
+        assert_eq!(vecs.len(), 2);
+        assert_eq!(vecs[0].len(), 4);
+    }
+
+    #[tokio::test]
+    async fn timeout_returns_error_and_worker_recovers() {
+        // Barrier lets us prove the worker is still alive after the timeout
+        // fires on the first request.
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier2 = Arc::clone(&barrier);
+
+        let engine = fake_engine(Duration::from_millis(50), move |texts, reply_tx| {
+            if texts[0] == "slow" {
+                // Block until the test signals us to proceed (after timeout fires).
+                barrier2.wait();
+                // Reply arrives after the caller's receiver was dropped — send
+                // fails silently, which is the self-healing path.
+                let _ = reply_tx.send(Ok(vec![vec![0.0; 4]]));
+                // Signal the test that we've finished processing the stale request.
+                barrier2.wait();
+            } else {
+                ok_handler(texts, reply_tx);
+            }
+        });
+
+        // First call times out.
+        let err = engine
+            .embed(&["slow".to_string()])
+            .await
+            .expect_err("slow embed should time out");
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected timeout error, got: {err}"
+        );
+
+        // Unblock the worker and wait for it to finish the stale request.
+        barrier.wait();
+        barrier.wait();
+
+        // Second call should succeed — the worker recovered.
+        let result = engine.embed(&["fast".to_string()]).await;
+        assert!(
+            result.is_ok(),
+            "engine should recover after timeout: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn disconnected_worker_returns_error() {
+        let (tx, rx) = mpsc::sync_channel::<EmbedRequest>(1);
+        // Drop the receiver immediately — worker is "dead".
+        drop(rx);
+        let engine = CandleEmbeddingEngine::with_worker(tx, 4, Duration::from_secs(5));
+
+        let err = engine
+            .embed(&["anything".to_string()])
+            .await
+            .expect_err("disconnected worker should error");
+        assert!(
+            err.to_string().contains("exited"),
+            "expected 'exited' in error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn busy_worker_returns_error() {
+        // Channel capacity 0 is not allowed by SyncSender; use capacity 1 but
+        // send two requests without the worker consuming either.
+        // Easier: use a zero-sleep worker that we pre-fill the channel for.
+        let (tx, rx) = mpsc::sync_channel::<EmbedRequest>(1);
+
+        // Pre-fill the single channel slot by sending directly, bypassing embed().
+        let (filler_tx, _filler_rx) = oneshot::channel::<Result<Vec<Vec<f32>>, MemoryError>>();
+        tx.send((vec!["fill".to_string()], filler_tx)).unwrap();
+
+        // Now embed() hits try_send on a full channel.
+        let engine = CandleEmbeddingEngine::with_worker(tx, 4, Duration::from_secs(5));
+        let err = engine
+            .embed(&["overflow".to_string()])
+            .await
+            .expect_err("full channel should error");
+        assert!(
+            err.to_string().contains("busy"),
+            "expected 'busy' in error, got: {err}"
+        );
+
+        drop(rx); // clean up
+    }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -181,13 +181,11 @@ mod tests {
             .expect("ProjectAndGlobal search should succeed");
         let pag_names: Vec<&str> = pag_results.iter().map(|(_, n, _)| n.as_str()).collect();
         assert!(
-            pag_names
-                .iter()
-                .any(|n| *n == "projects/testproj/contract-proj"),
+            pag_names.contains(&"projects/testproj/contract-proj"),
             "TC-02d: ProjectAndGlobal should include project entries"
         );
         assert!(
-            pag_names.iter().any(|n| *n == "global/contract-global"),
+            pag_names.contains(&"global/contract-global"),
             "TC-02d: ProjectAndGlobal should include global entries"
         );
         // Clean up

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use mcp_session::{BoundedSessionManager, SessionConfig};
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
+use tracing::Instrument;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // The SdkTracerProvider type is used in the otlp feature only.
@@ -124,6 +125,9 @@ struct ServeArgs {
     )]
     session_rate_window_secs: u64,
 
+    #[command(flatten)]
+    embed: EmbedArgs,
+
     /// Enable OTLP span export. The server will crash on startup if the
     /// collector is unreachable. Use --otlp-optional for graceful fallback.
     #[cfg(feature = "otlp")]
@@ -138,7 +142,34 @@ struct ServeArgs {
 }
 
 #[derive(Args)]
-struct WarmupArgs {}
+struct WarmupArgs {
+    #[command(flatten)]
+    embed: EmbedArgs,
+}
+
+#[derive(Args)]
+struct EmbedArgs {
+    /// Maximum seconds a single embedding call may block. After a timeout the
+    /// caller receives an error but the worker recovers automatically.
+    #[arg(
+        long,
+        default_value_t = 30,
+        env = "MEMORY_MCP_EMBED_TIMEOUT_SECS",
+        value_parser = parse_nonzero_u64,
+    )]
+    embed_timeout_secs: u64,
+
+    /// Maximum number of embedding requests that can queue behind the worker.
+    /// Higher values allow more concurrent callers to wait; lower values fail
+    /// fast under load.
+    #[arg(
+        long,
+        default_value_t = 64,
+        env = "MEMORY_MCP_EMBED_QUEUE_SIZE",
+        value_parser = parse_nonzero_usize,
+    )]
+    embed_queue_size: usize,
+}
 
 // ---------------------------------------------------------------------------
 // Tracing initialisation
@@ -353,8 +384,11 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     let repo = MemoryRepo::init_or_open(&repo_path, remote_url.as_deref())
         .with_context(|| format!("failed to open/init repo at {}", repo_path.display()))?;
 
-    let embedding: Box<dyn EmbeddingBackend> =
-        Box::new(CandleEmbeddingEngine::new().context("failed to init embedding engine")?);
+    let embed_timeout = std::time::Duration::from_secs(args.embed.embed_timeout_secs);
+    let embedding: Box<dyn EmbeddingBackend> = Box::new(
+        CandleEmbeddingEngine::new(embed_timeout, args.embed.embed_queue_size)
+            .context("failed to init embedding engine")?,
+    );
 
     let dimensions = embedding.dimensions();
 
@@ -376,17 +410,71 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         info!("removed legacy single-index files");
     }
 
-    let index: Box<dyn VectorStore> = Box::new(
+    let repo = Arc::new(repo);
+
+    // Load the persisted index and check freshness against repo HEAD.
+    // If the SHA doesn't match, discard the loaded index entirely and start
+    // fresh — this prevents ghost entries from deleted memories lingering.
+    let mut index: Box<dyn VectorStore> = Box::new(
         UsearchStore::load(&index_dir, dimensions).unwrap_or_else(|e| {
             tracing::warn!("could not load index ({}), creating fresh", e);
             UsearchStore::new(dimensions).expect("failed to create index")
         }),
     );
 
+    let head_sha = repo.head_sha().await;
+    let needs_reindex = head_sha != index.commit_sha();
+    if needs_reindex {
+        info!(
+            head = ?head_sha,
+            index = ?index.commit_sha(),
+            "index SHA does not match repo HEAD — rebuilding from scratch"
+        );
+        index = Box::new(UsearchStore::new(dimensions).expect("failed to create index"));
+
+        match memory_mcp::server::full_reindex(&repo, embedding.as_ref(), index.as_ref())
+            .instrument(tracing::info_span!("startup.full_reindex"))
+            .await
+        {
+            Ok(stats) => {
+                info!(
+                    added = stats.added,
+                    errors = stats.errors,
+                    "startup reindex complete"
+                );
+                if stats.added > 0 || stats.errors == 0 {
+                    if stats.errors > 0 {
+                        tracing::warn!(
+                            added = stats.added,
+                            errors = stats.errors,
+                            "startup reindex partially failed — some memories may not be searchable"
+                        );
+                    }
+                    if let Some(sha) = &head_sha {
+                        index.set_commit_sha(Some(sha));
+                    }
+                } else {
+                    tracing::warn!(
+                        errors = stats.errors,
+                        "all embeds failed — SHA not stamped, will retry on next startup"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "startup reindex failed — SHA not stamped, will retry on next startup"
+                );
+            }
+        }
+    } else {
+        tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
+    }
+
     let auth = AuthProvider::new();
 
     let state = Arc::new(AppState::new(
-        Arc::new(repo),
+        repo,
         args.branch.clone(),
         embedding,
         index,
@@ -460,9 +548,9 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Persist the scoped vector index so the next startup can skip a full reindex.
     std::fs::create_dir_all(&index_dir)
         .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
-    // TODO: set commit_sha to repo HEAD before saving so the next startup
-    // can use SHA-based freshness to skip reindexing unchanged scopes.
-    // For now, indexes are always rebuilt from scratch on startup if missing.
+    if let Some(sha) = state_for_shutdown.repo.head_sha().await {
+        state_for_shutdown.index.set_commit_sha(Some(&sha));
+    }
     if let Err(e) = state_for_shutdown.index.save(&index_dir) {
         tracing::warn!("failed to persist vector index on shutdown: {}", e);
     } else {
@@ -474,9 +562,13 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
 /// Load the embedding model and run a single dummy embed to warm the on-disk
 /// model cache, then exit. Intended for use as a Kubernetes init container.
-async fn run_warmup(_args: WarmupArgs) -> anyhow::Result<()> {
+async fn run_warmup(args: WarmupArgs) -> anyhow::Result<()> {
     info!("warming up embedding model '{}'", MODEL_ID);
-    let engine = CandleEmbeddingEngine::new().context("failed to init embedding engine")?;
+    let engine = CandleEmbeddingEngine::new(
+        std::time::Duration::from_secs(args.embed.embed_timeout_secs),
+        args.embed.embed_queue_size,
+    )
+    .context("failed to init embedding engine")?;
     // Run one dummy embed to ensure the model weights are fully loaded and any
     // cached files are written to disk.
     let _ = engine
@@ -494,6 +586,17 @@ async fn run_warmup(_args: WarmupArgs) -> anyhow::Result<()> {
 /// Parse a `usize` that must be at least 1. Used as a clap `value_parser`.
 fn parse_nonzero_usize(s: &str) -> Result<usize, String> {
     let n: usize = s
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid integer"))?;
+    if n == 0 {
+        return Err("value must be at least 1".to_owned());
+    }
+    Ok(n)
+}
+
+/// Parse a `u64` that must be at least 1. Used as a clap `value_parser`.
+fn parse_nonzero_u64(s: &str) -> Result<u64, String> {
+    let n: u64 = s
         .parse()
         .map_err(|_| format!("'{s}' is not a valid integer"))?;
     if n == 0 {
@@ -616,8 +719,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_nonzero_usize_hundred_is_ok() {
-        assert_eq!(parse_nonzero_usize("100").unwrap(), 100);
+    fn test_parse_nonzero_u64_zero_is_err() {
+        assert!(parse_nonzero_u64("0").is_err());
+    }
+
+    #[test]
+    fn test_parse_nonzero_u64_non_numeric_is_err() {
+        assert!(parse_nonzero_u64("abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_nonzero_u64_one_is_ok() {
+        assert_eq!(parse_nonzero_u64("1").unwrap(), 1);
     }
 
     #[test]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -180,6 +180,25 @@ impl MemoryRepo {
         })
     }
 
+    /// Return the current HEAD commit SHA as a hex string, or `None` if the
+    /// branch is unborn (no commits yet).
+    pub async fn head_sha(self: &Arc<Self>) -> Option<String> {
+        let me = Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            let repo = me.inner.lock().expect("repo mutex poisoned");
+            let oid_bytes = capture_head_oid(&repo).ok()?;
+            if oid_bytes == [0u8; 20] {
+                return None;
+            }
+            git2::Oid::from_bytes(&oid_bytes)
+                .ok()
+                .map(|oid| oid.to_string())
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Absolute path for a memory's markdown file inside the repo.
     fn memory_path(&self, name: &str, scope: &Scope) -> PathBuf {
         self.root

--- a/src/server.rs
+++ b/src/server.rs
@@ -199,6 +199,91 @@ async fn incremental_reindex(
     stats
 }
 
+/// Re-embed and re-index all memories in the repository.
+///
+/// This is a full rebuild: all memories are listed, their content is embedded,
+/// and the index is updated. Intended for startup freshness checks and
+/// recovery after a crash that discarded an in-progress index.
+///
+/// Unlike delegating to `incremental_reindex`, this function uses the content
+/// already loaded by `list_memories` to avoid reading each file a second time.
+pub async fn full_reindex(
+    repo: &Arc<MemoryRepo>,
+    embedding: &dyn EmbeddingBackend,
+    index: &dyn VectorStore,
+) -> Result<ReindexStats, MemoryError> {
+    let memories = repo.list_memories(None).await?;
+    if memories.is_empty() {
+        return Ok(ReindexStats::default());
+    }
+
+    let mut stats = ReindexStats::default();
+
+    let items: Vec<(Scope, String, String)> = memories
+        .into_iter()
+        .map(|m| {
+            let qualified = format!("{}/{}", m.metadata.scope.dir_prefix(), m.name);
+            (m.metadata.scope, qualified, m.content)
+        })
+        .collect();
+
+    // Embed and index in chunks so each embed() call maps to roughly one
+    // BERT forward pass (MAX_BATCH_SIZE=64 inside the worker) and stays
+    // within the per-call timeout budget.
+    const REINDEX_BATCH_SIZE: usize = 64;
+    for chunk in items.chunks(REINDEX_BATCH_SIZE) {
+        let contents: Vec<String> = chunk.iter().map(|(_, _, c)| c.clone()).collect();
+
+        let vectors = match embedding.embed(&contents).await {
+            Ok(v) => v,
+            Err(batch_err) => {
+                warn!(error = %batch_err, "full_reindex: batch embed failed; falling back to per-item");
+                let mut vecs = Vec::with_capacity(contents.len());
+                for (i, content) in contents.iter().enumerate() {
+                    match embedding.embed(std::slice::from_ref(content)).await {
+                        Ok(mut v) => vecs.push(v.remove(0)),
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                qualified_name = %chunk[i].1,
+                                "full_reindex: per-item embed failed; skipping"
+                            );
+                            stats.errors += 1;
+                            vecs.push(Vec::new());
+                        }
+                    }
+                }
+                vecs
+            }
+        };
+
+        debug_assert_eq!(
+            vectors.len(),
+            chunk.len(),
+            "embed() must return exactly one vector per input"
+        );
+
+        for ((scope, qualified_name, _), vector) in chunk.iter().zip(vectors.iter()) {
+            if vector.is_empty() {
+                continue;
+            }
+            match index.add(scope, vector, qualified_name.clone()) {
+                Ok(_) => stats.added += 1,
+                Err(e) => {
+                    warn!(
+                        qualified_name = %qualified_name,
+                        error = %e,
+                        "full_reindex: index add failed; skipping"
+                    );
+                    stats.errors += 1;
+                }
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
 #[tool_router]
 impl MemoryServer {
     /// Create a new MCP server backed by the given application state.
@@ -793,6 +878,7 @@ impl MemoryServer {
                     .map_err(ErrorData::from)?
                     .map_err(ErrorData::from)?;
 
+                    let mut reindex_failed_completely = false;
                     if !changes.is_empty() {
                         let stats = incremental_reindex(
                             &state.repo,
@@ -809,7 +895,18 @@ impl MemoryServer {
                             errors = stats.errors,
                             "incremental reindex complete"
                         );
+                        reindex_failed_completely =
+                            stats.added == 0 && stats.updated == 0 && stats.errors > 0;
                         reindex_stats = Some(stats);
+                    }
+
+                    // Advance the stored SHA so the next startup doesn't trigger
+                    // a full reindex for changes already processed. Skip when every
+                    // embed failed so the next startup retries.
+                    if !reindex_failed_completely {
+                        if let Some(sha) = state.repo.head_sha().await {
+                            state.index.set_commit_sha(Some(&sha));
+                        }
                     }
                 }
 

--- a/tests/candle_embedding.rs
+++ b/tests/candle_embedding.rs
@@ -4,7 +4,11 @@
 //! correct dimensions, normalisation, determinism, semantic similarity,
 //! and batch/single consistency (attention mask correctness).
 
+use std::time::Duration;
+
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
@@ -16,7 +20,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// The engine must produce 384-dimensional vectors for BGE-small-en-v1.5.
 #[tokio::test]
 async fn produces_384_dim_vectors() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     assert_eq!(engine.dimensions(), 384);
 
     let vec = engine.embed_one("hello world").await.unwrap();
@@ -26,7 +30,7 @@ async fn produces_384_dim_vectors() {
 /// Vectors must be L2-normalised (unit length).
 #[tokio::test]
 async fn vectors_are_normalised() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     let vec = engine.embed_one("test normalisation").await.unwrap();
     let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
     assert!((norm - 1.0).abs() < 1e-4, "expected unit norm, got {norm}");
@@ -35,7 +39,7 @@ async fn vectors_are_normalised() {
 /// Same input must produce identical output (deterministic).
 #[tokio::test]
 async fn self_consistency() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     let a = engine.embed_one("determinism check").await.unwrap();
     let b = engine.embed_one("determinism check").await.unwrap();
     assert_eq!(a, b);
@@ -44,7 +48,7 @@ async fn self_consistency() {
 /// Semantically similar texts should cluster together.
 #[tokio::test]
 async fn semantic_similarity() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
 
     let rust = engine.embed_one("Rust programming language").await.unwrap();
     let cargo = engine
@@ -68,7 +72,7 @@ async fn semantic_similarity() {
 /// Batch embed must return one vector per input, all normalised.
 #[tokio::test]
 async fn batch_embed() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     let texts: Vec<String> = vec!["first".into(), "second".into(), "third".into()];
     let vecs = engine.embed(&texts).await.unwrap();
     assert_eq!(vecs.len(), 3);
@@ -83,7 +87,7 @@ async fn batch_embed() {
 /// This validates that the attention mask correctly excludes padding tokens.
 #[tokio::test]
 async fn batch_single_consistency() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
 
     // Deliberately different lengths to force padding in the batch path.
     let short = "hi";
@@ -115,7 +119,7 @@ async fn batch_single_consistency() {
 /// Embedding an empty batch must return an empty vec (not an error).
 #[tokio::test]
 async fn empty_batch_returns_empty() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     let result = engine.embed(&[]).await.unwrap();
     assert!(result.is_empty());
 }
@@ -125,7 +129,7 @@ async fn empty_batch_returns_empty() {
 /// vectors are identical regardless of which chunk they land in.
 #[tokio::test]
 async fn large_batch_is_chunked() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
 
     // 65 texts: first chunk of 64, second chunk of 1.
     let texts: Vec<String> = (0..65).map(|i| format!("sentence number {i}")).collect();
@@ -155,7 +159,7 @@ async fn large_batch_is_chunked() {
 /// Text exceeding the 512-token limit must be truncated, not rejected.
 #[tokio::test]
 async fn long_text_is_truncated() {
-    let engine = CandleEmbeddingEngine::new().unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
     let long_text = "word ".repeat(600); // ~600 tokens, well over the 512 limit
     let vec = engine.embed_one(&long_text).await.unwrap();
     assert_eq!(vec.len(), 384);

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -598,9 +598,8 @@ fn auth_failure_produces_warn_event() {
             Some(h) => std::env::set_var("HOME", h),
             None => std::env::remove_var("HOME"),
         }
-        match &saved_token {
-            Some(t) => std::env::set_var("MEMORY_MCP_GITHUB_TOKEN", t),
-            None => {} // already removed above
+        if let Some(t) = &saved_token {
+            std::env::set_var("MEMORY_MCP_GITHUB_TOKEN", t);
         }
     });
     let store = store.lock().unwrap();


### PR DESCRIPTION
## Summary

Fixes #192 and #193 — fallout from a candle-core infinite loop incident (#194).

- **#192 (embed timeout)**: Replace `Arc<Mutex<CandleInner>>` + `spawn_blocking` with a dedicated worker thread communicating via bounded `mpsc::sync_channel` + `oneshot` reply channels. Callers get configurable timeout (`--embed-timeout-secs`, default 30s). The worker self-heals after timeouts (callers get errors, worker finishes its task and picks up the next). Panics caught via `catch_unwind` with tokenizer state recovery. Proper `Drop` impl joins the worker thread.

- **#193 (startup reindex)**: Compare persisted index `commit_sha` against repo HEAD on startup. On mismatch, discard the loaded index and rebuild from scratch using already-loaded memory content (no double disk reads). Ghost entries from deleted memories are eliminated by starting fresh. `commit_sha` is set on shutdown save and after sync pulls to prevent spurious reindexes. SHA stamping is skipped on total embed failure so the next startup retries.

### New CLI args
- `--embed-timeout-secs` / `MEMORY_MCP_EMBED_TIMEOUT_SECS` (default: 30) — per-call timeout
- `--embed-queue-size` / `MEMORY_MCP_EMBED_QUEUE_SIZE` (default: 64) — bounded channel capacity

### Additional fixes
- Pre-existing Rust 1.95 clippy lints (`manual_contains`, `single_match`)
- `head_sha()` uses `spawn_blocking` consistent with other `MemoryRepo` methods

### Follow-up
- #198 — chunk `full_reindex` embed calls to avoid single-batch timeout on large repos

## Test plan

- [x] 163/163 tests pass (`cargo nextest run --workspace`)
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo doc --no-deps` clean
- [x] 4 new unit tests for embed worker (happy path, timeout+recovery, disconnected, busy)
- [x] 3 new tests for `parse_nonzero_u64`
- [x] 7 rounds of 3-agent code review (correctness, design, architecture+security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)