### PR TITLE
fix: reject no-op edit calls that provide neither content nor tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.12.1] - 2026-05-18
+
+### Fixed
+- `edit` tool now rejects calls that provide neither `content` nor `tags`, returning an `InvalidInput` error instead of silently succeeding with a timestamp-only commit (#219)
+
 ## [0.12.0] - 2026-05-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/server.rs
+++ b/src/server.rs
@@ -578,6 +578,11 @@ impl MemoryServer {
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         validate_name(&args.name).map_err(ErrorData::from)?;
+        if args.content.is_none() && args.tags.is_none() {
+            return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
+                reason: "nothing to update — provide content or tags".into(),
+            }));
+        }
         if let Some(ref content) = args.content {
             if content.len() > MAX_CONTENT_SIZE {
                 return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {


### PR DESCRIPTION
## Summary

Closes #219.

- Adds an early validation guard in the `edit` handler that returns `InvalidInput` when neither `content` nor `tags` is provided
- Prevents silent no-op commits that only bump `updated_at`
- Bumps version to 0.12.1

## Context

When an MCP client calls `edit` with unexpected parameters (e.g. `find`/`replace` instead of `content`), serde ignores the unknown fields and `content` deserializes as `None`. The handler then reads the memory, bumps the timestamp, commits, and returns success — giving no signal that nothing meaningful changed.

The server logs showed `content_size=0` and `content_changed=false` on every such call, but the response was indistinguishable from a successful edit.

## Test plan

- [ ] `cargo check` passes
- [ ] Existing tests pass (excluding pre-existing `auth_status_no_token` failure from keyring presence)
- [ ] Manual test: call `edit` with only `name` and `scope` → should return `InvalidInput` error
- [ ] Manual test: call `edit` with `name`, `scope`, and `content` → should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)