### PR TITLE
feat: recall event log with SQLite backend and recall_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [0.13.0] - 2026-05-25
+
+### Added
+- `MemoryName` newtype: validated memory name with `FromStr`, `Deserialize`, `JsonSchema` — construction is the sole validation path (#224)
+- `MemoryRef` newtype pairing `Scope` + `MemoryName` with `qualified_path()` method (#228)
+- `RecallLog`: SQLite-backed append-only event log for recall threshold calibration (#213)
+- `recall_id` field in recall responses for correlating results with telemetry
+- SIGTERM handler for graceful shutdown alongside existing SIGINT (Ctrl+C) (#195)
+
+### Changed
+- `Memory.name` changed from `String` to `MemoryName` (**breaking**) (#224)
+- `Memory::new()` now takes `impl Into<String>` for name and content, validates internally, returns `Result<Self, MemoryError>` (#230)
+- `Memory::from_validated()` added as `pub(crate)` constructor for pre-validated names
+- `AppState::new()` gains `recall_log: Option<RecallLog>` parameter (**breaking**)
+- `parse_qualified_name()` returns `MemoryRef` instead of `(Scope, MemoryName)` tuple
+
+### Fixed
+- Auth tests isolated from system keyring backends (`DBUS_SESSION_BUS_ADDRESS`, `DISPLAY`) (#225)
+- Flaky subprocess integration tests converted to in-process tower oneshot tests (#227)
+
+### Dependencies
+- Added `rusqlite` 0.34 (bundled) for recall event logging
+
 ## [0.12.1] - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1371,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1909,6 +1930,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2104,7 @@ dependencies = [
  "portpicker",
  "reqwest",
  "rmcp",
+ "rusqlite",
  "secrecy",
  "serde",
  "serde_json",
@@ -3004,6 +3037,20 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"
@@ -50,6 +50,7 @@ dirs = "6"
 mcp-session = "0.2"
 http = "1"
 arc-swap = "1"
+rusqlite = { version = "0.34", features = ["bundled"] }
 
 # Candle direct — pure-Rust BERT inference for embeddings.
 candle-core = "0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub(crate) mod fs_util;
 pub mod health;
 /// HNSW vector index for approximate nearest-neighbour search.
 pub mod index;
+/// Append-only SQLite event log for recall telemetry and threshold calibration.
+pub mod recall_log;
 /// Git-backed memory repository — read, write, sync, and diff operations.
 pub mod repo;
 /// MCP server implementation — tool handlers for the memory protocol.

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use memory_mcp::auth::{self, AuthProvider, StoreBackend};
 use memory_mcp::embedding::{CandleEmbeddingEngine, EmbeddingBackend, MODEL_ID};
 use memory_mcp::health::{healthz_handler, readyz_handler, version_handler, HealthRegistry};
 use memory_mcp::index::{UsearchStore, VectorStore};
+use memory_mcp::recall_log::RecallLog;
 use memory_mcp::repo::MemoryRepo;
 use memory_mcp::server::MemoryServer;
 use memory_mcp::types::{validate_branch_name, AppState};
@@ -564,6 +565,18 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         health.vector_index.report_ok();
     }
 
+    let recall_log_path = index_dir.join("recall_log.sqlite");
+    let recall_log = match RecallLog::open(&recall_log_path) {
+        Ok(log) => {
+            info!("recall log opened at {}", recall_log_path.display());
+            Some(log)
+        }
+        Err(e) => {
+            warn!(error = %e, "failed to open recall log — recall events will not be logged");
+            None
+        }
+    };
+
     let state = Arc::new(AppState::new(
         repo,
         args.branch.clone(),
@@ -571,6 +584,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         index,
         auth,
         health,
+        recall_log,
     ));
 
     // Keep a reference for post-shutdown index persistence.

--- a/src/recall_log.rs
+++ b/src/recall_log.rs
@@ -1,0 +1,162 @@
+use rusqlite::Connection;
+use std::{path::Path, sync::Mutex};
+
+use crate::error::MemoryError;
+
+/// Append-only SQLite log of recall events for threshold calibration.
+pub struct RecallLog {
+    conn: Mutex<Connection>,
+}
+
+impl RecallLog {
+    /// Open (or create) the recall log database at the given path.
+    pub fn open(path: &Path) -> Result<Self, MemoryError> {
+        let conn = Connection::open(path)
+            .map_err(|e| MemoryError::Internal(format!("recall log open: {e}")))?;
+        conn.execute_batch(
+            "
+            PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = NORMAL;
+            CREATE TABLE IF NOT EXISTS recall_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                recall_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                memory_name TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                rank INTEGER NOT NULL,
+                distance REAL NOT NULL,
+                returned_at TEXT NOT NULL DEFAULT (datetime('now')),
+                was_read INTEGER NOT NULL DEFAULT 0,
+                was_applied INTEGER,
+                application_note TEXT,
+                confidence TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_recall_events_recall_id ON recall_events(recall_id);
+            CREATE INDEX IF NOT EXISTS idx_recall_events_memory ON recall_events(memory_name, scope);
+        ",
+        )
+        .map_err(|e| MemoryError::Internal(format!("recall log init: {e}")))?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Generate a unique recall_id for a batch of results.
+    pub fn generate_recall_id() -> String {
+        format!("r_{}", uuid::Uuid::new_v4().as_simple())
+    }
+
+    /// Log a batch of recall results.
+    pub fn log_results(
+        &self,
+        recall_id: &str,
+        session_id: &str,
+        results: &[RecallResult],
+    ) -> Result<(), MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| MemoryError::Internal("recall log mutex poisoned".to_string()))?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| MemoryError::Internal(format!("recall log tx: {e}")))?;
+        {
+            let mut stmt = tx
+                .prepare_cached(
+                    "INSERT INTO recall_events \
+                     (recall_id, session_id, memory_name, scope, rank, distance) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                )
+                .map_err(|e| MemoryError::Internal(format!("recall log prepare: {e}")))?;
+            for r in results {
+                stmt.execute(rusqlite::params![
+                    recall_id,
+                    session_id,
+                    r.memory_name,
+                    r.scope,
+                    r.rank,
+                    r.distance
+                ])
+                .map_err(|e| MemoryError::Internal(format!("recall log insert: {e}")))?;
+            }
+        }
+        tx.commit()
+            .map_err(|e| MemoryError::Internal(format!("recall log commit: {e}")))?;
+        Ok(())
+    }
+}
+
+/// A single recall result for logging purposes.
+pub struct RecallResult {
+    /// Name of the memory that was returned.
+    pub memory_name: String,
+    /// Scope of the memory (e.g. "global" or "project:foo").
+    pub scope: String,
+    /// Zero-based rank in the result set (lower is more relevant).
+    pub rank: usize,
+    /// Cosine distance from the query vector (lower is more similar).
+    pub distance: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn open_creates_table() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path).unwrap();
+        let conn = log.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM recall_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn log_results_inserts_rows() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path).unwrap();
+
+        let recall_id = RecallLog::generate_recall_id();
+        let results = vec![
+            RecallResult {
+                memory_name: "foo".to_string(),
+                scope: "global".to_string(),
+                rank: 0,
+                distance: 0.1,
+            },
+            RecallResult {
+                memory_name: "bar".to_string(),
+                scope: "project:myproj".to_string(),
+                rank: 1,
+                distance: 0.3,
+            },
+        ];
+
+        log.log_results(&recall_id, "test-session", &results)
+            .unwrap();
+
+        let conn = log.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM recall_events WHERE recall_id = ?1",
+                [&recall_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn generate_recall_id_unique() {
+        let id1 = RecallLog::generate_recall_id();
+        let id2 = RecallLog::generate_recall_id();
+        assert_ne!(id1, id2);
+        assert!(id1.starts_with("r_"));
+        assert!(id2.starts_with("r_"));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ use crate::{
     embedding::EmbeddingBackend,
     error::MemoryError,
     index::VectorStore,
+    recall_log::{RecallLog, RecallResult},
     repo::MemoryRepo,
     types::{
         parse_qualified_name, parse_scope, parse_scope_filter, AppState, ChangedMemories, EditArgs,
@@ -398,10 +399,12 @@ impl MemoryServer {
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         let session_id = extract_session_id(&parts);
+        let recall_id = RecallLog::generate_recall_id();
         // Note: query text is intentionally omitted from the span (R-17 privacy decision).
         let span = tracing::info_span!(
             "handler.recall",
             session_id = %session_id,
+            recall_id = %recall_id,
             scope = ?args.scope,
             limit = ?args.limit,
             count = tracing::field::Empty,
@@ -435,6 +438,7 @@ impl MemoryServer {
 
             let pre_filter_count = results.len();
             let mut results_vec = Vec::new();
+            let mut log_entries: Vec<RecallResult> = Vec::new();
             let mut skipped_errors: usize = 0;
 
             for (_key, qualified_name, distance) in results {
@@ -470,7 +474,15 @@ impl MemoryServer {
                     }
                 };
 
+                let rank = results_vec.len();
                 let (snippet, content_length, truncated) = build_snippet(&memory.content);
+
+                log_entries.push(RecallResult {
+                    memory_name: memory.name.to_string(),
+                    scope: memory.metadata.scope.to_string(),
+                    rank,
+                    distance,
+                });
 
                 results_vec.push(serde_json::json!({
                     "id": memory.id,
@@ -484,11 +496,18 @@ impl MemoryServer {
                 }));
             }
 
+            if let Some(ref log) = state.recall_log {
+                if let Err(e) = log.log_results(&recall_id, &session_id, &log_entries) {
+                    warn!(error = %e, "failed to write recall log entries");
+                }
+            }
+
             let count = results_vec.len();
             tracing::Span::current().record("count", count);
             info!(returned = count, skipped_errors, "recall complete");
 
             Ok(serde_json::json!({
+                "recall_id": recall_id,
                 "results": results_vec,
                 "count": count,
                 "limit": limit,

--- a/src/types.rs
+++ b/src/types.rs
@@ -721,6 +721,8 @@ pub struct AppState {
     pub branch: String,
     /// Passive health registry — subsystems report here, `/readyz` reads here.
     pub health: HealthRegistry,
+    /// Optional append-only recall event log for threshold calibration.
+    pub recall_log: Option<crate::recall_log::RecallLog>,
 }
 
 impl AppState {
@@ -732,6 +734,7 @@ impl AppState {
         index: Box<dyn VectorStore>,
         auth: AuthProvider,
         health: HealthRegistry,
+        recall_log: Option<crate::recall_log::RecallLog>,
     ) -> Self {
         Self {
             repo,
@@ -740,6 +743,7 @@ impl AppState {
             auth,
             branch,
             health,
+            recall_log,
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -57,6 +57,7 @@ pub fn build_stub_state(tmp: &tempfile::TempDir, health: HealthRegistry) -> Arc<
         Box::new(InMemoryStore::new(4)),
         AuthProvider::new(),
         health,
+        None,
     ))
 }
 


### PR DESCRIPTION
## Summary

- Add `rusqlite` dependency (bundled) for local SQLite storage
- New `RecallLog` module: append-only event log for recall threshold calibration
- Each recall response now includes a `recall_id` for correlation
- Recall results are logged to SQLite with session_id, rank, distance, scope, memory name
- Schema includes `was_read`, `was_applied`, `confidence` columns for future `mark_applied` tool (#213 follow-up)
- Logging is non-fatal — failures are warned, not propagated

First phase of #213. Follow-ups: `mark_applied` MCP tool, read-recall correlation, `recall-stats` CLI.

## Design decisions

- **SQLite only, no frontmatter** — single source of truth for telemetry data (confirmed with maintainer)
- **`Mutex<Connection>`** — rusqlite Connection is Send but not Sync; Mutex is the minimal wrapper
- **`Option<RecallLog>` in AppState** — tests pass `None`, prod initializes the real log
- **WAL mode + NORMAL sync** — good write perf for append-only workload

## Test plan

- [x] `open_creates_table` — DB and table created on first open
- [x] `log_results_inserts_rows` — batch insert verified via COUNT query
- [x] `generate_recall_id_unique` — UUIDs are unique and prefixed with `r_`
- [x] All 131 lib tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)