### PR TITLE
ci: parallelize test/clippy matrix, cache HF model, bump git2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ env:
   IMAGE: butterflyskies/memory-mcp
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,27 +37,74 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: "false"
-      - name: Install cargo-nextest
-        run: |
-          curl -fsSL "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.131/cargo-nextest-0.9.131-x86_64-unknown-linux-gnu.tar.gz" \
-            -o /tmp/cargo-nextest.tar.gz
-          echo "8e38b16299864c9f597c9a1e2caf25b7e8b598ffc659ec014c2c735a9befd8fa  /tmp/cargo-nextest.tar.gz" | sha256sum -c -
-          tar xzf /tmp/cargo-nextest.tar.gz -C /usr/local/bin
       - run: cargo fmt --check
-      - run: cargo clippy --workspace -- -D warnings
-      - run: cargo clippy --workspace --features k8s -- -D warnings
-      - run: cargo clippy --workspace --features otlp -- -D warnings
-      - run: cargo clippy --workspace --features native-certs -- -D warnings
-      - run: cargo clippy --workspace --all-features -- -D warnings
       - name: Verify no opentelemetry in default build
         run: |
           cargo tree 2>&1 | grep -i opentelemetry && \
             { echo "ERROR: opentelemetry appeared in default build tree" >&2; exit 1; } || \
             echo "OK: opentelemetry not present in default build"
-      - run: cargo nextest run --workspace --no-fail-fast
-      - run: cargo nextest run --workspace --no-fail-fast --features k8s
-      - run: cargo nextest run --workspace --no-fail-fast --features otlp
-      - run: cargo nextest run --workspace --no-fail-fast --all-features
+
+  clippy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - ""
+          - "--features k8s"
+          - "--features otlp"
+          - "--features native-certs"
+          - "--all-features"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: clippy-${{ matrix.features }}
+          cache-bin: "false"
+      - run: cargo clippy --workspace ${{ matrix.features }} -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - ""
+          - "--features k8s"
+          - "--features otlp"
+          - "--all-features"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: test-${{ matrix.features }}
+          cache-bin: "false"
+      - name: Cache HuggingFace model
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-model-${{ hashFiles('src/embedding.rs') }}
+      - name: Install cargo-nextest
+        run: |
+          curl -fsSL "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.136/cargo-nextest-0.9.136-x86_64-unknown-linux-gnu.tar.gz" \
+            -o /tmp/cargo-nextest.tar.gz
+          echo "a098eed56f2dd88c7fdca1e554a6b99fa1ffbd2a7a1c41b865700112981f6f52  /tmp/cargo-nextest.tar.gz" | sha256sum -c -
+          tar xzf /tmp/cargo-nextest.tar.gz -C /usr/local/bin
+      - run: cargo nextest run --workspace --no-fail-fast ${{ matrix.features }}
 
   # Catch cross-platform compilation failures before they reach the release pipeline.
   # Mirrors the release.yml publish-binaries matrix (minus Windows — see #42).
@@ -148,7 +195,7 @@ jobs:
 
   build:
     if: github.event_name != 'pull_request' || github.base_ref == 'main'
-    needs: [test, audit, semver-checks, cross-compile, msrv]
+    needs: [lint, clippy, test, audit, semver-checks, cross-compile, msrv]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,17 +1297,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags",
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -1908,9 +1905,7 @@ checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -1936,20 +1931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", 
 rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-git2 = "0.20"
+git2 = "0.21"
 usearch = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -92,7 +92,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 libz-sys = { version = "1", features = ["static"] }
 
 [dev-dependencies]
-git2 = "0.20"
+git2 = "0.21"
 portpicker = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }


### PR DESCRIPTION
## Summary

- **Matrix parallelization**: split monolithic `test` job into parallel matrix jobs
  - 5 clippy jobs (default, k8s, otlp, native-certs, all-features) — run simultaneously
  - 4 nextest jobs (default, k8s, otlp, all-features) — run simultaneously
  - `fmt --check` + otel tree check in a lightweight `lint` job
- **HuggingFace model cache**: `actions/cache` on `~/.cache/huggingface` keyed by `src/embedding.rs` hash — eliminates model download flakes and speeds up candle embedding tests
- **git2 0.20 → 0.21**: rolls in #223 (dependabot). Drops `libssh2-sys` transitive dep.

Closes #238. Supersedes #223.

## Expected impact

Wall-clock CI time drops from ~15min serial to ~7min parallel. HF model cache eliminates the `empty_batch_returns_empty` flake seen in #223's CI run.

## Test plan

- [x] `cargo nextest run --lib` passes (131 tests) with git2 0.21
- [x] All action SHAs pinned and verified
- [x] `build` job `needs:` updated to include new `lint` + `clippy` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)