### PR TITLE
docs: update README config table, ROADMAP status, and ADR-0026 for v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ All options can be set via CLI flags or environment variables:
 | `--mcp-path` | `MEMORY_MCP_PATH` | `/mcp` | URL path for the MCP endpoint |
 | `--remote-url` | `MEMORY_MCP_REMOTE_URL` | *(none)* | Git remote URL. Omit for local-only mode. |
 | `--branch` | `MEMORY_MCP_BRANCH` | `main` | Branch for push/pull operations |
+| `--max-sessions` | `MEMORY_MCP_MAX_SESSIONS` | `100` | Maximum concurrent MCP sessions |
+| `--session-rate-limit` | `MEMORY_MCP_SESSION_RATE_LIMIT` | `10` | Max new sessions per rate-limit window (0 to disable) |
+| `--session-rate-window-secs` | `MEMORY_MCP_SESSION_RATE_WINDOW_SECS` | `60` | Rate-limit window duration in seconds |
+| `--embed-timeout-secs` | `MEMORY_MCP_EMBED_TIMEOUT_SECS` | `30` | Max seconds per embedding call before timeout |
+| `--embed-queue-size` | `MEMORY_MCP_EMBED_QUEUE_SIZE` | `64` | Embedding request queue capacity |
 
 ## Authentication
 
@@ -316,6 +321,8 @@ Token resolution order: `MEMORY_MCP_GITHUB_TOKEN` env var → `~/.config/memory-
 ## Embedding model
 
 Embeddings are computed locally using [candle](https://github.com/huggingface/candle) with [BGE-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) (384 dimensions). The model is downloaded from HuggingFace Hub on first run — no API keys required. Use `memory-mcp warmup` to pre-download.
+
+A dedicated worker thread processes embedding requests sequentially. If a call exceeds `--embed-timeout-secs`, the caller gets an error but the worker recovers automatically and picks up the next request. Panics in the inference engine are caught and recovered from without killing the worker. On startup, the vector index is checked against the repo HEAD and rebuilt if stale or missing (e.g. after a crash).
 
 ## Deployment
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,16 +50,19 @@ Closed issues from original TODO: #60 (cargo-auditable), #62 (Trusted Publishing
 
 **Goal:** Lay the observability foundation early so all subsequent work is automatically instrumented. Improve dev workflow and testing infrastructure.
 
-| Issue | Title | Effort | Depends on |
-|-------|-------|--------|------------|
-| #52 (partial) | Tracing scaffold | Medium | -- |
-| #114 | Surface keep-alive timeout to clients | Small | -- |
-| #94 | Vector index trait abstraction | Medium | -- |
-| #109 | Content-level secret scanning | Medium | #108 |
-| #98 | Automate CHANGELOG without bypassing branch protection | Medium | -- |
-| #78 | `validate` subcommand + Docker build speedup | Large | -- |
-| #145 | Extract OAuth client ID from hardcoded const into config module | Small | -- |
-| #146 | Integration tests for auth login, auth status, MEMORY_MCP_BIND | Medium | -- |
+| Issue | Title | Effort | Depends on | Status |
+|-------|-------|--------|------------|--------|
+| #52 (partial) | Tracing scaffold | Medium | -- | **Done** (v0.8.0, PR #170) |
+| #94 | Vector index trait abstraction | Medium | -- | **Done** (v0.8.0, PR #177) |
+| #145 | DeviceFlowProvider trait | Small | -- | **Done** (v0.8.0, PR #178) |
+| #192 | Embed timeout — self-healing worker thread | Medium | -- | **Done** (v0.10.0, PR #199) |
+| #193 | Startup reindex after crash | Medium | -- | **Done** (v0.10.0, PR #199) |
+| #164 | `/readyz` health endpoint | Small | #94 | |
+| #114 | Surface keep-alive timeout to clients | Small | -- | |
+| #109 | Content-level secret scanning | Medium | #108 | |
+| #98 | Automate CHANGELOG without bypassing branch protection | Medium | -- | |
+| #78 | `validate` subcommand + Docker build speedup | Large | -- | |
+| #146 | Integration tests for auth login, auth status, MEMORY_MCP_BIND | Medium | -- | |
 
 **Key insight:** #52 (comprehensive tracing) is cross-cutting. The scaffold goes in Phase 2 so every new feature gets spans for free. Structured fields: operation, scope, memory_name, duration. OTLP export behind feature flag.
 
@@ -165,7 +168,7 @@ Items without a phase assignment yet. These will be scheduled as priorities beco
 
 ```
 Phase 1 (Stabilize)           ████████████████████  Done (v0.6.0/v0.6.1)
