### PR TITLE
feat: session lifecycle CLI flags for idle timeout and max lifetime (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [0.12.0] - 2026-05-14
+
+### Added
+- `--idle-timeout-secs` CLI flag / `MEMORY_MCP_IDLE_TIMEOUT_SECS` env var for configurable session idle timeout (default 14400s / 4 hours) (#114)
+- `--max-session-lifetime-secs` CLI flag / `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS` env var for absolute session lifetime cap (default disabled) (#114)
+- Runtime warning when both idle timeout and max session lifetime are disabled
+- Design artifacts in `docs/design/session-lifecycle/`
+
+### Changed
+- Session manager construction uses `BoundedSessionManagerBuilder` from mcp-session 0.2
+- Structured tracing events emitted on session create/close with `session_id`, `duration_secs`, and `CloseReason`
+
+### Dependencies
+- Upgraded `mcp-session` from 0.1 to 0.2 (builder API, max lifetime, lifecycle tracing)
+- Upgraded `rmcp` from 1.6 to 1.7
+
 ## [0.11.1] - 2026-05-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,10 +376,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2017,14 +2015,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-session"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168f3afd1c9f395e57cde442514e2a39779ef0a2f7cdc04b9299a3ecd979700"
+checksum = "07f380e87be280df4a2000c1c30fb8d69f9a06151063d6fc6fd7edd592fd8345"
 dependencies = [
  "futures-core",
  "rmcp",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2045,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2487,18 +2486,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2964,9 +2963,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2995,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4717,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"
@@ -47,7 +47,7 @@ keyring = { version = "3", features = ["sync-secret-service", "apple-native", "w
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 async-trait = "0.1"
 dirs = "6"
-mcp-session = "0.1"
+mcp-session = "0.2"
 http = "1"
 arc-swap = "1"
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ All options can be set via CLI flags or environment variables:
 | `--max-sessions` | `MEMORY_MCP_MAX_SESSIONS` | `100` | Maximum concurrent MCP sessions |
 | `--session-rate-limit` | `MEMORY_MCP_SESSION_RATE_LIMIT` | `10` | Max new sessions per rate-limit window (0 to disable) |
 | `--session-rate-window-secs` | `MEMORY_MCP_SESSION_RATE_WINDOW_SECS` | `60` | Rate-limit window duration in seconds |
+| `--idle-timeout-secs` | `MEMORY_MCP_IDLE_TIMEOUT_SECS` | `14400` | Idle timeout for sessions in seconds (0 to disable) |
+| `--max-session-lifetime-secs` | `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS` | `0` (disabled) | Absolute max session lifetime in seconds (0 to disable) |
 | `--embed-timeout-secs` | `MEMORY_MCP_EMBED_TIMEOUT_SECS` | `30` | Max seconds per embedding call before timeout |
 | `--embed-queue-size` | `MEMORY_MCP_EMBED_QUEUE_SIZE` | `64` | Embedding request queue capacity |
 | `--require-remote-sync` | `MEMORY_MCP_REQUIRE_REMOTE_SYNC` | `false` | Include sync health in readiness checks. Performs initial pull at startup. |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,3 +7,4 @@ Each component or feature gets its own subdirectory.
 |--------|-------|-------|------|--------|
 | [Tracing Scaffold](tracing/) | #52 | 2 | 2026-04-23 | Approved |
 | [Phase 2 Quality](phase2-quality/) | #94, #145, #146, #164 | 2 | 2026-04-25 | Approved |
+| [Session Lifecycle](session-lifecycle/) | #114 | 2 | 2026-05-14 | Approved (threat model skipped) |

--- a/docs/design/session-lifecycle/architecture.md
+++ b/docs/design/session-lifecycle/architecture.md
@@ -1,0 +1,236 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-14
+phase: 3
+-->
+
+# Architecture: Session Lifecycle Observability (#114)
+
+## Architectural Decisions
+
+### D-01: Idle timeout delegates to rmcp
+
+rmcp's `LocalSessionWorker::run()` already implements an idle timer via
+`tokio::time::sleep()` at the top of each `select!` loop iteration. Any event
+naturally resets it. This is the most performant and leak-proof approach — the
+timer lives in the event loop with zero shared state.
+
+mcp-session's builder exposes `.idle_timeout(Duration)` which sets
+`SessionConfig::keep_alive` on the inner `LocalSessionManager`. No separate
+timer, no reimplementation.
+
+### D-02: Max lifetime is a one-shot per-session task
+
+When max lifetime is configured, `create_session()` spawns a single
+`tokio::spawn(async { sleep(max_lifetime).await; close_session(id) })`.
+The task's `AbortHandle` is stored in `SessionLifecycleEntry` and cancelled
+in `close_session()` if the session closes for any other reason.
+
+One-shot tasks are the simplest construct that can't drift, can't leak (if
+cancelled), and have zero per-message cost.
+
+### D-03: Builder absorbs keep_alive to prevent two-knob conflict
+
+`BoundedSessionManagerBuilder` owns the idle timeout configuration.
+If `.idle_timeout()` is called, it sets `SessionConfig::keep_alive` to
+that value. If a passthrough `SessionConfig` also has `keep_alive` set,
+the builder overrides it with a `tracing::warn!`.
+
+If `.idle_timeout()` is never called, the passthrough `SessionConfig::keep_alive`
+flows through to rmcp unmodified. Existing consumers see no change.
+
+### D-04: Close reason is best-effort
+
+The `SessionManager` trait's `close_session(&SessionId)` carries no reason
+parameter (it's rmcp's trait). mcp-session tracks close reasons via internal
+state:
+
+- **Evicted**: known — triggered by `create_session()` when capacity is full
+- **MaxLifetime**: known — triggered by the one-shot task
+- **Closed**: catch-all for idle timeout, client DELETE, server shutdown, and
+  any other external `close_session()` call
+
+To distinguish Evicted and MaxLifetime from external calls, the close path
+checks a `pending_reason: Option<CloseReason>` set just before calling
+`inner.close_session()`. The default is `Closed`.
+
+### D-05: Per-session lifecycle tracking
+
+`BoundedSessionManager` gains a `lifecycle: RwLock<HashMap<SessionId, SessionLifecycleEntry>>`
+field. Each entry tracks `created_at: Instant` and `abort_handle: Option<AbortHandle>`.
+This is separate from rmcp's internal session map.
+
+The lifecycle map is updated in `create_session()` (insert) and
+`close_session()` (remove + log). The existing `creation_order` deque is
+retained for FIFO eviction ordering.
+
+### D-06: Existing API preserved
+
+`BoundedSessionManager::new(session_config, max_sessions)` and
+`.with_rate_limit(count, window)` continue to work. The builder is an
+alternative construction path that produces the same type. Internally,
+the builder calls `new()` after preparing the `SessionConfig`.
+
+## Component Diagram
+
+mcp-session sits between memory-mcp (consumer) and rmcp (transport layer).
+The builder constructs `BoundedSessionManager` with lifecycle tracking.
+Idle timeout flows through to rmcp's event-loop timer; max lifetime is
+managed by mcp-session via one-shot tasks.
+
+```mermaid
+graph TB
+    subgraph "memory-mcp (consumer)"
+        CLI["CLI / main.rs\n--idle-timeout-secs\n--max-session-lifetime-secs"]
+        Handler["MemoryServer\n(MCP tool handler)"]
+    end
+
+    subgraph "mcp-session"
+        Builder["BoundedSessionManagerBuilder\n---\nidle_timeout: Option<Duration>\nmax_lifetime: Option<Duration>\nrate_limit: Option<(usize, Duration)>\nsession_config: SessionConfig"]
+        BSM["BoundedSessionManager\n---\ninner: LocalSessionManager\nmax_lifetime: Option<Duration>\nlifecycle: RwLock<HashMap<SessionId,\n  SessionLifecycleEntry>>\ncreation_order: Mutex<VecDeque<SessionId>>\nrate_limiter: Option<RateLimiter>"]
+        Entry["SessionLifecycleEntry\n---\ncreated_at: Instant\nabort_handle: Option<AbortHandle>"]
+        Reason["CloseReason\n---\nEvicted\nMaxLifetime\nClosed"]
+        MaxLifeTask["max_lifetime task\n(one-shot tokio::spawn)"]
+    end
+
+    subgraph "rmcp (unchanged)"
+        LSM["LocalSessionManager"]
+        Worker["LocalSessionWorker\n(event loop with idle timer)"]
+        SConfig["SessionConfig\nkeep_alive → idle timeout"]
+        SHS["StreamableHttpService"]
+    end
+
+    CLI -->|"constructs via"| Builder
+    Builder -->|".build()"| BSM
+    CLI -->|"passes to"| SHS
+    SHS -->|"routes HTTP"| BSM
+    Handler -->|"served by"| SHS
+
+    BSM -->|"delegates"| LSM
+    BSM -->|"tracks"| Entry
+    BSM -->|"spawns"| MaxLifeTask
+    BSM -->|"passes keep_alive"| SConfig
+    Entry -->|"AbortHandle cancels"| MaxLifeTask
+    MaxLifeTask -->|"close_session()"| BSM
+    LSM -->|"spawns"| Worker
+    Worker -->|"idle timeout →\nclose_session()"| BSM
+```
+
+## Session Lifecycle State Diagram
+
+A session transitions through Created → Active → Closed. The Closed state
+is terminal and is reached via four distinct paths, each carrying a
+`CloseReason` for the tracing event.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created : create_session()
+
+    Created --> Active : initialize + first message
+
+    Created --> Closed : Evicted (capacity full)
+
+    Active --> Closed : Idle timeout (rmcp)\nreason = Closed
+
+    Active --> Closed : Max lifetime (mcp-session)\nreason = MaxLifetime
+
+    Active --> Closed : Client DELETE\nreason = Closed
+
+    Active --> Closed : Server shutdown\nreason = Closed
+
+    Closed --> [*] : AbortHandle cancelled\nlifecycle entry removed\ntracing event emitted
+```
+
+## Sequence: Session Creation with Max Lifetime
+
+When a session is created with max lifetime configured, `BoundedSessionManager`
+delegates to rmcp for the actual session, then spawns a one-shot task and
+records the lifecycle entry.
+
+```mermaid
+sequenceDiagram
+    participant HTTP as StreamableHttpService
+    participant BSM as BoundedSessionManager
+    participant LSM as LocalSessionManager
+    participant Task as max_lifetime task
+    participant Log as tracing
+
+    HTTP->>BSM: create_session()
+    BSM->>BSM: rate_limiter.reserve()
+    BSM->>BSM: check capacity, evict if needed
+    BSM->>LSM: inner.create_session()
+    LSM-->>BSM: (session_id, transport)
+
+    BSM->>BSM: created_at = Instant::now()
+    BSM->>Task: tokio::spawn(sleep(max_lifetime);\nclose_session(session_id))
+    Task-->>BSM: abort_handle
+
+    BSM->>BSM: lifecycle.insert(session_id,\n{created_at, abort_handle})
+    BSM->>BSM: creation_order.push_back(session_id)
+    BSM->>Log: info!(session.created, session_id)
+    BSM-->>HTTP: (session_id, transport)
+```
+
+## Sequence: Max Lifetime Expiry
+
+When the one-shot task fires, it calls `close_session()` with reason
+`MaxLifetime`. The close path cancels any remaining abort handle (no-op
+in this case), removes tracking state, delegates to rmcp for cleanup,
+and emits the tracing event with session duration.
+
+```mermaid
+sequenceDiagram
+    participant Task as max_lifetime task
+    participant BSM as BoundedSessionManager
+    participant LSM as LocalSessionManager
+    participant Log as tracing
+
+    Note over Task: sleep(max_lifetime) completes
+
+    Task->>BSM: close_session(session_id)
+    BSM->>BSM: pending_reason = MaxLifetime
+
+    BSM->>BSM: lifecycle.remove(session_id)\n→ {created_at, abort_handle}
+    BSM->>BSM: abort_handle.abort() (no-op)
+    BSM->>BSM: elapsed = created_at.elapsed()
+    BSM->>BSM: creation_order.retain(|id| id != session_id)
+
+    BSM->>LSM: inner.close_session(session_id)
+    LSM-->>BSM: Ok(())
+
+    BSM->>Log: info!(session.closed,\nsession_id, duration, reason=MaxLifetime)
+    BSM-->>Task: Ok(())
+```
+
+## Data Model
+
+```mermaid
+erDiagram
+    BoundedSessionManager ||--o{ SessionLifecycleEntry : "lifecycle map"
+    BoundedSessionManager ||--|| LocalSessionManager : "inner (delegation)"
+    BoundedSessionManager ||--o| RateLimiter : "optional"
+    SessionLifecycleEntry ||--o| AbortHandle : "optional (max lifetime)"
+
+    BoundedSessionManager {
+        usize max_sessions
+        Option_Duration max_lifetime
+    }
+    SessionLifecycleEntry {
+        Instant created_at
+        Option_AbortHandle abort_handle
+    }
+```
+
+## Key Design Properties
+
+**Performance**: zero per-message overhead from mcp-session. Idle timeout
+is handled by rmcp's event loop. Max lifetime is a one-shot sleep. Lifecycle
+tracking is two map operations (insert on create, remove on close).
+
+**Leak prevention**: max lifetime tasks are cancelled via `AbortHandle` in
+every `close_session()` call path. The lifecycle map and creation_order deque
+are cleaned up in the same close path. No orphaned tasks or entries.
+
+**Backward compatibility**: existing `new()` constructor works unchanged.
+Builder is opt-in. No managed lifecycle tracking is created unless the
+builder is used with `.idle_timeout()` or `.max_lifetime()`.

--- a/docs/design/session-lifecycle/problem.md
+++ b/docs/design/session-lifecycle/problem.md
@@ -1,0 +1,127 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-14
+phase: 1
+-->
+
+# Problem Space: Session Lifecycle Observability (#114)
+
+## What problem exists today?
+
+When an MCP session expires due to keep-alive timeout, the server logs:
+
+```
+worker quit with fatal: keep alive timeout after 14400000ms
+```
+
+The client receives no signal. The SSE stream silently closes. The client
+discovers the session is dead only when its next request returns HTTP 404 with
+a plain-text body that carries no structured information or reconnection
+guidance.
+
+This hits AI agents hardest: they believe the connection is live, attempt a
+tool call, get a raw 404, and enter unpredictable error-recovery behavior.
+
+## Why now?
+
+memory-mcp is deployed in long-running production environments serving AI
+agents that hold sessions for hours. The 4-hour keep-alive is a reasonable
+safety net, but the silent death when it fires creates operational confusion.
+Additionally, mcp-session has consumers beyond memory-mcp (~420 non-memory-mcp
+downloads) who face the same problem with no tooling to address it.
+
+## Architectural constraint
+
+The keep-alive timeout mechanism lives inside rmcp's `LocalSessionWorker::run()`
+loop. The timer is created fresh at the top of each loop iteration — it is
+actually an **idle timer** that resets on every message, not an absolute
+lifetime. When no events arrive for the configured duration, the worker returns
+`WorkerQuitReason::Fatal(KeepAliveTimeout(...))` — no callback, no event, the
+session dies. mcp-session wraps session counting and rate limiting but has no
+visibility into or control over session lifecycle events.
+
+rmcp's idle timer is already correct and elegant — it creates a fresh
+`tokio::time::sleep()` at the top of each `select!` loop iteration, so any
+event naturally resets it with zero overhead. Reimplementing this outside the
+event loop would be strictly worse.
+
+The approach is to **lean on rmcp for idle timeout** (passing the configured
+value through `SessionConfig::keep_alive` via mcp-session's builder) and add
+**max lifetime as a genuinely new capability** via a one-shot per-session
+tokio task. mcp-session's builder absorbs the `keep_alive` field from
+`SessionConfig` to prevent the two-knob problem, but passes the value through
+rather than replacing the timer.
+
+## Inputs and outputs
+
+**Inputs:**
+- Idle timeout duration (currently hardcoded in each consumer, delegated to rmcp)
+- Max session lifetime (new — absolute cap regardless of activity)
+- Session creation/destruction events (currently opaque inside rmcp)
+
+**Outputs:**
+- Structured session lifecycle logs (created, closed with reason and duration)
+- Configurable idle timeout and max lifetime via CLI flags / environment variables
+- Clean session shutdown with close reason tracking
+
+## Scope
+
+### In scope
+
+- **mcp-session API changes**: builder pattern, idle timeout and max
+  lifetime configuration, session lifecycle tracing with close reasons
+- **Idle timeout**: passed through to rmcp's `SessionConfig::keep_alive`
+  (rmcp's event-loop timer handles the actual idle detection)
+- **Max lifetime**: new per-session one-shot tokio task, cancelled on
+  early close via `AbortHandle`
+- **SessionConfig absorption**: mcp-session's builder owns `keep_alive`;
+  other `SessionConfig` fields pass through. Conflicting `keep_alive` on
+  a passthrough `SessionConfig` is overridden with a logged warning.
+- **memory-mcp CLI**: `--idle-timeout-secs` and `--max-session-lifetime-secs`
+  flags with corresponding env vars
+- **Backward compatibility**: consumers who upgrade mcp-session without
+  changing code see no behavior change. The builder is opt-in. If
+  `.idle_timeout()` is not called, the `SessionConfig` value flows
+  through to rmcp unmodified.
+
+### Out of scope
+
+- Changes to rmcp itself
+- Client-side reconnection logic (we provide the signal; the client decides
+  what to do with it)
+- Session persistence or resumption across timeout (separate feature)
+- Specific deployment environment details
+
+## Adjacent systems
+
+- **rmcp** (v1.7.0): provides `LocalSessionManager`, `SessionConfig`,
+  `StreamableHttpService`, the worker loop with keep-alive timer
+- **mcp-session** (v0.2.0): wraps `LocalSessionManager` with bounded
+  sessions, rate limiting, FIFO eviction, lifecycle tracking. Re-exports
+  `SessionConfig`.
+- **memory-mcp**: the primary consumer; constructs `BoundedSessionManager`
+  and `StreamableHttpService`, defines CLI flags
+
+## Success criteria
+
+1. Session lifecycle events (created, closed) are logged with `session_id`,
+   duration, and close reason via structured tracing.
+2. Idle timeout and max session lifetime are independently configurable via
+   CLI flags and environment variables.
+3. The mcp-session API change is additive — existing consumers who don't
+   opt into managed timeouts see no behavior change.
+4. No timer conflict: idle timeout flows through a single configuration
+   path (builder → SessionConfig → rmcp).
+
+## Failure modes
+
+- **Breaking existing consumers**: if the API change requires code changes
+  from consumers who don't want the new feature. Prevented by keeping the
+  existing constructor and making the builder opt-in.
+- **Orphaned max-lifetime tasks**: if a session is closed (eviction, client
+  DELETE, server shutdown) but the one-shot max-lifetime task is not
+  cancelled, it fires on a dead session. Prevented by cancelling via
+  `AbortHandle` in `close_session`.
+- **Two-knob conflict**: if a consumer sets `keep_alive` on both the
+  builder and a passthrough `SessionConfig`. Prevented by the builder
+  overriding the passthrough value with a logged warning.

--- a/docs/design/session-lifecycle/requirements.md
+++ b/docs/design/session-lifecycle/requirements.md
@@ -1,0 +1,97 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-14
+phase: 2
+-->
+
+# Requirements: Session Lifecycle Observability (#114)
+
+## Use Cases
+
+| ID | Actor | Use Case | Type | Priority |
+|----|-------|----------|------|----------|
+| UC-01 | MCP Client | Hold a long-running session for tool calls | Normal | Must |
+| UC-02 | Operator | Configure idle timeout and max lifetime for deployment | Normal | Must |
+| UC-03 | Operator | Monitor session lifecycle events in logs | Normal | Must |
+| UC-04 | Operator | Diagnose why a session ended (timeout vs eviction vs client close) | Normal | Should |
+| AC-01 | Attacker | Hold sessions indefinitely to exhaust server resources | Abuse | Must-mitigate |
+| SC-01 | System | Enforce session lifetime regardless of client behavior | Security | Must |
+| SC-02 | System | Log session lifecycle with audit-quality detail | Security | Should |
+
+### Notes on abuse cases
+
+- **AC-01**: Mitigated by three independent mechanisms: `BoundedSessionManager`
+  (max sessions + FIFO eviction), idle timeout (rmcp reaps inactive sessions),
+  and max lifetime (absolute cap for chatty sessions). All three are independent.
+
+## Key discovery: rmcp's keep_alive is already an idle timer
+
+rmcp's `SessionConfig::keep_alive` creates a `tokio::time::sleep()` at the top
+of each `select!` loop iteration in `LocalSessionWorker::run()`. Any event
+resets it naturally. The timeout only fires after the full duration with zero
+activity.
+
+mcp-session's builder absorbs this field to prevent the two-knob problem, but
+passes the value through to rmcp rather than reimplementing the timer. The
+genuinely new capability is **max lifetime** — an absolute session cap
+regardless of activity, implemented as a one-shot per-session tokio task.
+
+## Requirements
+
+### mcp-session (crate changes)
+
+| Req ID | Requirement | Source UC | ASVS | Priority |
+|--------|-------------|-----------|------|----------|
+| R-01 | mcp-session SHALL provide a builder API for `BoundedSessionManager` that accepts idle timeout, max lifetime, and max sessions as parameters | UC-02 | — | Must |
+| R-02 | The builder's `.idle_timeout(duration)` SHALL set `SessionConfig::keep_alive` to the given value on the inner `LocalSessionManager` | UC-01, SC-01 | V3.3 | Must |
+| R-03 | If a passthrough `SessionConfig` has `keep_alive` set AND the builder's `.idle_timeout()` was called, mcp-session SHALL override the `SessionConfig` value and log a warning | UC-02 | — | Must |
+| R-04 | If `.idle_timeout()` is not called on the builder, the passthrough `SessionConfig::keep_alive` SHALL flow through to rmcp unmodified | UC-01 | — | Must |
+| R-05 | When max lifetime is configured, mcp-session SHALL spawn a one-shot tokio task per session that calls `close_session()` after the configured duration | SC-01, AC-01 | V3.3 | Must |
+| R-06 | Max lifetime tasks SHALL be cancelled via `AbortHandle` when the session is closed for any other reason (eviction, client DELETE, idle timeout, server shutdown) | SC-01 | V3.3 | Must |
+| R-07 | mcp-session SHALL emit a structured tracing event when a session is created, including `session_id` | UC-03, SC-02 | V7.1 | Must |
+| R-08 | mcp-session SHALL emit a structured tracing event when a session is closed, including `session_id` and session duration (elapsed since creation) | UC-03, SC-02 | V7.1 | Must |
+| R-09 | Session close tracing events SHALL include a close reason where determinable: `Evicted`, `MaxLifetime`, or `Closed` (catch-all for idle timeout, client DELETE, and other external closes) | UC-04 | V7.1 | Should |
+| R-10 | Consumers who construct `BoundedSessionManager` via the existing `new()` + `with_rate_limit()` API SHALL see no behavior change | UC-01 | — | Must |
+| R-11 | The builder SHALL accept optional `SessionConfig` for passthrough fields (`channel_capacity`, `sse_retry`, `completed_cache_ttl`, `init_timeout`); `keep_alive` is subject to R-03 and R-04 | UC-02 | — | Must |
+| R-12 | The builder SHALL re-expose rate limiting configuration so all session management is configurable through a single builder chain | UC-02 | — | Should |
+
+### memory-mcp (consumer changes)
+
+| Req ID | Requirement | Source UC | ASVS | Priority |
+|--------|-------------|-----------|------|----------|
+| R-13 | memory-mcp SHALL expose `--idle-timeout-secs` as a CLI flag and `MEMORY_MCP_IDLE_TIMEOUT_SECS` env var, defaulting to 14400 (4 hours, matching current behavior) | UC-02 | — | Must |
+| R-14 | memory-mcp SHALL expose `--max-session-lifetime-secs` as a CLI flag and `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS` env var, defaulting to 0 (disabled) | UC-02 | — | Should |
+| R-15 | memory-mcp SHALL construct `BoundedSessionManager` via the new builder API, passing the CLI-configured values | UC-02 | — | Must |
+
+## ASVS Categories Reviewed
+
+| Category | Applicable? | Rationale |
+|----------|-------------|-----------|
+| V3 Session Management | **Yes** | Core — session lifetime, idle timeout, max lifetime |
+| V7 Error Handling, Logging | **Yes** | Lifecycle logging with structured tracing |
+| V1 Architecture | Reviewed | Timer delegation to rmcp covered in problem.md |
+| V2 Authentication | No | Session lifecycle is orthogonal to auth |
+| V4 Access Control | No | No authorization changes |
+| V5 Validation | No | No new input parsing beyond CLI flags (handled by clap) |
+| V11 Business Logic | No | Session timeout is infrastructure |
+| V13 API | No | No new client-facing API surface |
+
+## Security Requirements Traceability Matrix
+
+| Req ID | Requirement | Source UC | ASVS | Test Case |
+|--------|-------------|-----------|------|-----------|
+| R-01 | Builder API for BoundedSessionManager | UC-02 | — | U-01, U-02, T-06, T-07 |
+| R-02 | Builder idle_timeout sets SessionConfig::keep_alive | UC-01, SC-01 | V3.3 | U-01 |
+| R-03 | Override conflicting SessionConfig::keep_alive with warning | UC-02 | — | U-01 |
+| R-04 | Unmanaged keep_alive passthrough when idle_timeout not called | UC-01 | — | U-01 |
+| R-05 | One-shot max lifetime task per session | SC-01, AC-01 | V3.3 | T-01, T-03, T-08, I-03 |
+| R-06 | Max lifetime task cancelled on early close | SC-01 | V3.3 | T-02, T-08, I-02 |
+| R-07 | Tracing event on session created with session_id | UC-03, SC-02 | V7.1 | T-04, I-01 |
+| R-08 | Tracing event on session closed with session_id + duration | UC-03, SC-02 | V7.1 | T-01, T-05, I-01 |
+| R-09 | Close reason: Evicted, MaxLifetime, or Closed | UC-04 | V7.1 | T-01, T-03, T-05, U-03 |
+| R-10 | Existing new() API backward compatible | UC-01 | — | T-06 |
+| R-11 | Builder accepts passthrough SessionConfig | UC-02 | — | U-02 |
+| R-12 | Builder includes rate_limit configuration | UC-02 | — | T-07 |
+| R-13 | memory-mcp --idle-timeout-secs CLI flag + env var | UC-02 | — | M-01, M-03 |
+| R-14 | memory-mcp --max-session-lifetime-secs CLI flag + env var | UC-02 | — | M-02, M-03 |
+| R-15 | memory-mcp uses builder API | UC-02 | — | M-03 |

--- a/docs/design/session-lifecycle/test-plan.md
+++ b/docs/design/session-lifecycle/test-plan.md
@@ -1,0 +1,74 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-14
+phase: 5
+-->
+
+# Test Plan: Session Lifecycle Observability (#114)
+
+Integration tests use `tokio::time::pause()` for deterministic time control.
+Tracing assertions use a capturing subscriber layer (assert on field
+presence/values, not log formatting).
+
+## mcp-session tests
+
+### Unit tests
+
+| Test ID | Req | Description |
+|---------|-----|-------------|
+| U-01 | R-02, R-03, R-04 | Builder idle_timeout/passthrough resolution: (a) idle_timeout set → keep_alive = idle_timeout, (b) both set → idle_timeout wins + warn logged, (c) only passthrough → passthrough value used, (d) neither → SessionConfig default |
+| U-02 | R-11 | Builder passthrough: `channel_capacity`, `sse_retry`, `completed_cache_ttl`, `init_timeout` all flow through to inner SessionConfig |
+| U-03 | R-09 | `CloseReason` implements Debug, Clone, Copy, PartialEq, Eq |
+
+### Integration tests
+
+| Test ID | Req | Description |
+|---------|-----|-------------|
+| T-01 | R-05, R-08, R-09 | Max lifetime closes session: create with `max_lifetime=100ms`, advance 100ms, assert `has_session` returns false. Tracing event has `reason=MaxLifetime` and `duration_secs` in expected range |
+| T-02 | R-06 | Early close cancels max lifetime task: create with `max_lifetime=1s`, close immediately, advance 1.5s, assert no panic or double-close |
+| T-03 | R-05, R-06, R-09 | Eviction + max lifetime: `max_sessions=1`, `max_lifetime=5s`. Create A, create B (evicts A with reason=Evicted). Advance 5s, B closes with reason=MaxLifetime |
+| T-04 | R-07 | Session creation emits tracing event with `session_id` field |
+| T-05 | R-08, R-09 | Session close emits tracing event with `session_id`, `duration_secs`, and `reason` |
+| T-06 | R-10 | Backward compat: `BoundedSessionManager::new(config, max)` works, no lifecycle tracking or max lifetime tasks |
+| T-07 | R-12 | Builder with only `.rate_limit()` — rate limiting works, no lifecycle tasks spawned |
+| T-08 | R-05, R-06 | Multiple sessions with max lifetime: create 5 sessions with `max_lifetime=100ms`, advance time, verify all 5 close. No leaked tasks or entries. |
+
+### Invariant tests
+
+These test structural invariants across operation sequences. Not property
+tests in the QuickCheck sense — they're deterministic scenarios designed
+to exercise the invariant, not random generation.
+
+| Test ID | Req | Invariant | Scenario |
+|---------|-----|-----------|----------|
+| I-01 | R-07, R-08 | Lifecycle map has exactly one entry per live session | Create 5, close 2, assert map len = 3. Close remaining 3, assert map empty. |
+| I-02 | R-06 | No abort handles leak after all sessions close | Create 3 with max_lifetime. Close all. Advance past max_lifetime. Assert no panics, no task activity. |
+| I-03 | R-05, R-09 | Eviction + timeout interactions don't corrupt state | `max_sessions=2`. Create A, B, C (evicts A), D (evicts B). Advance past max_lifetime. Assert C and D close with MaxLifetime. Lifecycle map empty. |
+
+## memory-mcp tests
+
+| Test ID | Req | Description |
+|---------|-----|-------------|
+| M-01 | R-13 | `--idle-timeout-secs 300` parses correctly. Default is 14400. `MEMORY_MCP_IDLE_TIMEOUT_SECS` env var works. |
+| M-02 | R-14 | `--max-session-lifetime-secs 600` parses correctly. Default is 0 (disabled). Env var works. |
+| M-03 | R-15 | Server with `--idle-timeout-secs 300 --max-session-lifetime-secs 3600` starts and uses builder API |
+
+## SRTM (final)
+
+| Req ID | Requirement | Test Cases |
+|--------|-------------|------------|
+| R-01 | Builder API | U-01, U-02, T-06, T-07 |
+| R-02 | idle_timeout sets keep_alive | U-01 |
+| R-03 | Override conflicting keep_alive | U-01 |
+| R-04 | Passthrough when idle_timeout not called | U-01 |
+| R-05 | One-shot max lifetime task | T-01, T-03, T-08, I-03 |
+| R-06 | AbortHandle cancelled on early close | T-02, T-08, I-02 |
+| R-07 | Tracing: session created | T-04, I-01 |
+| R-08 | Tracing: session closed with duration | T-01, T-05, I-01 |
+| R-09 | Close reason enum | T-01, T-03, T-05, U-03 |
+| R-10 | Existing new() backward compat | T-06 |
+| R-11 | Builder passthrough SessionConfig | U-02 |
+| R-12 | Builder includes rate_limit | T-07 |
+| R-13 | memory-mcp --idle-timeout-secs | M-01, M-03 |
+| R-14 | memory-mcp --max-session-lifetime-secs | M-02, M-03 |
+| R-15 | memory-mcp uses builder API | M-03 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
-use mcp_session::{BoundedSessionManager, SessionConfig};
+use mcp_session::BoundedSessionManagerBuilder;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
 use tracing::Instrument;
+use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 // The SdkTracerProvider type is used in the otlp feature only.
@@ -126,6 +126,21 @@ struct ServeArgs {
         env = "MEMORY_MCP_SESSION_RATE_WINDOW_SECS"
     )]
     session_rate_window_secs: u64,
+
+    /// Idle timeout for MCP sessions, in seconds. Sessions are closed after
+    /// this duration of inactivity. Set to 0 to disable (not recommended).
+    #[arg(long, default_value_t = 14400, env = "MEMORY_MCP_IDLE_TIMEOUT_SECS")]
+    idle_timeout_secs: u64,
+
+    /// Maximum session lifetime in seconds, regardless of activity. Sessions
+    /// are closed after this duration even if actively used. Set to 0 to
+    /// disable (default).
+    #[arg(
+        long,
+        default_value_t = 0,
+        env = "MEMORY_MCP_MAX_SESSION_LIFETIME_SECS"
+    )]
+    max_session_lifetime_secs: u64,
 
     /// Additional hostname to accept in the HTTP Host header. Required when
     /// the server is accessed via a reverse proxy or gateway (e.g.
@@ -565,25 +580,30 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     let ct = CancellationToken::new();
     let ct_child = ct.child_token();
 
-    // SessionConfig and StreamableHttpServerConfig are #[non_exhaustive] in
-    // rmcp 1.4+, so struct literal syntax is unavailable from external crates.
-    // Default + field mutation is the intended pattern (see mcp-session#11).
-    #[allow(clippy::field_reassign_with_default)]
     let service = StreamableHttpService::new(
         move || Ok(MemoryServer::new(Arc::clone(&state))),
-        Arc::new({
-            let mut session_config = SessionConfig::default();
-            session_config.keep_alive = Some(std::time::Duration::from_secs(4 * 60 * 60));
-            let mgr = BoundedSessionManager::new(session_config, args.max_sessions);
+        {
+            let mut builder = BoundedSessionManagerBuilder::new(args.max_sessions);
+            if args.idle_timeout_secs == 0 && args.max_session_lifetime_secs == 0 {
+                warn!("both idle timeout and max session lifetime are disabled; sessions are only cleaned up by FIFO eviction at capacity");
+            }
+            if args.idle_timeout_secs > 0 {
+                builder =
+                    builder.idle_timeout(std::time::Duration::from_secs(args.idle_timeout_secs));
+            }
+            if args.max_session_lifetime_secs > 0 {
+                builder = builder.max_lifetime(std::time::Duration::from_secs(
+                    args.max_session_lifetime_secs,
+                ));
+            }
             if args.session_rate_limit > 0 && args.session_rate_window_secs > 0 {
-                mgr.with_rate_limit(
+                builder = builder.rate_limit(
                     args.session_rate_limit,
                     std::time::Duration::from_secs(args.session_rate_window_secs),
-                )
-            } else {
-                mgr
+                );
             }
-        }),
+            builder.build()
+        },
         {
             let mut server_config = StreamableHttpServerConfig::default();
             server_config.cancellation_token = ct_child;
@@ -901,6 +921,49 @@ mod tests {
             msg.contains("not supported"),
             "error should mention unsupported: {msg}"
         );
+    }
+
+    #[test]
+    fn test_cli_serve_idle_timeout_default() {
+        let cli = Cli::try_parse_from(["memory-mcp", "serve"]).expect("serve should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.idle_timeout_secs, 14400),
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_idle_timeout_custom() {
+        let cli = Cli::try_parse_from(["memory-mcp", "serve", "--idle-timeout-secs", "300"])
+            .expect("serve with idle-timeout should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.idle_timeout_secs, 300),
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_max_session_lifetime_default() {
+        let cli = Cli::try_parse_from(["memory-mcp", "serve"]).expect("serve should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.max_session_lifetime_secs, 0),
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_max_session_lifetime_custom() {
+        let cli = Cli::try_parse_from([
+            "memory-mcp",
+            "serve",
+            "--max-session-lifetime-secs",
+            "86400",
+        ])
+        .expect("serve with max-session-lifetime should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.max_session_lifetime_secs, 86400),
+            _ => panic!("expected Serve command"),
+        }
     }
 
     #[cfg(feature = "k8s")]


### PR DESCRIPTION
## Summary

- Add `--idle-timeout-secs` (default 14400/4h, env `MEMORY_MCP_IDLE_TIMEOUT_SECS`) and `--max-session-lifetime-secs` (default 0/disabled, env `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS`) CLI flags
- Wire through `BoundedSessionManagerBuilder` from mcp-session 0.2
- Runtime warning when both idle timeout and max lifetime are disabled
- Design artifacts in `docs/design/session-lifecycle/`

## Dependencies

Uses mcp-session 0.2.0 from crates.io (published).

## Test plan

- 185 tests pass (4 new CLI flag tests, no regressions)
- Session lifecycle behavior (max lifetime, idle timeout, eviction, tracing) tested in mcp-session's test suite (18 tests including idle timeout lifecycle cleanup proof)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)