### PR TITLE
fix: isolate auth test from system keyring backends

### DIFF
--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -160,6 +160,8 @@ async fn auth_status_no_token_prints_not_configured() {
         .args(["auth", "status"])
         .env_remove("MEMORY_MCP_GITHUB_TOKEN")
         .env_remove("DBUS_SESSION_BUS_ADDRESS")
+        .env_remove("DISPLAY")
+        .env("XDG_RUNTIME_DIR", tmp.path())
         .env("HOME", tmp.path())
         .output()
         .await


### PR DESCRIPTION
## Problem

`auth_status_no_token_prints_not_configured` fails on machines with a system keyring accessible without DBUS (e.g. file-based keyring backends, KWallet). The test removes `DBUS_SESSION_BUS_ADDRESS` but that's not sufficient to block all keyring access paths.

## Fix

Also remove `DISPLAY` and redirect `XDG_RUNTIME_DIR` to the temp directory, fully isolating the subprocess from any system keyring backend.

## Test plan

- [x] Test now passes locally on a machine where it previously failed
- [x] Full test suite: 192/192 passing