### PR TITLE
fix: enable git2 https + vendored-openssl features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.13.2] - 2026-05-25
+
+### Fixed
+- git2 0.21 dropped `https` from default features, breaking HTTPS git operations in container deployments (`no TLS stream available`) (#244)
+- RecallLog `open()` now creates parent directories before opening the SQLite file
+
+### Dependencies
+- git2: enabled `https` + `vendored-openssl` features (required since git2 0.21)
+
 ## [0.13.1] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,9 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "url",
 ]
 
 [[package]]
@@ -1906,6 +1909,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -2057,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"
@@ -24,7 +24,7 @@ otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", 
 rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-git2 = "0.21"
+git2 = { version = "0.21", features = ["https", "vendored-openssl"] }
 usearch = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/recall_log.rs
+++ b/src/recall_log.rs
@@ -54,6 +54,10 @@ impl RecallLog {
     /// `busy_timeout` controls how long each connection will wait when the
     /// database is locked before returning an error.
     pub fn open(path: &Path, busy_timeout: Duration) -> Result<Self, MemoryError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| MemoryError::Internal(format!("recall log dir: {e}")))?;
+        }
         let conn = Connection::open(path)
             .map_err(|e| MemoryError::Internal(format!("recall log open: {e}")))?;
         conn.busy_timeout(busy_timeout)


### PR DESCRIPTION
## Summary

git2 0.21 removed `https` from default features (#239 bumped git2). This broke HTTPS git operations in the container deployment — `no TLS stream available` on startup pull.

Also fixes RecallLog `open()` to create parent directories before opening the SQLite file (found during the same deploy failure).

Closes #244

## Changes

- `git2 = { version = "0.21", features = ["https", "vendored-openssl"] }`
- `RecallLog::open()` calls `create_dir_all` on parent directory
- Version bump to 0.13.2

## Test plan

- [x] 141 lib tests pass
- [x] `cargo fmt --check` clean
- [x] Verified `cargo tree -p libgit2-sys -e features` now includes openssl-sys

🤖 Generated with [Claude Code](https://claude.com/claude-code)