-Phase 2 (Tracing + Quality)   ░░░████░░░░░░░░░░░░░  Next
+Phase 2 (Tracing + Quality)   ░░░████████░░░░░░░░░░  In progress (5/11 done)
   #79 (GitHub App Auth)       ░░░░░██░░░░░░░░░░░░░  Interleave anytime
 Phase 3 (Transport/Stdio)     ░░░░░░░███░░░░░░░░░░  After core quality
 Phase 4 (Search/Lifecycle)    ░░░░░░░░░░███░░░░░░░  After transport

--- a/docs/adr/0026-channel-worker-embedding-engine.md
+++ b/docs/adr/0026-channel-worker-embedding-engine.md
@@ -1,0 +1,35 @@
+# ADR-0026: Channel-based worker thread for embedding engine
+
+## Status
+Accepted
+
+## Context
+The original embedding engine used `Arc<Mutex<CandleInner>>` with `tokio::task::spawn_blocking`.
+A candle-core infinite loop on ARM64 macOS (#194) held the mutex forever, permanently blocking
+all semantic operations (#192). The only recovery was `kill -9`, which left the index in an
+unrecoverable state (#193).
+
+Alternatives considered:
+- **Timeout + AtomicBool dead flag**: Wrapping `spawn_blocking` in `tokio::time::timeout` and
+  setting a "dead" flag on timeout. Rejected because the blocking thread keeps running with the
+  mutex held — subsequent callers would each block on `arc.lock()` before timing out. The dead
+  flag makes the engine permanently unavailable (no self-healing).
+- **Timeout + engine recreation**: Dropping the old `Arc<Mutex>` and creating a new engine on
+  timeout. Rejected due to complexity (model reload latency, HF cache concerns) and the risk
+  of the old thread still running with dangling references.
+
+## Decision
+Replace the mutex with a dedicated OS thread that owns `CandleInner` exclusively. Async callers
+send `(texts, oneshot::Sender)` via a bounded `mpsc::sync_channel` and await the reply with a
+configurable timeout. On timeout, the caller gets an error; the worker finishes its current task,
+discards the stale reply (send fails silently), and picks up the next request. `catch_unwind`
+in the worker loop catches panics without killing the thread. A `Drop` impl closes the channel
+and joins the worker.
+
+## Consequences
+- **Self-healing**: timeouts and panics are non-fatal; the engine recovers automatically.
+- **No mutex contention**: the worker owns the model exclusively; no shared mutable state.
+- **Backpressure**: bounded channel (configurable `--embed-queue-size`) rejects overflow immediately.
+- **Breaking API change**: `CandleEmbeddingEngine::new()` now requires `(Duration, usize)` params.
+  `CandleEmbeddingEngine` lost `UnwindSafe`/`RefUnwindSafe` auto-trait impls (due to `JoinHandle`
+  and `SyncSender` fields).


### PR DESCRIPTION
## Summary

Documentation updates following the v0.10.0 changes in #199.

- **README**: Add 5 missing CLI args to Configuration table (`--max-sessions`, `--session-rate-limit`, `--session-rate-window-secs`, `--embed-timeout-secs`, `--embed-queue-size`). Add embedding worker description to Embedding model section.
- **ROADMAP**: Add Status column to Phase 2 table showing 5/11 items done. Update progress bar.
- **ADR-0026**: New — documents the channel-based worker thread decision, alternatives considered (timeout+dead flag, timeout+engine recreation), and consequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)