### PR TITLE
fix: propagate tracing dispatch across spawn_blocking boundaries

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "tokio::task::spawn_blocking", reason = "use crate::repo::traced_spawn_blocking to propagate tracing dispatch" },
+]

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -105,6 +105,25 @@ fn build_auth_callbacks(token: SecretString) -> git2::RemoteCallbacks<'static> {
     callbacks
 }
 
+/// Spawn a blocking task with the caller's `tracing::Dispatch` propagated.
+///
+/// Blocking-pool threads do not inherit the caller's thread-local dispatch,
+/// so `Span::current()`, events, and `Span::record()` are silently dropped
+/// unless the dispatch is explicitly re-installed. This wrapper captures the
+/// current dispatch and sets it as the thread-local default inside the closure.
+pub(crate) fn traced_spawn_blocking<F, T>(f: F) -> tokio::task::JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let dispatch = tracing::dispatcher::get_default(|d| d.clone());
+    #[allow(clippy::disallowed_methods)]
+    tokio::task::spawn_blocking(move || {
+        let _guard = tracing::dispatcher::set_default(&dispatch);
+        f()
+    })
+}
+
 /// Git-backed repository for persisting and syncing memory files.
 pub struct MemoryRepo {
     inner: Mutex<Repository>,
@@ -209,7 +228,7 @@ impl MemoryRepo {
     /// branch is unborn (no commits yet).
     pub async fn head_sha(self: &Arc<Self>) -> Option<String> {
         let me = Arc::clone(self);
-        tokio::task::spawn_blocking(move || {
+        traced_spawn_blocking(move || {
             let repo = me.inner.lock().expect("repo mutex poisoned");
             let oid_bytes = capture_head_oid(&repo).ok()?;
             if oid_bytes == [0u8; 20] {
@@ -251,7 +270,7 @@ impl MemoryRepo {
         // Capture span before entering spawn_blocking so the child thread can record oid.
         let span = tracing::debug_span!("repo.save", name = %name, oid = tracing::field::Empty);
 
-        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -310,7 +329,7 @@ impl MemoryRepo {
         let name = name.to_string();
         let file_path_clone = file_path.clone();
         let span = tracing::debug_span!("repo.delete", name = %name);
-        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -390,7 +409,7 @@ impl MemoryRepo {
         let arc = Arc::clone(self);
         let name = name.to_string();
         let span = tracing::debug_span!("repo.read", name = %name);
-        let result = tokio::task::spawn_blocking(move || -> Result<Memory, MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<Memory, MemoryError> {
             let _enter = span.entered();
             // Check existence/symlink status before opening.
             match std::fs::symlink_metadata(&file_path) {
@@ -431,7 +450,7 @@ impl MemoryRepo {
         let scope_clone = scope.cloned();
         let span = tracing::debug_span!("repo.list", file_count = tracing::field::Empty,);
 
-        let result = tokio::task::spawn_blocking(move || -> Result<Vec<Memory>, MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<Vec<Memory>, MemoryError> {
             let _enter = span.entered();
             let dirs: Vec<PathBuf> = match scope_clone.as_ref() {
                 Some(s) => vec![root.join(s.dir_prefix())],
@@ -522,7 +541,7 @@ impl MemoryRepo {
         let branch = branch.to_string();
         let span = tracing::debug_span!("repo.push", branch = %branch);
 
-        let result = tokio::task::spawn_blocking(move || -> Result<(), MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<(), MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner
@@ -672,7 +691,7 @@ impl MemoryRepo {
         let branch = branch.to_string();
         let span = tracing::debug_span!("repo.pull", branch = %branch);
 
-        let result = tokio::task::spawn_blocking(move || -> Result<PullResult, MemoryError> {
+        let result = traced_spawn_blocking(move || -> Result<PullResult, MemoryError> {
             let _enter = span.entered();
             let repo = arc
                 .inner

--- a/src/server.rs
+++ b/src/server.rs
@@ -870,7 +870,7 @@ impl MemoryServer {
 
                 if let Some((old_head, new_head)) = oid_range {
                     let repo = Arc::clone(&state.repo);
-                    let changes = tokio::task::spawn_blocking(move || {
+                    let changes = crate::repo::traced_spawn_blocking(move || {
                         repo.diff_changed_memories(old_head, new_head)
                     })
                     .await

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -10,6 +10,10 @@
 //!
 //! The in-memory subscriber collects span/event metadata so we can assert on
 //! it without touching real networking or the file system (where possible).
+//!
+//! **Note:** `with_capturing` uses `tracing::subscriber::with_default`, which is
+//! thread-local. Production code uses `traced_spawn_blocking` to propagate the
+//! dispatch into blocking threads, so span records and events are visible to tests.
 
 use std::{
     collections::HashSet,
@@ -201,11 +205,24 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
     }
 }
 
+/// Panic unless running under nextest (process-per-test isolation).
+///
+/// Tests that use `tracing::subscriber::with_default` + `traced_spawn_blocking`
+/// rely on thread-local dispatch propagation that is unsound under `cargo test`
+/// (shared process, concurrent tests). Nextest sets `NEXTEST=1` in every child.
+fn require_nextest() {
+    assert!(
+        std::env::var("NEXTEST").is_ok(),
+        "this test requires nextest (cargo nextest run)"
+    );
+}
+
 /// Build a subscriber with the capturing layer installed and run `f` inside it.
 fn with_capturing<F, R>(f: F) -> (R, Arc<Mutex<RecordStore>>)
 where
     F: FnOnce() -> R,
 {
+    require_nextest();
     let store = Arc::new(Mutex::new(RecordStore::default()));
     let layer = CapturingLayer {
         store: Arc::clone(&store),
@@ -634,6 +651,7 @@ fn auth_failure_produces_warn_event() {
 
 #[test]
 fn debug_spans_are_filtered_when_only_info_enabled() {
+    require_nextest();
     use memory_mcp::index::{UsearchStore, VectorStore};
     use memory_mcp::types::Scope;
 
@@ -734,8 +752,11 @@ fn repo_save_span_has_name_and_oid_fields() {
         save_span.fields
     );
     assert!(
-        save_span.fields.iter().any(|(k, _)| k == "oid"),
-        "repo.save missing 'oid' field; fields: {:?}",
+        save_span
+            .fields
+            .iter()
+            .any(|(k, v)| k == "oid" && !v.is_empty()),
+        "repo.save 'oid' field missing or empty; fields: {:?}",
         save_span.fields
     );
 }


### PR DESCRIPTION
## Summary

- Add `traced_spawn_blocking` wrapper that captures the caller's `tracing::Dispatch` and re-installs it on the blocking thread via `set_default`
- Replace all 8 bare `tokio::task::spawn_blocking` calls (7 in `repo.rs`, 1 in `server.rs`)
- Add `clippy.toml` with `disallowed_methods` entry banning bare `spawn_blocking`
- Gate tracing tests on nextest via `require_nextest()` guard
- Strengthen oid assertion to verify value is non-empty (now possible with dispatch propagation)

## Why

`Span::current()`, events (`info!`, `warn!`), and `Span::record()` dispatch through a thread-local `Dispatch`. `spawn_blocking` threads don't inherit it, so tracing from blocking closures was invisible to test subscribers. In production (global subscriber via `.init()`), this was a no-op — but it made tracing tests unable to verify cross-thread span records and events.

## Test plan

- [x] `cargo nextest run` — 180 passed, 2 skipped
- [x] `cargo clippy -- -D warnings` — clean (bare `spawn_blocking` blocked)
- [x] Strengthened oid assertion passes (proves dispatch propagation works)
- [x] `require_nextest()` guard panics under `cargo test` (verified)

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)