### PR TITLE
refactor: MemoryName newtype — validate at construction, not at every call site

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -255,7 +255,6 @@ impl MemoryRepo {
     /// All blocking work (mutex lock + fs ops + git2 ops) is performed inside
     /// `tokio::task::spawn_blocking` so the async executor is not stalled.
     pub async fn save_memory(self: &Arc<Self>, memory: &Memory) -> Result<(), MemoryError> {
-        validate_name(&memory.name)?;
         if let Scope::Project(ref project_name) = memory.metadata.scope {
             validate_name(project_name)?;
         }
@@ -311,7 +310,6 @@ impl MemoryRepo {
         name: &str,
         scope: &Scope,
     ) -> Result<(), MemoryError> {
-        validate_name(name)?;
         if let Scope::Project(ref project_name) = *scope {
             validate_name(project_name)?;
         }
@@ -379,7 +377,6 @@ impl MemoryRepo {
         name: &str,
         scope: &Scope,
     ) -> Result<Memory, MemoryError> {
-        validate_name(name)?;
         if let Scope::Project(ref project_name) = *scope {
             validate_name(project_name)?;
         }
@@ -1242,7 +1239,7 @@ impl MemoryRepo {
 mod tests {
     use super::*;
     use crate::auth::AuthProvider;
-    use crate::types::{Memory, MemoryMetadata, PullResult, Scope};
+    use crate::types::{Memory, MemoryMetadata, MemoryName, PullResult, Scope};
     use std::sync::Arc;
 
     fn test_auth() -> AuthProvider {
@@ -1257,7 +1254,7 @@ mod tests {
             updated_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).unwrap(),
             source: None,
         };
-        Memory::new(name.to_string(), content.to_string(), meta)
+        Memory::new(MemoryName::new(name).unwrap(), content.to_string(), meta)
     }
 
     fn setup_bare_remote() -> (tempfile::TempDir, String) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -36,9 +36,9 @@ use crate::{
     index::VectorStore,
     repo::MemoryRepo,
     types::{
-        parse_qualified_name, parse_scope, parse_scope_filter, validate_name, AppState,
-        ChangedMemories, EditArgs, ForgetArgs, ListArgs, Memory, MemoryMetadata, PullResult,
-        ReadArgs, RecallArgs, ReindexStats, RememberArgs, Scope, ScopeFilter, SyncArgs,
+        parse_qualified_name, parse_scope, parse_scope_filter, AppState, ChangedMemories, EditArgs,
+        ForgetArgs, ListArgs, Memory, MemoryMetadata, MemoryName, PullResult, ReadArgs, RecallArgs,
+        ReindexStats, RememberArgs, Scope, ScopeFilter, SyncArgs,
     },
 };
 
@@ -102,9 +102,7 @@ async fn incremental_reindex(
     }
 
     // ---- 2. Resolve (scope, name) pairs for upserts -------------------------
-    // Each qualified name is "global/foo" or "projects/<project>/foo".
-    // parse_qualified_name handles both forms.
-    let mut pairs: Vec<(Scope, String, String)> = Vec::new(); // (scope, name, qualified_name)
+    let mut pairs: Vec<(Scope, MemoryName, String)> = Vec::new();
     for qualified in &changes.upserted {
         match parse_qualified_name(qualified) {
             Ok((scope, name)) => pairs.push((scope, name, qualified.clone())),
@@ -313,7 +311,7 @@ impl MemoryServer {
         Parameters(args): Parameters<RememberArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        validate_name(&args.name).map_err(ErrorData::from)?;
+        let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.len() > MAX_CONTENT_SIZE {
             return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
                 reason: format!(
@@ -328,7 +326,7 @@ impl MemoryServer {
         let span = tracing::info_span!(
             "handler.remember",
             session_id = %session_id,
-            name = %args.name,
+            name = %name,
             scope = ?args.scope,
             content_size,
         );
@@ -336,7 +334,7 @@ impl MemoryServer {
         async move {
             let scope = parse_scope(args.scope.as_deref()).map_err(ErrorData::from)?;
             let metadata = MemoryMetadata::new(scope.clone(), args.tags, args.source);
-            let memory = Memory::new(args.name, args.content, metadata);
+            let memory = Memory::new(name, args.content, metadata);
 
             // Order: (1) embed, (2) add to index, (3) save to repo.
             // If step 3 fails, index has a stale entry (harmless — recall will skip it).
@@ -517,12 +515,12 @@ impl MemoryServer {
         Parameters(args): Parameters<ForgetArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        validate_name(&args.name).map_err(ErrorData::from)?;
+        let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.forget",
             session_id = %session_id,
-            name = %args.name,
+            name = %name,
             scope = ?args.scope,
         );
         let state = Arc::clone(&self.state);
@@ -534,19 +532,19 @@ impl MemoryServer {
             // Delete from repo first — if this fails, index is untouched, memory stays functional.
             state
                 .repo
-                .delete_memory(&args.name, &scope)
+                .delete_memory(&name, &scope)
                 .await
                 .map_err(ErrorData::from)?;
 
             // Remove from index (best-effort — stale entries are skipped at recall time).
-            let qualified_name = format!("{}/{}", scope.dir_prefix(), args.name);
+            let qualified_name = format!("{}/{}", scope.dir_prefix(), name);
             if let Err(e) = state.index.remove(&scope, &qualified_name) {
-                warn!(name = %args.name, error = %e, "vector removal failed during forget; stale entry will be skipped at recall");
+                warn!(name = %name, error = %e, "vector removal failed during forget; stale entry will be skipped at recall");
             }
 
             info!(
                 ms = start.elapsed().as_millis(),
-                name = %args.name,
+                name = %name,
                 "memory forgotten"
             );
 
@@ -577,7 +575,7 @@ impl MemoryServer {
         Parameters(args): Parameters<EditArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        validate_name(&args.name).map_err(ErrorData::from)?;
+        let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.is_none() && args.tags.is_none() {
             return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
                 reason: "nothing to update — provide content or tags".into(),
@@ -599,7 +597,7 @@ impl MemoryServer {
         let span = tracing::info_span!(
             "handler.edit",
             session_id = %session_id,
-            name = %args.name,
+            name = %name,
             scope = ?args.scope,
             content_size,
         );
@@ -615,7 +613,7 @@ impl MemoryServer {
             // Read the existing memory.
             let mut memory = state
                 .repo
-                .read_memory(&args.name, &scope)
+                .read_memory(&name, &scope)
                 .await
                 .map_err(ErrorData::from)?;
 
@@ -656,7 +654,7 @@ impl MemoryServer {
 
             info!(
                 ms = start.elapsed().as_millis(),
-                name = %args.name,
+                name = %name,
                 content_changed,
                 "memory edited"
             );
@@ -770,12 +768,12 @@ impl MemoryServer {
         Parameters(args): Parameters<ReadArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
-        validate_name(&args.name).map_err(ErrorData::from)?;
+        let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         let session_id = extract_session_id(&parts);
         let span = tracing::info_span!(
             "handler.read",
             session_id = %session_id,
-            name = %args.name,
+            name = %name,
             scope = ?args.scope,
         );
         let state = Arc::clone(&self.state);
@@ -785,12 +783,12 @@ impl MemoryServer {
             let start = Instant::now();
             let memory = state
                 .repo
-                .read_memory(&args.name, &scope)
+                .read_memory(&name, &scope)
                 .await
                 .map_err(ErrorData::from)?;
             info!(
                 ms = start.elapsed().as_millis(),
-                name = %args.name,
+                name = %name,
                 "read memory"
             );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use rmcp::schemars;
-use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::{fmt, ops::Deref, str::FromStr};
 use uuid::Uuid;
 
 use crate::error::MemoryError;
@@ -58,6 +58,86 @@ pub fn validate_name(name: &str) -> Result<(), MemoryError> {
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// MemoryName newtype
+// ---------------------------------------------------------------------------
+
+/// A validated memory name.
+///
+/// Wraps a `String` that has been validated by [`validate_name`]. Constructing
+/// a `MemoryName` is the sole path to a valid name — once you hold one, you
+/// can use it as `&str` without re-validation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct MemoryName(String);
+
+impl MemoryName {
+    /// Validate `name` and wrap it.
+    pub fn new(name: impl Into<String>) -> Result<Self, MemoryError> {
+        let s = name.into();
+        validate_name(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Consume and return the inner `String`.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    /// Borrow as `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for MemoryName {
+    type Err = MemoryError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl fmt::Display for MemoryName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Deref for MemoryName {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for MemoryName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for MemoryName {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl schemars::JsonSchema for MemoryName {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("MemoryName")
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        String::json_schema(generator)
+    }
+
+    fn inline_schema() -> bool {
+        true
+    }
 }
 
 /// Validate a git branch name to prevent ref injection.
@@ -213,7 +293,7 @@ pub struct Memory {
     /// Stable UUID for vector-index keying.
     pub id: String,
     /// Human-readable name / filename stem.
-    pub name: String,
+    pub name: MemoryName,
     /// Markdown body (no frontmatter).
     pub content: String,
     /// Associated metadata (tags, scope, timestamps, source).
@@ -222,7 +302,7 @@ pub struct Memory {
 
 impl Memory {
     /// Create a new memory with a random UUID.
-    pub fn new(name: String, content: String, metadata: MemoryMetadata) -> Self {
+    pub fn new(name: MemoryName, content: String, metadata: MemoryMetadata) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             name,
@@ -256,7 +336,7 @@ impl Memory {
 
         let fm = Frontmatter {
             id: &self.id,
-            name: &self.name,
+            name: self.name.as_str(),
             tags: &self.metadata.tags,
             scope: &self.metadata.scope,
             created_at: &self.metadata.created_at,
@@ -303,7 +383,7 @@ impl Memory {
 
         Ok(Memory {
             id: fm.id,
-            name: fm.name,
+            name: MemoryName::new(fm.name)?,
             content: body.to_string(),
             metadata: MemoryMetadata {
                 tags: fm.tags,
@@ -371,18 +451,18 @@ pub fn parse_scope(scope: Option<&str>) -> Result<Scope, MemoryError> {
 }
 
 /// Parse a qualified name of the form `"global/<name>"` or
-/// `"projects/<project>/<name>"` back into a `(Scope, name)` pair.
-pub fn parse_qualified_name(qualified: &str) -> Result<(Scope, String), MemoryError> {
+/// `"projects/<project>/<name>"` back into a `(Scope, MemoryName)` pair.
+pub fn parse_qualified_name(qualified: &str) -> Result<(Scope, MemoryName), MemoryError> {
     if let Some(rest) = qualified.strip_prefix("global/") {
-        validate_name(rest)?;
-        return Ok((Scope::Global, rest.to_string()));
+        let name = MemoryName::new(rest)?;
+        return Ok((Scope::Global, name));
     }
     if let Some(rest) = qualified.strip_prefix("projects/") {
         // rest = "<project>/<memory_name>" (possibly nested)
         if let Some(slash_pos) = rest.find('/') {
             let project = &rest[..slash_pos];
-            let name = &rest[slash_pos + 1..];
-            if project.is_empty() || name.is_empty() {
+            let name_str = &rest[slash_pos + 1..];
+            if project.is_empty() || name_str.is_empty() {
                 return Err(MemoryError::InvalidInput {
                     reason: format!(
                         "malformed qualified name '{}': project or memory name is empty",
@@ -391,8 +471,8 @@ pub fn parse_qualified_name(qualified: &str) -> Result<(Scope, String), MemoryEr
                 });
             }
             validate_name(project)?;
-            validate_name(name)?;
-            return Ok((Scope::Project(project.to_string()), name.to_string()));
+            let name = MemoryName::new(name_str)?;
+            return Ok((Scope::Project(project.to_string()), name));
         }
         return Err(MemoryError::InvalidInput {
             reason: format!(
@@ -623,6 +703,55 @@ impl AppState {
 mod tests {
     use super::*;
 
+    #[test]
+    fn memory_name_valid() {
+        let name = MemoryName::new("my-memory").unwrap();
+        assert_eq!(name.as_str(), "my-memory");
+        assert_eq!(name.into_inner(), "my-memory");
+    }
+
+    #[test]
+    fn memory_name_empty_rejected() {
+        assert!(MemoryName::new("").is_err());
+    }
+
+    #[test]
+    fn memory_name_traversal_rejected() {
+        assert!(MemoryName::new("..").is_err());
+        assert!(MemoryName::new("../etc/passwd").is_err());
+        assert!(MemoryName::new(".hidden").is_err());
+    }
+
+    #[test]
+    fn memory_name_invalid_chars_rejected() {
+        assert!(MemoryName::new("has spaces").is_err());
+        assert!(MemoryName::new("has@symbol").is_err());
+    }
+
+    #[test]
+    fn memory_name_nested_valid() {
+        let name = MemoryName::new("sub/path").unwrap();
+        assert_eq!(name.as_str(), "sub/path");
+    }
+
+    #[test]
+    fn memory_name_display() {
+        let name = MemoryName::new("test-display").unwrap();
+        assert_eq!(format!("{name}"), "test-display");
+    }
+
+    #[test]
+    fn memory_name_serde_round_trip() {
+        let valid: MemoryName = serde_json::from_str("\"my-memory\"").unwrap();
+        assert_eq!(valid.as_str(), "my-memory");
+
+        let invalid: Result<MemoryName, _> = serde_json::from_str("\"../etc\"");
+        assert!(invalid.is_err());
+
+        let empty: Result<MemoryName, _> = serde_json::from_str("\"\"");
+        assert!(empty.is_err());
+    }
+
     fn make_memory() -> Memory {
         let meta = MemoryMetadata {
             tags: vec!["test".to_string(), "round-trip".to_string()],
@@ -633,7 +762,7 @@ mod tests {
         };
         Memory {
             id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
-            name: "test-memory".to_string(),
+            name: MemoryName::new("test-memory").unwrap(),
             content: "# Hello\n\nThis is a test memory.".to_string(),
             metadata: meta,
         }
@@ -664,7 +793,11 @@ mod tests {
     #[test]
     fn round_trip_global_scope() {
         let meta = MemoryMetadata::new(Scope::Global, vec!["global-tag".to_string()], None);
-        let mem = Memory::new("global-mem".to_string(), "Some content.".to_string(), meta);
+        let mem = Memory::new(
+            MemoryName::new("global-mem").unwrap(),
+            "Some content.".to_string(),
+            meta,
+        );
         let rendered = mem.to_markdown().unwrap();
         let parsed = Memory::from_markdown(&rendered).unwrap();
 
@@ -676,7 +809,11 @@ mod tests {
     #[test]
     fn round_trip_no_source() {
         let meta = MemoryMetadata::new(Scope::Project("proj".to_string()), vec![], None);
-        let mem = Memory::new("no-src".to_string(), "Body.".to_string(), meta);
+        let mem = Memory::new(
+            MemoryName::new("no-src").unwrap(),
+            "Body.".to_string(),
+            meta,
+        );
         let md = mem.to_markdown().unwrap();
         // source field should not appear in yaml
         assert!(!md.contains("source:"));
@@ -790,21 +927,21 @@ mod tests {
     fn test_parse_qualified_name_global() {
         let (scope, name) = parse_qualified_name("global/my-memory").unwrap();
         assert_eq!(scope, Scope::Global);
-        assert_eq!(name, "my-memory");
+        assert_eq!(name.as_str(), "my-memory");
     }
 
     #[test]
     fn test_parse_qualified_name_project() {
         let (scope, name) = parse_qualified_name("projects/my-project/my-memory").unwrap();
         assert_eq!(scope, Scope::Project("my-project".to_string()));
-        assert_eq!(name, "my-memory");
+        assert_eq!(name.as_str(), "my-memory");
     }
 
     #[test]
     fn test_parse_qualified_name_nested() {
         let (scope, name) = parse_qualified_name("projects/my-project/nested/memory").unwrap();
         assert_eq!(scope, Scope::Project("my-project".to_string()));
-        assert_eq!(name, "nested/memory");
+        assert_eq!(name.as_str(), "nested/memory");
     }
 
     // validate_branch_name tests

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -10,7 +10,7 @@ use memory_mcp::auth::AuthProvider;
 #[cfg(unix)]
 use memory_mcp::error::MemoryError;
 use memory_mcp::repo::MemoryRepo;
-use memory_mcp::types::{Memory, MemoryMetadata, PullResult, Scope};
+use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, PullResult, Scope};
 
 /// Full round-trip: init repo → save memory → read it back → list → delete → pull.
 ///
@@ -29,7 +29,7 @@ async fn repo_round_trip_with_test_auth_provider() {
     // Save a memory.
     let metadata = MemoryMetadata::new(Scope::Global, vec!["test".into()], None);
     let memory = Memory::new(
-        "test-memory".into(),
+        MemoryName::new("test-memory").unwrap(),
         "Hello from integration test.".into(),
         metadata,
     );
@@ -42,13 +42,13 @@ async fn repo_round_trip_with_test_auth_provider() {
         .read_memory("test-memory", &Scope::Global)
         .await
         .expect("read should find the memory");
-    assert_eq!(loaded.name, "test-memory");
+    assert_eq!(loaded.name.as_str(), "test-memory");
     assert_eq!(loaded.content, "Hello from integration test.");
 
     // List all memories.
     let list = repo.list_memories(None).await.expect("list should succeed");
     assert_eq!(list.len(), 1);
-    assert_eq!(list[0].name, "test-memory");
+    assert_eq!(list[0].name.as_str(), "test-memory");
 
     // Pull with no remote — exercises auth resolution path via with_token.
     let pull_result = repo.pull(&auth, "main").await.expect("pull should succeed");
@@ -92,7 +92,7 @@ async fn push_pull_with_bare_remote() {
     // Save a memory so there's something to push.
     let metadata = MemoryMetadata::new(Scope::Global, vec!["push-test".into()], None);
     let memory = Memory::new(
-        "push-memory".into(),
+        MemoryName::new("push-memory").unwrap(),
         "Content for push test.".into(),
         metadata,
     );
@@ -137,7 +137,7 @@ async fn push_pull_with_bare_remote() {
         .await
         .expect("list should succeed");
     assert_eq!(memories.len(), 1);
-    assert_eq!(memories[0].name, "push-memory");
+    assert_eq!(memories[0].name.as_str(), "push-memory");
     assert_eq!(memories[0].content, "Content for push test.");
 }
 
@@ -242,7 +242,7 @@ async fn push_rejected_by_server_hook() {
 
     let metadata = MemoryMetadata::new(Scope::Global, vec!["rejected".into()], None);
     let memory = Memory::new(
-        "rejected-memory".into(),
+        MemoryName::new("rejected-memory").unwrap(),
         "This push should be rejected.".into(),
         metadata,
     );

--- a/tests/scope_filter_integration.rs
+++ b/tests/scope_filter_integration.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use memory_mcp::repo::MemoryRepo;
-use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
 
 /// Helper: initialise a fresh in-memory repo in a temp directory.
 async fn make_repo() -> (Arc<MemoryRepo>, tempfile::TempDir) {
@@ -20,7 +20,11 @@ async fn make_repo() -> (Arc<MemoryRepo>, tempfile::TempDir) {
 /// Helper: save a memory with the given scope and name.
 async fn save(repo: &Arc<MemoryRepo>, name: &str, scope: Scope) {
     let metadata = MemoryMetadata::new(scope, vec![], None);
-    let memory = Memory::new(name.to_string(), format!("Content for {}", name), metadata);
+    let memory = Memory::new(
+        MemoryName::new(name).unwrap(),
+        format!("Content for {}", name),
+        metadata,
+    );
     repo.save_memory(&memory)
         .await
         .expect("save should succeed");
@@ -43,7 +47,7 @@ async fn list_scope_filter_global_only() {
         .expect("list should succeed");
 
     assert_eq!(memories.len(), 1, "expected only the global memory");
-    assert_eq!(memories[0].name, "global-mem");
+    assert_eq!(memories[0].name.as_str(), "global-mem");
     assert_eq!(memories[0].metadata.scope, Scope::Global);
 }
 
@@ -70,7 +74,7 @@ async fn list_scope_filter_project_specific() {
         .expect("list should succeed");
 
     assert_eq!(memories.len(), 1, "expected only the test-proj memory");
-    assert_eq!(memories[0].name, "proj-mem");
+    assert_eq!(memories[0].name.as_str(), "proj-mem");
     assert_eq!(
         memories[0].metadata.scope,
         Scope::Project("test-proj".to_string())

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -716,7 +716,7 @@ fn debug_spans_are_filtered_when_only_info_enabled() {
 #[test]
 fn repo_save_span_has_name_and_oid_fields() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -735,7 +735,11 @@ fn repo_save_span_has_name_and_oid_fields() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new("tc08-memory".to_string(), "test content".to_string(), meta);
+            let mem = Memory::new(
+                MemoryName::new("tc08-memory").unwrap(),
+                "test content".to_string(),
+                meta,
+            );
             repo.save_memory(&mem).await.expect("save");
         });
     });
@@ -768,7 +772,7 @@ fn repo_save_span_has_name_and_oid_fields() {
 #[test]
 fn repo_delete_span_has_name_and_oid_fields() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -787,7 +791,11 @@ fn repo_delete_span_has_name_and_oid_fields() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new("tc08b-memory".to_string(), "test content".to_string(), meta);
+            let mem = Memory::new(
+                MemoryName::new("tc08b-memory").unwrap(),
+                "test content".to_string(),
+                meta,
+            );
             repo.save_memory(&mem).await.expect("save");
             repo.delete_memory("tc08b-memory", &Scope::Global)
                 .await
@@ -823,7 +831,7 @@ fn repo_delete_span_has_name_and_oid_fields() {
 #[test]
 fn repo_save_does_not_log_content_text() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -843,7 +851,11 @@ fn repo_save_does_not_log_content_text() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new("tc17-memory".to_string(), secret_content.to_string(), meta);
+            let mem = Memory::new(
+                MemoryName::new("tc17-memory").unwrap(),
+                secret_content.to_string(),
+                meta,
+            );
             repo.save_memory(&mem).await.expect("save");
         });
     });


### PR DESCRIPTION
## Summary

TMFDYUT pass #1: introduces `MemoryName` newtype that validates memory names on construction, eliminating 8+ scattered `validate_name()` calls across server.rs and repo.rs.

## What changed

- **`MemoryName` newtype** in `types.rs` — wraps `String`, validates via `validate_name()` on construction. `FromStr`, `Display`, `Deref<Target=str>`, `AsRef<str>`, custom `Deserialize` (validates on deser), `JsonSchema` (delegates to String).
- **`Memory.name`**: `String` → `MemoryName`
- **`parse_qualified_name`**: returns `(Scope, MemoryName)` instead of `(Scope, String)`
- **Server handlers**: `validate_name(&args.name)?` → `MemoryName::new(args.name)?` at the boundary
- **Repo methods**: removed redundant `validate_name()` calls — `MemoryName` guarantees validity at construction
- **Tests**: updated to construct `MemoryName::new(...).unwrap()` and compare with `.as_str()`

## Design

The type carries the promise. Once you have a `MemoryName`, it's valid — no need to re-check at every function boundary. Tool argument structs still deserialize `name` as `String` from JSON (API unchanged), conversion to `MemoryName` happens at the handler boundary.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo nextest run --no-fail-fast` — 184/185 passing (1 pre-existing auth test failure, unrelated)
- [x] `cargo fmt --check` — clean

## Next in the TMFDYUT series

- `QualifiedName` struct (replaces `format!()` / `parse_qualified_name()` round-trips)
- `ProjectName` inside `Scope::Project` (validates project name at construction)
- `ValidatedContent` (MAX_CONTENT_SIZE check at construction)
- `PullStatus` enum (replaces string-matched status values)