### PR TITLE
feat: passive health reporting with /readyz endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [0.11.0] - 2026-05-10
+
+### Added
+- `/readyz` readiness probe endpoint with per-subsystem health reporting (git repo, embedding, vector index, sync)
+- `/healthz` liveness probe endpoint (always 200)
+- Passive health architecture: subsystems report their own operational state via `SubsystemReporter` backed by `arc-swap` — zero-contention, wait-free reads
+- `--require-remote-sync` flag: performs initial pull at startup, includes sync health in readiness checks
+- `--health-stale-secs` flag: opt-in staleness detection (disabled by default)
+- Transition-based logging: warn on degradation, info on recovery, debug on steady-state polling
+- ADR-0027: passive health reporting architecture
+
+### Changed
+- `CandleEmbeddingEngine::new()` now accepts a `SubsystemReporter` parameter
+- `UsearchStore` gains `new_with_reporter()` and `load_with_reporter()` constructors
+- `MemoryRepo` gains `init_or_open_with_reporter()` constructor with git + sync reporters
+- `AppState::new()` now accepts a `HealthRegistry` parameter
+- `read_memory` no longer marks git subsystem degraded on `NotFound` / `InvalidInput` errors
+- Startup health reporting is conditional on reindex success
+- Startup validation: `--require-remote-sync` without `--remote-url` is rejected immediately
+
+### Dependencies
+- Added `arc-swap` 1.x (wait-free atomic pointer swap for health state)
+
 ## [0.10.1] - 2026-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,9 +2045,10 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"
@@ -49,6 +49,7 @@ async-trait = "0.1"
 dirs = "6"
 mcp-session = "0.1"
 http = "1"
+arc-swap = "1"
 
 # Candle direct — pure-Rust BERT inference for embeddings.
 candle-core = "0.10"

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ All options can be set via CLI flags or environment variables:
 | `--session-rate-window-secs` | `MEMORY_MCP_SESSION_RATE_WINDOW_SECS` | `60` | Rate-limit window duration in seconds |
 | `--embed-timeout-secs` | `MEMORY_MCP_EMBED_TIMEOUT_SECS` | `30` | Max seconds per embedding call before timeout |
 | `--embed-queue-size` | `MEMORY_MCP_EMBED_QUEUE_SIZE` | `64` | Embedding request queue capacity |
+| `--require-remote-sync` | `MEMORY_MCP_REQUIRE_REMOTE_SYNC` | `false` | Include sync health in readiness checks. Performs initial pull at startup. |
+| `--health-stale-secs` | `MEMORY_MCP_HEALTH_STALE_SECS` | `0` (disabled) | Seconds before a subsystem with no activity is considered stale. 0 disables. |
 
 ## Authentication
 
