### PR TITLE
refactor: ergonomic Memory::new with inline name validation

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1239,7 +1239,7 @@ impl MemoryRepo {
 mod tests {
     use super::*;
     use crate::auth::AuthProvider;
-    use crate::types::{Memory, MemoryMetadata, MemoryName, PullResult, Scope};
+    use crate::types::{Memory, MemoryMetadata, PullResult, Scope};
     use std::sync::Arc;
 
     fn test_auth() -> AuthProvider {
@@ -1254,7 +1254,7 @@ mod tests {
             updated_at: chrono::DateTime::from_timestamp(updated_at_secs, 0).unwrap(),
             source: None,
         };
-        Memory::new(MemoryName::new(name).unwrap(), content.to_string(), meta)
+        Memory::new(name, content, meta).unwrap()
     }
 
     fn setup_bare_remote() -> (tempfile::TempDir, String) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -337,7 +337,7 @@ impl MemoryServer {
         async move {
             let scope = parse_scope(args.scope.as_deref()).map_err(ErrorData::from)?;
             let metadata = MemoryMetadata::new(scope.clone(), args.tags, args.source);
-            let memory = Memory::new(name, args.content, metadata);
+            let memory = Memory::from_validated(name, args.content, metadata);
 
             // Order: (1) embed, (2) add to index, (3) save to repo.
             // If step 3 fails, index has a stale entry (harmless — recall will skip it).

--- a/src/types.rs
+++ b/src/types.rs
@@ -301,12 +301,30 @@ pub struct Memory {
 }
 
 impl Memory {
-    /// Create a new memory with a random UUID.
-    pub fn new(name: MemoryName, content: String, metadata: MemoryMetadata) -> Self {
+    /// Create a new memory with a random UUID, validating the name.
+    pub fn new(
+        name: impl Into<String>,
+        content: impl Into<String>,
+        metadata: MemoryMetadata,
+    ) -> Result<Self, MemoryError> {
+        Ok(Self {
+            id: Uuid::new_v4().to_string(),
+            name: MemoryName::new(name)?,
+            content: content.into(),
+            metadata,
+        })
+    }
+
+    /// Create a new memory from an already-validated [`MemoryName`].
+    pub(crate) fn from_validated(
+        name: MemoryName,
+        content: impl Into<String>,
+        metadata: MemoryMetadata,
+    ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             name,
-            content,
+            content: content.into(),
             metadata,
         }
     }
@@ -824,11 +842,7 @@ mod tests {
     #[test]
     fn round_trip_global_scope() {
         let meta = MemoryMetadata::new(Scope::Global, vec!["global-tag".to_string()], None);
-        let mem = Memory::new(
-            MemoryName::new("global-mem").unwrap(),
-            "Some content.".to_string(),
-            meta,
-        );
+        let mem = Memory::new("global-mem", "Some content.", meta).unwrap();
         let rendered = mem.to_markdown().unwrap();
         let parsed = Memory::from_markdown(&rendered).unwrap();
 
@@ -840,11 +854,7 @@ mod tests {
     #[test]
     fn round_trip_no_source() {
         let meta = MemoryMetadata::new(Scope::Project("proj".to_string()), vec![], None);
-        let mem = Memory::new(
-            MemoryName::new("no-src").unwrap(),
-            "Body.".to_string(),
-            meta,
-        );
+        let mem = Memory::new("no-src", "Body.", meta).unwrap();
         let md = mem.to_markdown().unwrap();
         // source field should not appear in yaml
         assert!(!md.contains("source:"));

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -10,7 +10,7 @@ use memory_mcp::auth::AuthProvider;
 #[cfg(unix)]
 use memory_mcp::error::MemoryError;
 use memory_mcp::repo::MemoryRepo;
-use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, PullResult, Scope};
+use memory_mcp::types::{Memory, MemoryMetadata, PullResult, Scope};
 
 /// Full round-trip: init repo → save memory → read it back → list → delete → pull.
 ///
@@ -28,11 +28,7 @@ async fn repo_round_trip_with_test_auth_provider() {
 
     // Save a memory.
     let metadata = MemoryMetadata::new(Scope::Global, vec!["test".into()], None);
-    let memory = Memory::new(
-        MemoryName::new("test-memory").unwrap(),
-        "Hello from integration test.".into(),
-        metadata,
-    );
+    let memory = Memory::new("test-memory", "Hello from integration test.", metadata).unwrap();
     repo.save_memory(&memory)
         .await
         .expect("save should succeed");
@@ -91,11 +87,7 @@ async fn push_pull_with_bare_remote() {
 
     // Save a memory so there's something to push.
     let metadata = MemoryMetadata::new(Scope::Global, vec!["push-test".into()], None);
-    let memory = Memory::new(
-        MemoryName::new("push-memory").unwrap(),
-        "Content for push test.".into(),
-        metadata,
-    );
+    let memory = Memory::new("push-memory", "Content for push test.", metadata).unwrap();
     repo.save_memory(&memory)
         .await
         .expect("save should succeed");
@@ -241,11 +233,7 @@ async fn push_rejected_by_server_hook() {
     let auth = AuthProvider::with_token("ghp_fake_token");
 
     let metadata = MemoryMetadata::new(Scope::Global, vec!["rejected".into()], None);
-    let memory = Memory::new(
-        MemoryName::new("rejected-memory").unwrap(),
-        "This push should be rejected.".into(),
-        metadata,
-    );
+    let memory = Memory::new("rejected-memory", "This push should be rejected.", metadata).unwrap();
     repo.save_memory(&memory)
         .await
         .expect("save should succeed");

--- a/tests/scope_filter_integration.rs
+++ b/tests/scope_filter_integration.rs
@@ -20,11 +20,7 @@ async fn make_repo() -> (Arc<MemoryRepo>, tempfile::TempDir) {
 /// Helper: save a memory with the given scope and name.
 async fn save(repo: &Arc<MemoryRepo>, name: &str, scope: Scope) {
     let metadata = MemoryMetadata::new(scope, vec![], None);
-    let memory = Memory::new(
-        MemoryName::new(name).unwrap(),
-        format!("Content for {}", name),
-        metadata,
-    );
+    let memory = Memory::new(name, format!("Content for {}", name), metadata).unwrap();
     repo.save_memory(&memory)
         .await
         .expect("save should succeed");

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -716,7 +716,7 @@ fn debug_spans_are_filtered_when_only_info_enabled() {
 #[test]
 fn repo_save_span_has_name_and_oid_fields() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -735,11 +735,7 @@ fn repo_save_span_has_name_and_oid_fields() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new(
-                MemoryName::new("tc08-memory").unwrap(),
-                "test content".to_string(),
-                meta,
-            );
+            let mem = Memory::new("tc08-memory", "test content", meta).unwrap();
             repo.save_memory(&mem).await.expect("save");
         });
     });
@@ -772,7 +768,7 @@ fn repo_save_span_has_name_and_oid_fields() {
 #[test]
 fn repo_delete_span_has_name_and_oid_fields() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -791,11 +787,7 @@ fn repo_delete_span_has_name_and_oid_fields() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new(
-                MemoryName::new("tc08b-memory").unwrap(),
-                "test content".to_string(),
-                meta,
-            );
+            let mem = Memory::new("tc08b-memory", "test content", meta).unwrap();
             repo.save_memory(&mem).await.expect("save");
             repo.delete_memory("tc08b-memory", &Scope::Global)
                 .await
@@ -831,7 +823,7 @@ fn repo_delete_span_has_name_and_oid_fields() {
 #[test]
 fn repo_save_does_not_log_content_text() {
     use memory_mcp::repo::MemoryRepo;
-    use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, Scope};
+    use memory_mcp::types::{Memory, MemoryMetadata, Scope};
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().expect("tempdir");
@@ -851,11 +843,7 @@ fn repo_save_does_not_log_content_text() {
                 updated_at: chrono::Utc::now(),
                 source: None,
             };
-            let mem = Memory::new(
-                MemoryName::new("tc17-memory").unwrap(),
-                secret_content.to_string(),
-                meta,
-            );
+            let mem = Memory::new("tc17-memory", secret_content, meta).unwrap();
             repo.save_memory(&mem).await.expect("save");
         });
     });


### PR DESCRIPTION
## Summary

- `Memory::new` now takes `impl Into<String>` for the name and validates internally, returning `Result<Self, MemoryError>`
- Add `Memory::from_validated(MemoryName, ...)` as a `pub(crate)` constructor for internal code that already holds a validated name
- Simplifies external callers: `Memory::new("name", content, meta)?` instead of `Memory::new(MemoryName::new("name")?, content, meta)`

Part of the TMFDYUT pass. `MemoryName` stays public — the ergonomic win is at the `Memory` construction site, not by hiding the type.

## Test plan

- [x] All lib tests pass (128)
- [x] All integration tests pass (scope_filter, repo_round_trip, readyz, allowed_hosts, auth)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)