### PR TITLE
ci: use cross-compile artifact in docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,14 @@ jobs:
         with:
           key: ${{ matrix.target }}
           cache-bin: "false"
-      - run: cargo build --features k8s
+      - run: cargo build --release --features k8s
+      - name: Upload binary artifact
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: memory-mcp-linux-x86_64
+          path: target/release/memory-mcp
+          retention-days: 1
 
   # Verify the declared MSRV (Cargo.toml rust-version) still compiles.
   msrv:
@@ -143,6 +150,13 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download pre-built binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: memory-mcp-linux-x86_64
+          path: .ci-bin
+      - name: Prepare binary
+        run: chmod +x .ci-bin/memory-mcp
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -161,6 +175,7 @@ jobs:
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
+          file: Dockerfile.ci
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,27 @@
+# CI Dockerfile — uses a pre-built binary from the cross-compile job.
+# Skips the cargo build stage entirely, cutting build time to warmup + COPY.
+
+# Stage 1: Model download
+# Pre-download HuggingFace model weights so the runtime image ships warm.
+FROM debian:trixie-slim AS model
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libdbus-1-3 && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -u 1000 app
+COPY .ci-bin/memory-mcp /usr/local/bin/memory-mcp
+USER app
+ENV HF_HOME=/home/app/.cache/huggingface
+RUN /usr/local/bin/memory-mcp warmup
+
+# Stage 2: Runtime
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git libdbus-1-3 && rm -rf /var/lib/apt/lists/*
+RUN useradd -m -u 1000 memory-mcp
+COPY .ci-bin/memory-mcp /usr/local/bin/memory-mcp
+COPY --from=model --chown=memory-mcp:memory-mcp /home/app/.cache/huggingface /home/memory-mcp/.cache/huggingface
+USER memory-mcp
+WORKDIR /home/memory-mcp
+ENV MEMORY_MCP_BIND=0.0.0.0:8080
+ENV MEMORY_MCP_REPO_PATH=/data/repo
+ENV HF_HOME=/home/memory-mcp/.cache/huggingface
+EXPOSE 8080
+ENTRYPOINT ["memory-mcp"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary

- Cross-compile job now builds with `--release` (was debug)
- Linux x86_64 binary uploaded as a GitHub Actions artifact
- Docker build job downloads the pre-built binary instead of compiling from scratch
- New `Dockerfile.ci` skips the Rust builder stage entirely — just warmup + COPY
- Original `Dockerfile` preserved for local builds

Eliminates the redundant cargo compilation in the Docker build step. The binary is compiled once in cross-compile and reused.

Closes #233

## Expected impact

Docker build time drops from ~5-8 min (full `cargo build --release`) to ~1-2 min (model warmup + COPY).

## Test plan

- [x] `Dockerfile.ci` produces identical runtime image (same base, same user, same env vars)
- [x] Cross-compile uploads artifact only for linux target (macOS skipped via `if` condition)
- [x] `Dockerfile` unchanged — local builds still work
- [x] Artifact retention set to 1 day (ephemeral, no storage bloat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)