@@ -323,6 +325,31 @@ Token resolution order: `MEMORY_MCP_GITHUB_TOKEN` env var → `~/.config/memory-
 Embeddings are computed locally using [candle](https://github.com/huggingface/candle) with [BGE-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) (384 dimensions). The model is downloaded from HuggingFace Hub on first run — no API keys required. Use `memory-mcp warmup` to pre-download.
 
 A dedicated worker thread processes embedding requests sequentially. If a call exceeds `--embed-timeout-secs`, the caller gets an error but the worker recovers automatically and picks up the next request. Panics in the inference engine are caught and recovered from without killing the worker. On startup, the vector index is checked against the repo HEAD and rebuilt if stale or missing (e.g. after a crash).
+
+## Health endpoints
+
+| Endpoint | Purpose | Status code |
+|----------|---------|-------------|
+| `GET /healthz` | Liveness probe — process is running | Always 200 |
+| `GET /readyz` | Readiness probe — subsystems operational | 200 or 503 |
+
+`/readyz` returns structured JSON with per-subsystem status:
+
+```json
+{
+  "status": "ready",
+  "checks": {
+    "git_repo": { "status": "up" },
+    "embedding": { "status": "up" },
+    "vector_index": { "status": "up" },
+    "sync": { "status": "up" }
+  }
+}
+```
+
+The `sync` field appears only when `--require-remote-sync` is enabled. Subsystems report their own health passively during normal operations — the handler reads the latest state with zero probing.
+
+When `--health-stale-secs` is set (e.g. `300`), a subsystem with no successful operations within that window is reported as `"down"` with reason `"stale"`. Disabled by default to prevent idle pods from being evicted.
 
 ## Deployment
 
@@ -358,6 +385,7 @@ The deployment is hardened with:
 - `readOnlyRootFilesystem`, `runAsNonRoot`, `drop: [ALL]` capabilities
 - Split ServiceAccounts (runtime vs bootstrap)
 - Seccomp `RuntimeDefault` profile
+- Liveness (`/healthz`) and readiness (`/readyz`) probes
 
 See [docs/deployment.md](docs/deployment.md) for the full guide.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Closed issues from original TODO: #60 (cargo-auditable), #62 (Trusted Publishing
 | #145 | DeviceFlowProvider trait | Small | -- | **Done** (v0.8.0, PR #178) |
 | #192 | Embed timeout — self-healing worker thread | Medium | -- | **Done** (v0.10.0, PR #199) |
 | #193 | Startup reindex after crash | Medium | -- | **Done** (v0.10.0, PR #199) |
-| #164 | `/readyz` health endpoint | Small | #94 | |
+| #164 | `/readyz` health endpoint | Small | #94 | **Done** (v0.11.0, PR #202) |
 | #114 | Surface keep-alive timeout to clients | Small | -- | |
 | #109 | Content-level secret scanning | Medium | #108 | |
 | #98 | Automate CHANGELOG without bypassing branch protection | Medium | -- | |

--- a/docs/adr/0027-passive-health-reporting.md
+++ b/docs/adr/0027-passive-health-reporting.md
@@ -1,0 +1,39 @@
+# ADR-0027: Passive health reporting via subsystem reporters
+
+## Status
+Accepted
+
+## Context
+The `/readyz` endpoint (issue #164) needs to answer "can this instance serve requests?"
+for Kubernetes readiness probes. An active-probing approach (handler queries each
+subsystem on every request) introduces contention: acquiring the repo mutex, calling
+trait methods, potentially blocking the async runtime with filesystem I/O. It also
+inverts responsibility — the probe must understand each subsystem's health semantics.
+
+## Decision
+Each subsystem (git repo, embedding engine, vector index) holds a `SubsystemReporter`
+that writes to a shared `ArcSwap<SubsystemStatus>` during normal operations. The
+`/readyz` handler reads the three snapshots — zero probing, zero contention, zero I/O.
+
+Health is reported at operation boundaries in the concrete implementations:
+- `MemoryRepo`: after local git operations (read, write, delete, list). Remote sync
+  failures do NOT affect readiness (per requirement R-21).
+- `CandleEmbeddingEngine`: after each embed response from the worker channel.
+- `UsearchStore`: after add/search operations.
+
+Subsystems start in "not yet checked" (unhealthy) state. Successful construction
+during startup reports initial health before the HTTP listener opens.
+
+Transition-based logging uses `compare_exchange` on a shared `AtomicBool` to emit
+`warn` only on ready-to-not-ready transitions, avoiding probe-interval log spam.
+
+## Consequences
+- `/readyz` is wait-free: three atomic loads + JSON serialization.
+- No mutex contention between the probe and real operations.
+- Health reflects actual operational reality, not synthetic checks.
+- Adding a new subsystem requires: add a reporter to `HealthRegistry`, pass it to
+  the implementation, call `report_ok`/`report_err` at operation boundaries.
+- The `arc-swap` crate is added as a runtime dependency (~2K lines, well-maintained).
+- Extends ADR-0006 (structured observability) to health reporting.
+- Complements ADR-0026 (channel worker) — the embed worker's response path is a
+  natural reporting site.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,6 +105,46 @@ Add to `~/.claude.json` (or your project-local `.mcp.json`):
 
 ---
 
+## Health probes
+
+The server exposes `/healthz` (liveness) and `/readyz` (readiness) on the same
+port as the MCP endpoint. Configure Kubernetes probes:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+`/readyz` returns 200 when all subsystems (git repo, embedding engine, vector
+index) are operational, and 503 with per-subsystem detail when any is degraded.
+Subsystems report health passively during normal operations — the probe does no
+active checking.
+
+### Sync readiness
+
+If `--require-remote-sync` is set, the server performs an initial pull at startup
+and includes sync health in readiness checks. Push/pull failures will cause
+`/readyz` to return 503. Requires `--remote-url` to be configured.
+
+### Staleness detection
+
+Set `--health-stale-secs` (e.g. `300`) to flag subsystems that haven't performed
+a successful operation within the threshold. Disabled by default (`0`) — enable
+only for deployments with consistent traffic where silence indicates a problem.
+
+---
+
 ## Operational notes
 
 ### Resource sizing

--- a/src/embedding/candle.rs
+++ b/src/embedding/candle.rs
@@ -12,6 +12,7 @@ use tokio::time::{timeout, Duration};
 
 use super::EmbeddingBackend;
 use crate::error::MemoryError;
+use crate::health::SubsystemReporter;
 
 /// HuggingFace model ID. Only BGE-small-en-v1.5 is supported currently.
 pub const MODEL_ID: &str = "BAAI/bge-small-en-v1.5";
@@ -40,6 +41,7 @@ pub struct CandleEmbeddingEngine {
     worker: Option<std::thread::JoinHandle<()>>,
     dim: usize,
     embed_timeout: Duration,
+    reporter: SubsystemReporter,
 }
 
 struct CandleInner {
@@ -61,7 +63,15 @@ impl CandleEmbeddingEngine {
     /// `queue_size` sets the bounded channel capacity — how many requests can
     /// queue behind the one being processed. Extra callers get an immediate
     /// "busy" error.
-    pub fn new(embed_timeout: Duration, queue_size: usize) -> Result<Self, MemoryError> {
+    ///
+    /// `reporter` receives `report_ok`/`report_err` after each embed call so
+    /// the `/readyz` handler can reflect the engine's operational state without
+    /// active probing.
+    pub fn new(
+        embed_timeout: Duration,
+        queue_size: usize,
+        reporter: SubsystemReporter,
+    ) -> Result<Self, MemoryError> {
         let device = Device::Cpu;
 
         let (config, mut tokenizer, weights_path) =
@@ -112,6 +122,7 @@ impl CandleEmbeddingEngine {
             worker: Some(worker),
             dim,
             embed_timeout,
+            reporter,
         })
     }
 
@@ -132,6 +143,7 @@ impl CandleEmbeddingEngine {
             worker: None,
             dim,
             embed_timeout,
+            reporter: SubsystemReporter::new(),
         }
     }
 }
@@ -215,7 +227,7 @@ impl EmbeddingBackend for CandleEmbeddingEngine {
                 }
             })?;
 
-        match timeout(self.embed_timeout, reply_rx).await {
+        let result = match timeout(self.embed_timeout, reply_rx).await {
             Ok(Ok(result)) => result,
             // Fires if the worker drops reply_tx without sending (e.g. a
             // double-panic that escapes catch_unwind, or a panic in span setup).
@@ -226,7 +238,15 @@ impl EmbeddingBackend for CandleEmbeddingEngine {
                 "embedding timed out after {:.1}s — the worker will recover automatically",
                 self.embed_timeout.as_secs_f64(),
             ))),
+        };
+
+        // Report operational state passively so /readyz reflects reality without probing.
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("embed failed"),
         }
+
+        result
     }
 
     fn dimensions(&self) -> usize {

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,313 @@
+//! Health reporting infrastructure and HTTP handlers.
+//!
+//! Subsystems report their own operational state via [`SubsystemReporter`].
+//! The `/readyz` handler reads the latest state — no active probing.
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::{Duration, Instant};
+
+use arc_swap::ArcSwap;
+use axum::response::IntoResponse;
+
+// ---------------------------------------------------------------------------
+// SubsystemStatus
+// ---------------------------------------------------------------------------
+
+/// Per-subsystem health snapshot. Immutable once created.
+pub struct SubsystemStatus {
+    /// Whether the subsystem is currently healthy.
+    pub healthy: bool,
+    /// Human-readable reason for an unhealthy state. `None` when healthy.
+    pub reason: Option<&'static str>,
+    /// Timestamp of the most recent successful operation.
+    /// Used for staleness detection — if healthy but last success is old, may be stale.
+    pub last_success: Option<Instant>,
+    /// Timestamp of the most recent failed operation.
+    pub last_failure: Option<Instant>,
+}
+
+impl SubsystemStatus {
+    fn initial() -> Self {
+        Self {
+            healthy: false,
+            reason: Some("not yet checked"),
+            last_success: None,
+            last_failure: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SubsystemReporter
+// ---------------------------------------------------------------------------
+
+/// Lightweight handle for a subsystem to report its health.
+///
+/// Clone is cheap (Arc clone). Each clone shares the same underlying state.
+#[derive(Clone)]
+pub struct SubsystemReporter {
+    state: Arc<ArcSwap<SubsystemStatus>>,
+}
+
+impl SubsystemReporter {
+    /// Create a new reporter. Initial state is "not yet checked" (unhealthy until first success).
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(ArcSwap::new(Arc::new(SubsystemStatus::initial()))),
+        }
+    }
+
+    /// Report a successful operation.
+    pub fn report_ok(&self) {
+        self.state.rcu(|current| {
+            Arc::new(SubsystemStatus {
+                healthy: true,
+                reason: None,
+                last_success: Some(Instant::now()),
+                last_failure: current.last_failure,
+            })
+        });
+    }
+
+    /// Report a failed operation with a static reason string.
+    pub fn report_err(&self, reason: &'static str) {
+        self.state.rcu(|current| {
+            Arc::new(SubsystemStatus {
+                healthy: false,
+                reason: Some(reason),
+                last_success: current.last_success,
+                last_failure: Some(Instant::now()),
+            })
+        });
+    }
+
+    /// Load the current status snapshot.
+    pub fn load(&self) -> arc_swap::Guard<Arc<SubsystemStatus>> {
+        self.state.load()
+    }
+}
+
+impl Default for SubsystemReporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HealthRegistry
+// ---------------------------------------------------------------------------
+
+/// Central registry holding reporters for all subsystems.
+///
+/// Lives on `AppState`. The `/readyz` handler reads from here — no active probing.
+pub struct HealthRegistry {
+    /// Reporter for the git-backed memory repository.
+    pub git: SubsystemReporter,
+    /// Reporter for the embedding engine.
+    pub embedding: SubsystemReporter,
+    /// Reporter for the vector index.
+    pub vector_index: SubsystemReporter,
+    /// Reporter for remote sync (push/pull) operations.
+    pub sync: SubsystemReporter,
+    /// Whether sync failures affect readiness (`/readyz` returns 503 on sync failure).
+    pub require_sync: bool,
+    /// Duration after which a healthy subsystem with no recent successes is
+    /// considered stale. `None` disables staleness detection.
+    pub stale_threshold: Option<Duration>,
+    was_ready: AtomicBool,
+}
+
+impl HealthRegistry {
+    /// Create a new registry with all subsystems in "not yet checked" state.
+    ///
+    /// `require_sync` controls whether sync failures affect readiness.
+    /// `stale_threshold` sets the staleness window (`None` to disable).
+    pub fn new() -> Self {
+        Self::with_config(false, None)
+    }
+
+    /// Create a registry with explicit sync-gating and staleness configuration.
+    pub fn with_config(require_sync: bool, stale_threshold: Option<Duration>) -> Self {
+        Self {
+            git: SubsystemReporter::new(),
+            embedding: SubsystemReporter::new(),
+            vector_index: SubsystemReporter::new(),
+            sync: SubsystemReporter::new(),
+            require_sync,
+            stale_threshold,
+            was_ready: AtomicBool::new(false),
+        }
+    }
+}
+
+impl Default for HealthRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response types for JSON serialisation
+// ---------------------------------------------------------------------------
+
+/// Top-level readiness response returned by `/readyz`.
+#[derive(serde::Serialize)]
+pub struct ReadyzResponse {
+    /// `"ready"` or `"not_ready"`.
+    pub status: &'static str,
+    /// Per-subsystem check results.
+    pub checks: ReadyzChecks,
+}
+
+/// Individual subsystem check results.
+#[derive(serde::Serialize)]
+pub struct ReadyzChecks {
+    /// Git repository lock status.
+    pub git_repo: CheckResult,
+    /// Embedding model status.
+    pub embedding: CheckResult,
+    /// Vector index status.
+    pub vector_index: CheckResult,
+    /// Remote sync status. Present only when `--require-remote-sync` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sync: Option<CheckResult>,
+}
+
+/// Result of a single subsystem health check.
+#[derive(serde::Serialize)]
+pub struct CheckResult {
+    /// `"up"` or `"down"`.
+    pub status: &'static str,
+    /// Present only when `status` is `"down"` — fixed vocabulary, no dynamic content.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<&'static str>,
+}
+
+impl From<&SubsystemStatus> for CheckResult {
+    fn from(s: &SubsystemStatus) -> Self {
+        if s.healthy {
+            Self {
+                status: "up",
+                reason: None,
+            }
+        } else {
+            Self {
+                status: "down",
+                reason: s.reason,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Staleness helpers
+// ---------------------------------------------------------------------------
+
+/// Derive a `CheckResult` from a status snapshot, applying staleness detection
+/// when `threshold` is `Some`.
+///
+/// A subsystem that reports `healthy = true` but whose `last_success` is older
+/// than `threshold` is considered stale and returned as `"down"` with reason
+/// `"stale"`.
+fn check_with_staleness(status: &SubsystemStatus, threshold: Option<Duration>) -> CheckResult {
+    if !status.healthy {
+        return CheckResult::from(status);
+    }
+    if let Some(threshold) = threshold {
+        if let Some(last_success) = status.last_success {
+            if last_success.elapsed() > threshold {
+                return CheckResult {
+                    status: "down",
+                    reason: Some("stale"),
+                };
+            }
+        }
+        // No last_success but healthy (e.g. freshly reported via startup) — not stale yet.
+    }
+    CheckResult::from(status)
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handlers
+// ---------------------------------------------------------------------------
+
+/// Handler for `GET /readyz`.
+///
+/// Reads the latest reported state from each subsystem reporter — no active
+/// probing. Returns `200 OK` when all subsystems are up, `503` otherwise.
+pub async fn readyz_handler(
+    axum::extract::State(state): axum::extract::State<Arc<crate::types::AppState>>,
+) -> axum::response::Response {
+    let threshold = state.health.stale_threshold;
+
+    let git = state.health.git.load();
+    let embedding = state.health.embedding.load();
+    let vector_index = state.health.vector_index.load();
+
+    let git_check = check_with_staleness(&git, threshold);
+    let embedding_check = check_with_staleness(&embedding, threshold);
+    let vector_index_check = check_with_staleness(&vector_index, threshold);
+
+    let sync_check = if state.health.require_sync {
+        let sync = state.health.sync.load();
+        Some(check_with_staleness(&sync, threshold))
+    } else {
+        None
+    };
+
+    let all_up = git_check.status == "up"
+        && embedding_check.status == "up"
+        && vector_index_check.status == "up"
+        && sync_check.as_ref().is_none_or(|s| s.status == "up");
+
+    let response = ReadyzResponse {
+        status: if all_up { "ready" } else { "not_ready" },
+        checks: ReadyzChecks {
+            git_repo: git_check,
+            embedding: embedding_check,
+            vector_index: vector_index_check,
+            sync: sync_check,
+        },
+    };
+
+    // Transition-based logging via compare_exchange.
+    let status_code = if all_up {
+        if state
+            .health
+            .was_ready
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            tracing::info!("readyz: all subsystems up");
+        }
+        axum::http::StatusCode::OK
+    } else {
+        if state
+            .health
+            .was_ready
+            .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            tracing::warn!(
+                git_repo = response.checks.git_repo.status,
+                embedding = response.checks.embedding.status,
+                vector_index = response.checks.vector_index.status,
+                sync = response.checks.sync.as_ref().map_or("n/a", |s| s.status),
+                "readyz degraded: subsystem(s) down",
+            );
+        } else {
+            tracing::debug!("readyz check: not ready");
+        }
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (status_code, axum::Json(response)).into_response()
+}
+
+/// Handler for `GET /healthz` (liveness probe — always 200 OK).
+pub async fn healthz_handler() -> impl IntoResponse {
+    axum::Json(serde_json::json!({"status": "ok"}))
+}

--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -12,6 +12,7 @@ use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
 
 use crate::{
     error::MemoryError,
+    health::SubsystemReporter,
     types::{validate_name, Scope, ScopeFilter},
 };
 
@@ -394,6 +395,7 @@ impl<R: RawIndex> VectorIndex<R> {
 #[non_exhaustive]
 pub struct UsearchStore {
     inner: UsearchStoreInner<UsearchRawIndex>,
+    reporter: SubsystemReporter,
 }
 
 /// Generic inner implementation, separated so tests can substitute `R`.
@@ -414,7 +416,18 @@ struct UsearchStoreInner<R: RawIndex> {
 
 impl UsearchStore {
     /// Create a new `UsearchStore` with empty global + all indexes.
+    ///
+    /// `reporter` is called with `report_ok`/`report_err` after each `add` and
+    /// `search` so `/readyz` reflects the store's operational state passively.
     pub fn new(dimensions: usize) -> Result<Self, MemoryError> {
+        Self::new_with_reporter(dimensions, SubsystemReporter::new())
+    }
+
+    /// Create a new `UsearchStore` with a specific health reporter.
+    pub fn new_with_reporter(
+        dimensions: usize,
+        reporter: SubsystemReporter,
+    ) -> Result<Self, MemoryError> {
         let global = VectorIndex::new(dimensions)?;
         let all = VectorIndex::new(dimensions)?;
         let mut scopes = HashMap::new();
@@ -425,6 +438,7 @@ impl UsearchStore {
                 all,
                 dimensions,
             },
+            reporter,
         })
     }
 
@@ -433,6 +447,15 @@ impl UsearchStore {
     /// Missing subdirectories are treated as empty — those scopes will be
     /// rebuilt incrementally on next use.
     pub fn load(dir: &Path, dimensions: usize) -> Result<Self, MemoryError> {
+        Self::load_with_reporter(dir, dimensions, SubsystemReporter::new())
+    }
+
+    /// Load all indexes from subdirectories under `dir` with a specific health reporter.
+    pub fn load_with_reporter(
+        dir: &Path,
+        dimensions: usize,
+        reporter: SubsystemReporter,
+    ) -> Result<Self, MemoryError> {
         let span = tracing::info_span!("index.load", key_count = tracing::field::Empty,);
         let _enter = span.enter();
 
@@ -444,7 +467,7 @@ impl UsearchStore {
         if dirty_marker.exists() {
             tracing::warn!("detected interrupted index save — discarding indexes");
             let _ = std::fs::remove_file(&dirty_marker);
-            return Self::new(dimensions);
+            return Self::new_with_reporter(dimensions, reporter);
         }
 
         // Load all-index.
@@ -509,6 +532,7 @@ impl UsearchStore {
                 all,
                 dimensions,
             },
+            reporter,
         })
     }
 }
@@ -773,11 +797,21 @@ impl crate::index::VectorStore for UsearchStore {
         vector: &[f32],
         qualified_name: String,
     ) -> Result<u64, MemoryError> {
-        self.inner.add(scope, vector, qualified_name)
+        let result = self.inner.add(scope, vector, qualified_name);
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("index add failed"),
+        }
+        result
     }
 
     fn remove(&self, scope: &Scope, qualified_name: &str) -> Result<(), MemoryError> {
-        self.inner.remove(scope, qualified_name)
+        let result = self.inner.remove(scope, qualified_name);
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("index remove failed"),
+        }
+        result
     }
 
     fn search(
@@ -786,7 +820,12 @@ impl crate::index::VectorStore for UsearchStore {
         query: &[f32],
         limit: usize,
     ) -> Result<Vec<(u64, String, f32)>, MemoryError> {
-        self.inner.search(filter, query, limit)
+        let result = self.inner.search(filter, query, limit);
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("index search failed"),
+        }
+        result
     }
 
     fn find_by_name(&self, qualified_name: &str) -> Option<u64> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod embedding;
 pub mod error;
 /// Filesystem utilities — atomic writes with crash-safe temp-file-then-rename.
 pub(crate) mod fs_util;
+/// HTTP health-check handlers (`/readyz`).
+pub mod health;
 /// HNSW vector index for approximate nearest-neighbour search.
 pub mod index;
 /// Git-backed memory repository — read, write, sync, and diff operations.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider as OtlpProvider;
 
 use memory_mcp::auth::{self, AuthProvider, StoreBackend};
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend, MODEL_ID};
+use memory_mcp::health::{healthz_handler, readyz_handler, HealthRegistry};
 use memory_mcp::index::{UsearchStore, VectorStore};
 use memory_mcp::repo::MemoryRepo;
 use memory_mcp::server::MemoryServer;
@@ -131,6 +132,16 @@ struct ServeArgs {
     /// `memory-mcp.svc.echoes`). Can be specified multiple times.
     #[arg(long, env = "MEMORY_MCP_ALLOWED_HOST")]
     allowed_host: Vec<String>,
+
+    /// Include remote sync health in readiness checks. When enabled, push/pull
+    /// failures will cause /readyz to return 503.
+    #[arg(long, default_value_t = false, env = "MEMORY_MCP_REQUIRE_REMOTE_SYNC")]
+    require_remote_sync: bool,
+
+    /// Seconds after which a subsystem with no successful operations is considered
+    /// stale. Set to 0 to disable staleness detection (default).
+    #[arg(long, default_value_t = 0, env = "MEMORY_MCP_HEALTH_STALE_SECS")]
+    health_stale_secs: u64,
 
     #[command(flatten)]
     embed: EmbedArgs,
@@ -387,14 +398,35 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Filter out empty string to treat MEMORY_MCP_REMOTE_URL="" as unset.
     let remote_url = args.remote_url.filter(|u| !u.is_empty());
 
+    if args.require_remote_sync && remote_url.is_none() {
+        anyhow::bail!("--require-remote-sync requires --remote-url to be set");
+    }
+
+    // Create the health registry early so reporters can be passed to subsystems.
+    let stale_threshold = if args.health_stale_secs == 0 {
+        None
+    } else {
+        Some(std::time::Duration::from_secs(args.health_stale_secs))
+    };
+    let health = HealthRegistry::with_config(args.require_remote_sync, stale_threshold);
+
     // Initialise subsystems — each called function creates its own span.
-    let repo = MemoryRepo::init_or_open(&repo_path, remote_url.as_deref())
-        .with_context(|| format!("failed to open/init repo at {}", repo_path.display()))?;
+    let repo = MemoryRepo::init_or_open_with_reporter(
+        &repo_path,
+        remote_url.as_deref(),
+        health.git.clone(),
+        health.sync.clone(),
+    )
+    .with_context(|| format!("failed to open/init repo at {}", repo_path.display()))?;
 
     let embed_timeout = std::time::Duration::from_secs(args.embed.embed_timeout_secs);
     let embedding: Box<dyn EmbeddingBackend> = Box::new(
-        CandleEmbeddingEngine::new(embed_timeout, args.embed.embed_queue_size)
-            .context("failed to init embedding engine")?,
+        CandleEmbeddingEngine::new(
+            embed_timeout,
+            args.embed.embed_queue_size,
+            health.embedding.clone(),
+        )
+        .context("failed to init embedding engine")?,
     );
 
     let dimensions = embedding.dimensions();
@@ -423,62 +455,99 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // If the SHA doesn't match, discard the loaded index entirely and start
     // fresh — this prevents ghost entries from deleted memories lingering.
     let mut index: Box<dyn VectorStore> = Box::new(
-        UsearchStore::load(&index_dir, dimensions).unwrap_or_else(|e| {
-            tracing::warn!("could not load index ({}), creating fresh", e);
-            UsearchStore::new(dimensions).expect("failed to create index")
-        }),
+        UsearchStore::load_with_reporter(&index_dir, dimensions, health.vector_index.clone())
+            .unwrap_or_else(|e| {
+                tracing::warn!("could not load index ({}), creating fresh", e);
+                UsearchStore::new_with_reporter(dimensions, health.vector_index.clone())
+                    .expect("failed to create index")
+            }),
     );
 
     let head_sha = repo.head_sha().await;
     let needs_reindex = head_sha != index.commit_sha();
+    // Track whether the reindex (if it ran) completed without errors.
+    // Used below to gate startup report_ok for embedding and vector_index.
+    let reindex_ok;
     if needs_reindex {
         info!(
             head = ?head_sha,
             index = ?index.commit_sha(),
             "index SHA does not match repo HEAD — rebuilding from scratch"
         );
-        index = Box::new(UsearchStore::new(dimensions).expect("failed to create index"));
+        index = Box::new(
+            UsearchStore::new_with_reporter(dimensions, health.vector_index.clone())
+                .expect("failed to create index"),
+        );
 
-        match memory_mcp::server::full_reindex(&repo, embedding.as_ref(), index.as_ref())
-            .instrument(tracing::info_span!("startup.full_reindex"))
-            .await
-        {
-            Ok(stats) => {
-                info!(
-                    added = stats.added,
-                    errors = stats.errors,
-                    "startup reindex complete"
-                );
-                if stats.added > 0 || stats.errors == 0 {
-                    if stats.errors > 0 {
-                        tracing::warn!(
+        reindex_ok =
+            match memory_mcp::server::full_reindex(&repo, embedding.as_ref(), index.as_ref())
+                .instrument(tracing::info_span!("startup.full_reindex"))
+                .await
+            {
+                Ok(stats) => {
+                    info!(
+                        added = stats.added,
+                        errors = stats.errors,
+                        "startup reindex complete"
+                    );
+                    if stats.added > 0 || stats.errors == 0 {
+                        if stats.errors > 0 {
+                            tracing::warn!(
                             added = stats.added,
                             errors = stats.errors,
                             "startup reindex partially failed — some memories may not be searchable"
                         );
+                        }
+                        if let Some(sha) = &head_sha {
+                            index.set_commit_sha(Some(sha));
+                        }
+                        stats.errors == 0
+                    } else {
+                        tracing::warn!(
+                            errors = stats.errors,
+                            "all embeds failed — SHA not stamped, will retry on next startup"
+                        );
+                        false
                     }
-                    if let Some(sha) = &head_sha {
-                        index.set_commit_sha(Some(sha));
-                    }
-                } else {
-                    tracing::warn!(
-                        errors = stats.errors,
-                        "all embeds failed — SHA not stamped, will retry on next startup"
-                    );
                 }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "startup reindex failed — SHA not stamped, will retry on next startup"
-                );
-            }
-        }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "startup reindex failed — SHA not stamped, will retry on next startup"
+                    );
+                    false
+                }
+            };
     } else {
         tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
+        reindex_ok = true;
     }
 
     let auth = AuthProvider::new();
+
+    // When --require-remote-sync is set, perform an initial pull so the sync
+    // reporter starts with a known state (and the local repo is up-to-date).
+    if args.require_remote_sync && remote_url.is_some() {
+        info!("--require-remote-sync: performing initial pull");
+        match repo.pull(&auth, &args.branch).await {
+            Ok(result) => {
+                info!(?result, "initial pull completed");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "initial pull failed — sync reporter will show degraded");
+            }
+        }
+    }
+
+    // Mark git as healthy — if we reached this point, git init/open succeeded.
+    health.git.report_ok();
+    // Only mark embedding and vector_index healthy if the reindex succeeded or
+    // was skipped (SHA matched). If the reindex had errors, the subsystems have
+    // already reported their own state via their reporters.
+    if reindex_ok {
+        health.embedding.report_ok();
+        health.vector_index.report_ok();
+    }
 
     let state = Arc::new(AppState::new(
         repo,
@@ -486,6 +555,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         embedding,
         index,
         auth,
+        health,
     ));
 
     // Keep a reference for post-shutdown index persistence.
@@ -526,16 +596,10 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     let mcp_path = args.mcp_path.clone();
     let router = axum::Router::new()
-        .route(
-            // Static liveness check. Always returns 200 OK once the process is
-            // running. NOTE: a /readyz endpoint performing subsystem health checks
-            // (repo accessible, index loaded, embedding model ready) should be
-            // added when multi-replica deployments are supported.
-            "/healthz",
-            axum::routing::get(|| async {
-                axum::response::Json(serde_json::json!({"status": "ok"}))
-            }),
-        )
+        // Static liveness check. Always returns 200 OK once the process is running.
+        .route("/healthz", axum::routing::get(healthz_handler))
+        .route("/readyz", axum::routing::get(readyz_handler))
+        .with_state(Arc::clone(&state_for_shutdown))
         .nest_service(&mcp_path, service);
 
     let listener = tokio::net::TcpListener::bind(&args.bind)
@@ -573,10 +637,12 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 /// Load the embedding model and run a single dummy embed to warm the on-disk
 /// model cache, then exit. Intended for use as a Kubernetes init container.
 async fn run_warmup(args: WarmupArgs) -> anyhow::Result<()> {
+    use memory_mcp::health::SubsystemReporter;
     info!("warming up embedding model '{}'", MODEL_ID);
     let engine = CandleEmbeddingEngine::new(
         std::time::Duration::from_secs(args.embed.embed_timeout_secs),
         args.embed.embed_queue_size,
+        SubsystemReporter::new(),
     )
     .context("failed to init embedding engine")?;
     // Run one dummy embed to ensure the model weights are fully loaded and any

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -11,6 +11,7 @@ use secrecy::{ExposeSecret, SecretString};
 use crate::{
     auth::AuthProvider,
     error::MemoryError,
+    health::SubsystemReporter,
     types::{validate_name, ChangedMemories, Memory, PullResult, Scope},
 };
 
@@ -108,6 +109,8 @@ fn build_auth_callbacks(token: SecretString) -> git2::RemoteCallbacks<'static> {
 pub struct MemoryRepo {
     inner: Mutex<Repository>,
     root: PathBuf,
+    reporter: SubsystemReporter,
+    sync_reporter: SubsystemReporter,
 }
 
 // SAFETY: Repository holds raw pointers but is documented as safe to send
@@ -121,7 +124,27 @@ impl MemoryRepo {
     ///
     /// If `remote_url` is provided, ensures an `origin` remote exists pointing
     /// at that URL (creating or updating it as necessary).
+    ///
+    /// `reporter` receives `report_ok`/`report_err` after local git operations
+    /// so `/readyz` reflects the repository's operational state passively.
     pub fn init_or_open(path: &Path, remote_url: Option<&str>) -> Result<Self, MemoryError> {
+        Self::init_or_open_with_reporter(
+            path,
+            remote_url,
+            SubsystemReporter::new(),
+            SubsystemReporter::new(),
+        )
+    }
+
+    /// Open or initialise a git repo with specific health reporters.
+    ///
+    /// `reporter` tracks local git operations; `sync_reporter` tracks push/pull.
+    pub fn init_or_open_with_reporter(
+        path: &Path,
+        remote_url: Option<&str>,
+        reporter: SubsystemReporter,
+        sync_reporter: SubsystemReporter,
+    ) -> Result<Self, MemoryError> {
         let _span = tracing::info_span!("repo.init").entered();
 
         let repo = if path.join(".git").exists() {
@@ -177,6 +200,8 @@ impl MemoryRepo {
         Ok(Self {
             inner: Mutex::new(repo),
             root: path.to_path_buf(),
+            reporter,
+            sync_reporter,
         })
     }
 
@@ -226,7 +251,7 @@ impl MemoryRepo {
         // Capture span before entering spawn_blocking so the child thread can record oid.
         let span = tracing::debug_span!("repo.save", name = %name, oid = tracing::field::Empty);
 
-        tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -258,7 +283,13 @@ impl MemoryRepo {
             Ok(())
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("save_memory failed"),
+        }
+        result
     }
 
     /// Remove a memory's file and commit the deletion.
@@ -279,7 +310,7 @@ impl MemoryRepo {
         let name = name.to_string();
         let file_path_clone = file_path.clone();
         let span = tracing::debug_span!("repo.delete", name = %name);
-        tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -333,7 +364,13 @@ impl MemoryRepo {
             Ok(())
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("delete_memory failed"),
+        }
+        result
     }
 
     /// Read and parse a memory from disk.
@@ -353,7 +390,7 @@ impl MemoryRepo {
         let arc = Arc::clone(self);
         let name = name.to_string();
         let span = tracing::debug_span!("repo.read", name = %name);
-        tokio::task::spawn_blocking(move || -> Result<Memory, MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<Memory, MemoryError> {
             let _enter = span.entered();
             // Check existence/symlink status before opening.
             match std::fs::symlink_metadata(&file_path) {
@@ -372,7 +409,17 @@ impl MemoryRepo {
             Memory::from_markdown(&raw)
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(MemoryError::NotFound { .. }) | Err(MemoryError::InvalidInput { .. }) => {
+                // Application-level errors — the repo itself is fine.
+                self.reporter.report_ok();
+            }
+            Err(_) => self.reporter.report_err("read_memory failed"),
+        }
+        result
     }
 
     /// List all memories, optionally filtered by scope.
@@ -384,7 +431,7 @@ impl MemoryRepo {
         let scope_clone = scope.cloned();
         let span = tracing::debug_span!("repo.list", file_count = tracing::field::Empty,);
 
-        tokio::task::spawn_blocking(move || -> Result<Vec<Memory>, MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<Vec<Memory>, MemoryError> {
             let _enter = span.entered();
             let dirs: Vec<PathBuf> = match scope_clone.as_ref() {
                 Some(s) => vec![root.join(s.dir_prefix())],
@@ -449,7 +496,13 @@ impl MemoryRepo {
             Ok(memories)
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("list_memories failed"),
+        }
+        result
     }
 
     /// Push local commits to `origin/<branch>`.
@@ -469,7 +522,7 @@ impl MemoryRepo {
         let branch = branch.to_string();
         let span = tracing::debug_span!("repo.push", branch = %branch);
 
-        tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -520,7 +573,13 @@ impl MemoryRepo {
             Ok(())
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.sync_reporter.report_ok(),
+            Err(_) => self.sync_reporter.report_err("push failed"),
+        }
+        result
     }
 
     /// Perform a normal (non-fast-forward) merge of `fetch_commit` into HEAD.
@@ -613,7 +672,7 @@ impl MemoryRepo {
         let branch = branch.to_string();
         let span = tracing::debug_span!("repo.pull", branch = %branch);
 
-        tokio::task::spawn_blocking(move || -> Result<PullResult, MemoryError> {
+        let result = tokio::task::spawn_blocking(move || -> Result<PullResult, MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -681,7 +740,13 @@ impl MemoryRepo {
             arc.merge_with_remote(&repo, &fetch_commit, &branch)
         })
         .await
-        .map_err(|e| MemoryError::Join(e.to_string()))?
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.sync_reporter.report_ok(),
+            Err(_) => self.sync_reporter.report_err("pull failed"),
+        }
+        result
     }
 
     /// Diff two commits and return the memory files that changed.

--- a/src/types.rs
+++ b/src/types.rs
@@ -570,7 +570,8 @@ pub struct ReindexStats {
 use std::sync::Arc;
 
 use crate::{
-    auth::AuthProvider, embedding::EmbeddingBackend, index::VectorStore, repo::MemoryRepo,
+    auth::AuthProvider, embedding::EmbeddingBackend, health::HealthRegistry, index::VectorStore,
+    repo::MemoryRepo,
 };
 
 /// Shared application state threaded through the Axum server.
@@ -589,6 +590,8 @@ pub struct AppState {
     pub auth: AuthProvider,
     /// Branch name used for push/pull operations (default: "main").
     pub branch: String,
+    /// Passive health registry — subsystems report here, `/readyz` reads here.
+    pub health: HealthRegistry,
 }
 
 impl AppState {
@@ -599,6 +602,7 @@ impl AppState {
         embedding: Box<dyn EmbeddingBackend>,
         index: Box<dyn VectorStore>,
         auth: AuthProvider,
+        health: HealthRegistry,
     ) -> Self {
         Self {
             repo,
@@ -606,6 +610,7 @@ impl AppState {
             index,
             auth,
             branch,
+            health,
         }
     }
 }

--- a/tests/candle_embedding.rs
+++ b/tests/candle_embedding.rs
@@ -7,6 +7,7 @@
 use std::time::Duration;
 
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend};
+use memory_mcp::health::SubsystemReporter;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -20,7 +21,7 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// The engine must produce 384-dimensional vectors for BGE-small-en-v1.5.
 #[tokio::test]
 async fn produces_384_dim_vectors() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     assert_eq!(engine.dimensions(), 384);
 
     let vec = engine.embed_one("hello world").await.unwrap();
@@ -30,7 +31,7 @@ async fn produces_384_dim_vectors() {
 /// Vectors must be L2-normalised (unit length).
 #[tokio::test]
 async fn vectors_are_normalised() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     let vec = engine.embed_one("test normalisation").await.unwrap();
     let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
     assert!((norm - 1.0).abs() < 1e-4, "expected unit norm, got {norm}");
@@ -39,7 +40,7 @@ async fn vectors_are_normalised() {
 /// Same input must produce identical output (deterministic).
 #[tokio::test]
 async fn self_consistency() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     let a = engine.embed_one("determinism check").await.unwrap();
     let b = engine.embed_one("determinism check").await.unwrap();
     assert_eq!(a, b);
@@ -48,7 +49,7 @@ async fn self_consistency() {
 /// Semantically similar texts should cluster together.
 #[tokio::test]
 async fn semantic_similarity() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
 
     let rust = engine.embed_one("Rust programming language").await.unwrap();
     let cargo = engine
@@ -72,7 +73,7 @@ async fn semantic_similarity() {
 /// Batch embed must return one vector per input, all normalised.
 #[tokio::test]
 async fn batch_embed() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     let texts: Vec<String> = vec!["first".into(), "second".into(), "third".into()];
     let vecs = engine.embed(&texts).await.unwrap();
     assert_eq!(vecs.len(), 3);
@@ -87,7 +88,7 @@ async fn batch_embed() {
 /// This validates that the attention mask correctly excludes padding tokens.
 #[tokio::test]
 async fn batch_single_consistency() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
 
     // Deliberately different lengths to force padding in the batch path.
     let short = "hi";
@@ -119,7 +120,7 @@ async fn batch_single_consistency() {
 /// Embedding an empty batch must return an empty vec (not an error).
 #[tokio::test]
 async fn empty_batch_returns_empty() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     let result = engine.embed(&[]).await.unwrap();
     assert!(result.is_empty());
 }
@@ -129,7 +130,7 @@ async fn empty_batch_returns_empty() {
 /// vectors are identical regardless of which chunk they land in.
 #[tokio::test]
 async fn large_batch_is_chunked() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
 
     // 65 texts: first chunk of 64, second chunk of 1.
     let texts: Vec<String> = (0..65).map(|i| format!("sentence number {i}")).collect();
@@ -159,7 +160,7 @@ async fn large_batch_is_chunked() {
 /// Text exceeding the 512-token limit must be truncated, not rejected.
 #[tokio::test]
 async fn long_text_is_truncated() {
-    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64).unwrap();
+    let engine = CandleEmbeddingEngine::new(TEST_TIMEOUT, 64, SubsystemReporter::new()).unwrap();
     let long_text = "word ".repeat(600); // ~600 tokens, well over the 512 limit
     let vec = engine.embed_one(&long_text).await.unwrap();
     assert_eq!(vec.len(), 384);

--- a/tests/readyz.rs
+++ b/tests/readyz.rs
@@ -1,0 +1,197 @@
+//! Integration tests for the `/readyz` health endpoint.
+//!
+//! The healthy-path test spins up the real binary. The degraded-path test
+//! constructs its own axum server with a controlled `AppState` so we can
+//! inject subsystem failures without modifying the production binary.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use memory_mcp::auth::AuthProvider;
+use memory_mcp::embedding::EmbeddingBackend;
+use memory_mcp::error::MemoryError;
+use memory_mcp::health::{readyz_handler, HealthRegistry};
+use memory_mcp::index::InMemoryStore;
+use memory_mcp::repo::MemoryRepo;
+use memory_mcp::types::AppState;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Start the real server binary with a fresh repo and wait for /healthz.
+async fn start_server(extra_args: &[&str]) -> (tokio::process::Child, u16, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo_path = tmp.path().to_str().expect("non-utf8 temp path");
+    let port = portpicker::pick_unused_port().expect("no free port");
+    let bind = format!("127.0.0.1:{port}");
+
+    let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_memory-mcp"));
+    cmd.args(["serve", "--bind", &bind, "--repo-path", repo_path])
+        .args(extra_args)
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    let child = cmd.spawn().expect("failed to start memory-mcp");
+
+    let client = reqwest::Client::new();
+    let healthz_url = format!("http://{bind}/healthz");
+    for _ in 0..100 {
+        if client.get(&healthz_url).send().await.is_ok() {
+            return (child, port, tmp);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("server did not become ready within 10s");
+}
+
+/// A stub embedding backend — used for AppState construction in the degraded
+/// test. Health is controlled via the HealthRegistry, not this backend.
+struct StubEmbeddingBackend;
+
+#[async_trait::async_trait]
+impl EmbeddingBackend for StubEmbeddingBackend {
+    async fn embed(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        Ok(vec![])
+    }
+
+    fn dimensions(&self) -> usize {
+        4
+    }
+}
+
+/// Build a test server with a degraded `AppState` and return its base URL.
+///
+/// The `/readyz` handler reads directly from the `HealthRegistry`, so we
+/// control the reported state by calling `report_err` on reporters before
+/// the server starts — no need to inject failures through the subsystems.
+async fn start_degraded_server() -> (u16, tempfile::TempDir, tokio::task::JoinHandle<()>) {
+    let tmp = tempfile::tempdir().expect("failed to create temp dir");
+    let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo init");
+
+    // Build a registry and mark the embedding subsystem as degraded.
+    // git_repo and vector_index are left at "not yet checked" (also unhealthy),
+    // but we explicitly mark embedding to test the reason field.
+    let registry = HealthRegistry::new();
+    registry.embedding.report_err("embed failed");
+
+    let state = Arc::new(AppState::new(
+        Arc::new(repo),
+        "main".to_string(),
+        Box::new(StubEmbeddingBackend),
+        Box::new(InMemoryStore::new(4)),
+        AuthProvider::new(),
+        registry,
+    ));
+
+    let router = axum::Router::new()
+        .route(
+            "/healthz",
+            axum::routing::get(|| async {
+                axum::response::Json(serde_json::json!({"status": "ok"}))
+            }),
+        )
+        .route("/readyz", axum::routing::get(readyz_handler))
+        .with_state(state);
+
+    let port = portpicker::pick_unused_port().expect("no free port");
+    let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{port}"))
+        .await
+        .expect("bind");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+
+    // Wait for the server to accept connections.
+    let client = reqwest::Client::new();
+    for _ in 0..50 {
+        if client
+            .get(format!("http://127.0.0.1:{port}/healthz"))
+            .send()
+            .await
+            .is_ok()
+        {
+            return (port, tmp, handle);
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("degraded test server did not start within 2.5s");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Healthy server (real binary): /readyz returns 200 with all subsystems "up".
+#[tokio::test]
+async fn readyz_healthy_server_returns_200_ready() {
+    let (mut child, port, _tmp) = start_server(&[]).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/readyz"))
+        .send()
+        .await
+        .expect("readyz request should succeed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "healthy server should return 200"
+    );
+
+    let body: serde_json::Value = resp.json().await.expect("body should be valid JSON");
+
+    assert_eq!(body["status"], "ready");
+
+    for check in &["git_repo", "embedding", "vector_index"] {
+        assert_eq!(
+            body["checks"][check]["status"], "up",
+            "check '{check}' should be 'up', got: {body}"
+        );
+        assert!(
+            body["checks"][check]["reason"].is_null(),
+            "check '{check}' should have no reason when up"
+        );
+    }
+
+    child.kill().await.ok();
+}
+
+/// Degraded server (test-controlled): /readyz returns 503 with failing subsystems.
+///
+/// The HealthRegistry is the source of truth — we mark subsystems as degraded
+/// directly via `report_err`, bypassing any subsystem implementation details.
+#[tokio::test]
+async fn readyz_degraded_server_returns_503_not_ready() {
+    let (port, _tmp, handle) = start_degraded_server().await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/readyz"))
+        .send()
+        .await
+        .expect("readyz request should succeed");
+
+    assert_eq!(
+        resp.status().as_u16(),
+        503,
+        "degraded server should return 503"
+    );
+
+    let body: serde_json::Value = resp.json().await.expect("body should be valid JSON");
+
+    assert_eq!(body["status"], "not_ready");
+
+    // Embedding was explicitly marked down with a reason.
+    assert_eq!(body["checks"]["embedding"]["status"], "down");
+    assert_eq!(body["checks"]["embedding"]["reason"], "embed failed");
+
+    // Git and vector_index were never reported (still "not yet checked").
+    assert_eq!(body["checks"]["git_repo"]["status"], "down");
+    assert_eq!(body["checks"]["vector_index"]["status"], "down");
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary

- Adds `/readyz` readiness probe and `/healthz` liveness probe endpoints
- Subsystems (git repo, embedding, vector index, sync) passively report their own health via `SubsystemReporter` backed by `arc-swap` — the handler reads the latest state with zero probing, zero contention
- `--require-remote-sync` flag performs an initial pull at startup and includes sync health in readiness checks
- `--health-stale-secs` enables opt-in staleness detection (disabled by default to avoid idle death-spiral)
- Transition-based logging via `compare_exchange` (warn on degradation, info on recovery, debug steady-state)
- ADR-0027 documents the passive health architecture

## Design decisions

- **Passive over active**: subsystems know their own health best. The probe just reads reported state.
- **`arc-swap` + `rcu`**: wait-free reads, atomic updates, no torn reads across fields.
- **Staleness off by default**: prevents idle pods from being removed from service. Operators opt in for high-traffic deployments.
- **Sync gated by flag**: remote sync failures don't affect readiness unless explicitly required (`--require-remote-sync`). Misconfiguring the flag without `--remote-url` is caught at startup.
- **Error classification**: application-level errors (NotFound, InvalidInput) don't mark subsystems degraded — only infrastructure failures do.

## Test plan

- [x] Integration test: healthy binary returns 200 with all checks "up"
- [x] Integration test: degraded server (controlled HealthRegistry) returns 503
- [x] 172 existing tests pass (no regressions)
- [x] 3 rounds of multi-agent code review, all findings addressed
- [ ] Manual: deploy to goddess cluster, verify K8s readiness probe works
- [ ] Manual: test `--require-remote-sync` with and without remote configured

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)