### PR TITLE
refactor: add MemoryRef newtype for scope+name pairs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -37,8 +37,8 @@ use crate::{
     repo::MemoryRepo,
     types::{
         parse_qualified_name, parse_scope, parse_scope_filter, AppState, ChangedMemories, EditArgs,
-        ForgetArgs, ListArgs, Memory, MemoryMetadata, MemoryName, PullResult, ReadArgs, RecallArgs,
-        ReindexStats, RememberArgs, Scope, ScopeFilter, SyncArgs,
+        ForgetArgs, ListArgs, Memory, MemoryMetadata, MemoryName, MemoryRef, PullResult, ReadArgs,
+        RecallArgs, ReindexStats, RememberArgs, Scope, ScopeFilter, SyncArgs,
     },
 };
 
@@ -77,8 +77,8 @@ async fn incremental_reindex(
     // ---- 1. Removals --------------------------------------------------------
     for name in &changes.removed {
         match parse_qualified_name(name) {
-            Ok((scope, _)) => {
-                if let Err(e) = index.remove(&scope, name) {
+            Ok(mref) => {
+                if let Err(e) = index.remove(&mref.scope, name) {
                     warn!(
                         qualified_name = %name,
                         error = %e,
@@ -101,11 +101,11 @@ async fn incremental_reindex(
         // If not in index, remove is a no-op — not an error.
     }
 
-    // ---- 2. Resolve (scope, name) pairs for upserts -------------------------
-    let mut pairs: Vec<(Scope, MemoryName, String)> = Vec::new();
+    // ---- 2. Resolve MemoryRefs for upserts ----------------------------------
+    let mut refs: Vec<MemoryRef> = Vec::new();
     for qualified in &changes.upserted {
         match parse_qualified_name(qualified) {
-            Ok((scope, name)) => pairs.push((scope, name, qualified.clone())),
+            Ok(mref) => refs.push(mref),
             Err(e) => {
                 warn!(
                     qualified_name = %qualified,
@@ -118,10 +118,11 @@ async fn incremental_reindex(
     }
 
     // ---- 3. Read memories from disk -----------------------------------------
-    // (scope, qualified_name, content)
-    let mut to_embed: Vec<(Scope, String, String)> = Vec::new();
-    for (scope, name, qualified) in &pairs {
-        let memory = match repo.read_memory(name, scope).await {
+    // (MemoryRef, content)
+    let mut to_embed: Vec<(MemoryRef, String)> = Vec::new();
+    for mref in &refs {
+        let qualified = mref.qualified_path();
+        let memory = match repo.read_memory(&mref.name, &mref.scope).await {
             Ok(m) => m,
             Err(e) => {
                 warn!(
@@ -133,7 +134,7 @@ async fn incremental_reindex(
                 continue;
             }
         };
-        to_embed.push((scope.clone(), qualified.clone(), memory.content));
+        to_embed.push((mref.clone(), memory.content));
     }
 
     if to_embed.is_empty() {
@@ -141,7 +142,7 @@ async fn incremental_reindex(
     }
 
     // ---- 4. Batch embed all content -----------------------------------------
-    let contents: Vec<String> = to_embed.iter().map(|(_, _, c)| c.clone()).collect();
+    let contents: Vec<String> = to_embed.iter().map(|(_, c)| c.clone()).collect();
     let vectors = match embedding.embed(&contents).await {
         Ok(v) => v,
         Err(batch_err) => {
@@ -154,7 +155,7 @@ async fn incremental_reindex(
                     Err(e) => {
                         warn!(
                             error = %e,
-                            qualified_name = %to_embed[i].1,
+                            qualified_name = %to_embed[i].0.qualified_path(),
                             "incremental_reindex: per-item embed failed; skipping"
                         );
                         failed.push(i);
@@ -171,10 +172,11 @@ async fn incremental_reindex(
     };
 
     // ---- 5. Update index entries --------------------------------------------
-    for ((scope, qualified_name, _), vector) in to_embed.iter().zip(vectors.iter()) {
-        let is_update = index.find_by_name(qualified_name).is_some();
+    for ((mref, _), vector) in to_embed.iter().zip(vectors.iter()) {
+        let qualified_name = mref.qualified_path();
+        let is_update = index.find_by_name(&qualified_name).is_some();
 
-        match index.add(scope, vector, qualified_name.clone()) {
+        match index.add(&mref.scope, vector, qualified_name.clone()) {
             Ok(_) => {}
             Err(e) => {
                 warn!(
@@ -217,11 +219,11 @@ pub async fn full_reindex(
 
     let mut stats = ReindexStats::default();
 
-    let items: Vec<(Scope, String, String)> = memories
+    let items: Vec<(MemoryRef, String)> = memories
         .into_iter()
         .map(|m| {
-            let qualified = format!("{}/{}", m.metadata.scope.dir_prefix(), m.name);
-            (m.metadata.scope, qualified, m.content)
+            let mref = MemoryRef::new(m.metadata.scope, m.name);
+            (mref, m.content)
         })
         .collect();
 
@@ -230,7 +232,7 @@ pub async fn full_reindex(
     // within the per-call timeout budget.
     const REINDEX_BATCH_SIZE: usize = 64;
     for chunk in items.chunks(REINDEX_BATCH_SIZE) {
-        let contents: Vec<String> = chunk.iter().map(|(_, _, c)| c.clone()).collect();
+        let contents: Vec<String> = chunk.iter().map(|(_, c)| c.clone()).collect();
 
         let vectors = match embedding.embed(&contents).await {
             Ok(v) => v,
@@ -243,7 +245,7 @@ pub async fn full_reindex(
                         Err(e) => {
                             warn!(
                                 error = %e,
-                                qualified_name = %chunk[i].1,
+                                qualified_name = %chunk[i].0.qualified_path(),
                                 "full_reindex: per-item embed failed; skipping"
                             );
                             stats.errors += 1;
@@ -261,11 +263,12 @@ pub async fn full_reindex(
             "embed() must return exactly one vector per input"
         );
 
-        for ((scope, qualified_name, _), vector) in chunk.iter().zip(vectors.iter()) {
+        for ((mref, _), vector) in chunk.iter().zip(vectors.iter()) {
             if vector.is_empty() {
                 continue;
             }
-            match index.add(scope, vector, qualified_name.clone()) {
+            let qualified_name = mref.qualified_path();
+            match index.add(&mref.scope, vector, qualified_name.clone()) {
                 Ok(_) => stats.added += 1,
                 Err(e) => {
                     warn!(
@@ -440,8 +443,8 @@ impl MemoryServer {
                 if results_vec.len() >= limit {
                     break;
                 }
-                let (scope, name) = match parse_qualified_name(&qualified_name) {
-                    Ok(pair) => pair,
+                let mref = match parse_qualified_name(&qualified_name) {
+                    Ok(r) => r,
                     Err(e) => {
                         warn!(
                             qualified_name = %qualified_name,
@@ -454,11 +457,11 @@ impl MemoryServer {
                 };
 
                 // Read the memory; if it was deleted but still in the index, skip it.
-                let memory = match state.repo.read_memory(&name, &scope).await {
+                let memory = match state.repo.read_memory(&mref.name, &mref.scope).await {
                     Ok(m) => m,
                     Err(e) => {
                         warn!(
-                            name = %name,
+                            name = %mref.name,
                             error = %e,
                             "could not read memory from repo (deleted?); skipping"
                         );

--- a/src/types.rs
+++ b/src/types.rs
@@ -439,6 +439,37 @@ pub fn parse_scope_filter(scope: Option<&str>) -> Result<ScopeFilter, MemoryErro
 }
 
 // ---------------------------------------------------------------------------
+// MemoryRef — a scope+name pair
+// ---------------------------------------------------------------------------
+
+/// A reference to a specific memory: scope + validated name.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MemoryRef {
+    /// Where this memory lives (global or project-scoped).
+    pub scope: Scope,
+    /// Validated memory name.
+    pub name: MemoryName,
+}
+
+impl MemoryRef {
+    /// Create a reference from a scope and a validated name.
+    pub fn new(scope: Scope, name: MemoryName) -> Self {
+        Self { scope, name }
+    }
+
+    /// The on-disk qualified path: `"global/<name>"` or `"projects/<project>/<name>"`.
+    pub fn qualified_path(&self) -> String {
+        format!("{}/{}", self.scope.dir_prefix(), self.name)
+    }
+}
+
+impl fmt::Display for MemoryRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.scope, self.name)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helper functions
 // ---------------------------------------------------------------------------
 
@@ -451,11 +482,11 @@ pub fn parse_scope(scope: Option<&str>) -> Result<Scope, MemoryError> {
 }
 
 /// Parse a qualified name of the form `"global/<name>"` or
-/// `"projects/<project>/<name>"` back into a `(Scope, MemoryName)` pair.
-pub fn parse_qualified_name(qualified: &str) -> Result<(Scope, MemoryName), MemoryError> {
+/// `"projects/<project>/<name>"` back into a [`MemoryRef`].
+pub fn parse_qualified_name(qualified: &str) -> Result<MemoryRef, MemoryError> {
     if let Some(rest) = qualified.strip_prefix("global/") {
         let name = MemoryName::new(rest)?;
-        return Ok((Scope::Global, name));
+        return Ok(MemoryRef::new(Scope::Global, name));
     }
     if let Some(rest) = qualified.strip_prefix("projects/") {
         // rest = "<project>/<memory_name>" (possibly nested)
@@ -472,7 +503,7 @@ pub fn parse_qualified_name(qualified: &str) -> Result<(Scope, MemoryName), Memo
             }
             validate_name(project)?;
             let name = MemoryName::new(name_str)?;
-            return Ok((Scope::Project(project.to_string()), name));
+            return Ok(MemoryRef::new(Scope::Project(project.to_string()), name));
         }
         return Err(MemoryError::InvalidInput {
             reason: format!(
@@ -925,23 +956,58 @@ mod tests {
 
     #[test]
     fn test_parse_qualified_name_global() {
-        let (scope, name) = parse_qualified_name("global/my-memory").unwrap();
-        assert_eq!(scope, Scope::Global);
-        assert_eq!(name.as_str(), "my-memory");
+        let r = parse_qualified_name("global/my-memory").unwrap();
+        assert_eq!(r.scope, Scope::Global);
+        assert_eq!(r.name.as_str(), "my-memory");
+        assert_eq!(r.qualified_path(), "global/my-memory");
     }
 
     #[test]
     fn test_parse_qualified_name_project() {
-        let (scope, name) = parse_qualified_name("projects/my-project/my-memory").unwrap();
-        assert_eq!(scope, Scope::Project("my-project".to_string()));
-        assert_eq!(name.as_str(), "my-memory");
+        let r = parse_qualified_name("projects/my-project/my-memory").unwrap();
+        assert_eq!(r.scope, Scope::Project("my-project".to_string()));
+        assert_eq!(r.name.as_str(), "my-memory");
+        assert_eq!(r.qualified_path(), "projects/my-project/my-memory");
     }
 
     #[test]
     fn test_parse_qualified_name_nested() {
-        let (scope, name) = parse_qualified_name("projects/my-project/nested/memory").unwrap();
-        assert_eq!(scope, Scope::Project("my-project".to_string()));
-        assert_eq!(name.as_str(), "nested/memory");
+        let r = parse_qualified_name("projects/my-project/nested/memory").unwrap();
+        assert_eq!(r.scope, Scope::Project("my-project".to_string()));
+        assert_eq!(r.name.as_str(), "nested/memory");
+        assert_eq!(r.qualified_path(), "projects/my-project/nested/memory");
+    }
+
+    // MemoryRef tests
+
+    #[test]
+    fn memory_ref_qualified_path_global() {
+        let r = MemoryRef::new(Scope::Global, MemoryName::new("my-mem").unwrap());
+        assert_eq!(r.qualified_path(), "global/my-mem");
+    }
+
+    #[test]
+    fn memory_ref_qualified_path_project() {
+        let r = MemoryRef::new(
+            Scope::Project("proj".to_string()),
+            MemoryName::new("my-mem").unwrap(),
+        );
+        assert_eq!(r.qualified_path(), "projects/proj/my-mem");
+    }
+
+    #[test]
+    fn memory_ref_display() {
+        let r = MemoryRef::new(
+            Scope::Project("proj".to_string()),
+            MemoryName::new("my-mem").unwrap(),
+        );
+        assert_eq!(format!("{r}"), "project:proj:my-mem");
+    }
+
+    #[test]
+    fn memory_ref_display_global() {
+        let r = MemoryRef::new(Scope::Global, MemoryName::new("foo").unwrap());
+        assert_eq!(format!("{r}"), "global:foo");
     }
 
     // validate_branch_name tests


### PR DESCRIPTION
## Summary

- Add `MemoryRef` struct pairing `Scope` + `MemoryName` with a `qualified_path()` method
- Replace loose `(Scope, MemoryName)` tuples and manual `format!("{}/{}", scope.dir_prefix(), name)` calls throughout the codebase
- Update `parse_qualified_name` to return `MemoryRef` instead of a tuple
- Thread `MemoryRef` through `incremental_reindex` and `full_reindex` in server.rs

Part of the ongoing TMFDYUT (newtypes) pass. Follows #224 (MemoryName).

## Test plan

- [x] All existing tests updated and passing (128 lib, 3 allowed_hosts, 3 readyz, 6 auth)
- [x] New tests: `memory_ref_qualified_path_global`, `memory_ref_qualified_path_project`, `memory_ref_display`, `memory_ref_display_global`
- [x] `parse_qualified_name` tests updated to use `MemoryRef` return type
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)