### PR TITLE
feat: /version endpoint for runtime version introspection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-bin: "false"
       - name: Install cargo-nextest
         run: |
           curl -fsSL "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.131/cargo-nextest-0.9.131-x86_64-unknown-linux-gnu.tar.gz" \
@@ -77,6 +79,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
+          cache-bin: "false"
       - run: cargo build --features k8s
 
   # Verify the declared MSRV (Cargo.toml rust-version) still compiles.
@@ -94,6 +97,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: msrv
+          cache-bin: "false"
       - run: cargo check --workspace --all-features
 
   audit:
@@ -121,6 +125,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: semver
+          cache-bin: "false"
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.11.1] - 2026-05-13
+
+### Added
+- `/version` HTTP endpoint returning `{"version": "..."}` for runtime version introspection (#204)
+
 ## [0.11.0] - 2026-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/health.rs
+++ b/src/health.rs
@@ -311,3 +311,8 @@ pub async fn readyz_handler(
 pub async fn healthz_handler() -> impl IntoResponse {
     axum::Json(serde_json::json!({"status": "ok"}))
 }
+
+/// Handler for `GET /version`.
+pub async fn version_handler() -> impl IntoResponse {
+    axum::Json(serde_json::json!({"version": env!("CARGO_PKG_VERSION")}))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider as OtlpProvider;
 
 use memory_mcp::auth::{self, AuthProvider, StoreBackend};
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend, MODEL_ID};
-use memory_mcp::health::{healthz_handler, readyz_handler, HealthRegistry};
+use memory_mcp::health::{healthz_handler, readyz_handler, version_handler, HealthRegistry};
 use memory_mcp::index::{UsearchStore, VectorStore};
 use memory_mcp::repo::MemoryRepo;
 use memory_mcp::server::MemoryServer;
@@ -599,6 +599,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         // Static liveness check. Always returns 200 OK once the process is running.
         .route("/healthz", axum::routing::get(healthz_handler))
         .route("/readyz", axum::routing::get(readyz_handler))
+        .route("/version", axum::routing::get(version_handler))
         .with_state(Arc::clone(&state_for_shutdown))
         .nest_service(&mcp_path, service);
 

--- a/tests/readyz.rs
+++ b/tests/readyz.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `/readyz` health endpoint.
+//! Integration tests for the health and info HTTP endpoints (`/readyz`, `/version`).
 //!
 //! The healthy-path test spins up the real binary. The degraded-path test
 //! constructs its own axum server with a controlled `AppState` so we can
@@ -194,4 +194,24 @@ async fn readyz_degraded_server_returns_503_not_ready() {
     assert_eq!(body["checks"]["vector_index"]["status"], "down");
 
     handle.abort();
+}
+
+/// `/version` returns 200 with the crate version from Cargo.toml.
+#[tokio::test]
+async fn version_returns_cargo_pkg_version() {
+    let (mut child, port, _tmp) = start_server(&[]).await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/version"))
+        .send()
+        .await
+        .expect("version request should succeed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let body: serde_json::Value = resp.json().await.expect("body should be valid JSON");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+
+    child.kill().await.ok();
 }


### PR DESCRIPTION
## Summary
- Add `GET /version` endpoint returning `{"version": "0.11.1"}` (from `CARGO_PKG_VERSION`)
- Bump version to 0.11.1, update CHANGELOG
- Set `cache-bin: "false"` on all `Swatinem/rust-cache` steps in CI — cached rustup shims from `~/.cargo/bin` can become stale when GitHub updates the runner image, causing `cargo` to resolve to `rustup-init` (observed on macOS cross-compile job)

Closes #204

## Test plan
- [x] Integration test `version_returns_cargo_pkg_version` — spins up real binary, hits `/version`, asserts response matches `CARGO_PKG_VERSION`
- [ ] CI passes (including macOS cross-compile with cache-bin disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>