### PR TITLE
chore: regenerate Cargo.lock after 0.13.0 publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"


### PR DESCRIPTION
Cargo.lock was stale after `cargo publish` updated it as a side effect during the v0.13.0 release. This regenerates it via `cargo update`.