### PR TITLE
docs: add mark_applied to server instructions for recall feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.13.3] - 2026-05-25
+
+### Changed
+- Server instructions now guide agents to call `mark_applied` after acting on recalled memories, closing the feedback loop for threshold calibration
+
 ## [0.13.2] - 2026-05-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1150,15 +1150,18 @@ impl ServerHandler for MemoryServer {
             "A semantic memory system for AI coding agents. Memories are stored as markdown files \
             in a git repository and indexed for semantic retrieval. Use `remember` to store, `recall` \
             to search, `read` to fetch a specific memory, `edit` to update, `forget` to delete, \
-            `list` to browse, `sync` to push/pull the remote, and `recall_stats` to inspect recall \
-            precision statistics bucketed by distance for threshold calibration.\n\n\
+            `list` to browse, and `sync` to push/pull the remote.\n\n\
             Scope convention: always pass scope='project:<basename-of-your-cwd>' when working within \
             a project. This returns project memories alongside global ones. Omitting scope defaults to \
             global-only for queries (recall, list) and targets a single memory for point operations \
             (remember, edit, read, forget). Use scope='all' to search across all projects.\n\n\
             IMPORTANT: Never store credentials, API keys, tokens, passwords, or other secrets in \
             memory content. Memories are stored as plaintext markdown files committed to a git \
-            repository and may be synced to a remote. Treat all memory content as public."
+            repository and may be synced to a remote. Treat all memory content as public.\n\n\
+            Recall feedback: after acting on recalled memories, call `mark_applied` for each result \
+            with your verdict ('applied', 'maybe', or 'not_applied'). Every recall response includes \
+            a `recall_id` — pass it back with each verdict. This bidirectional feedback calibrates \
+            recall thresholds. Use `recall_stats` to inspect precision by distance bucket."
                 .to_string(),
         )
     }


### PR DESCRIPTION
## Summary

Server instructions now explicitly guide agents to call `mark_applied` after acting on recalled memories. Without this, agents only discover `mark_applied` from the tool list — most won't call it unprompted.

### Before
> Use `remember` to store, `recall` to search, ... `recall_stats` to inspect recall precision statistics

### After
> ... Use `recall_stats` to inspect precision by distance bucket.
>
> Recall feedback: after acting on recalled memories, call `mark_applied` for each result with your verdict ('applied', 'maybe', or 'not_applied'). Every recall response includes a `recall_id` — pass it back with each verdict.

Version bump to 0.13.3.

## Test plan

- [x] 141 lib tests pass
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)