### PR TITLE
fix: handle SIGTERM for graceful shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -631,9 +631,21 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            tokio::signal::ctrl_c()
-                .await
-                .expect("failed to listen for ctrl-c");
+            #[cfg(unix)]
+            {
+                use tokio::signal::unix::{signal, SignalKind};
+                let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {},
+                    _ = sigterm.recv() => {},
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                tokio::signal::ctrl_c()
+                    .await
+                    .expect("failed to listen for ctrl-c");
+            }
             info!("shutdown signal received");
             ct.cancel();
         })


### PR DESCRIPTION
## Summary

- Add SIGTERM handler alongside existing SIGINT (Ctrl+C) handler in the server shutdown future
- Uses `tokio::select!` to race both signals on Unix; Windows keeps SIGINT-only behavior
- Prevents `.save-in-progress` dirty marker from being left on disk when stopped by systemd, Docker, or Kubernetes

Closes #195

## Test plan

- [x] `cargo test --lib` passes (128 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] Unix-only code gated with `#[cfg(unix)]` / `#[cfg(not(unix))]`
- [x] Cross-compile targets unaffected (checked in CI via prior stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)