### PR TITLE
docs: metadata framework design + ADR backfill

### DIFF
--- a/docs/adr/0028-schema-driven-metadata-model.md
+++ b/docs/adr/0028-schema-driven-metadata-model.md
@@ -1,0 +1,23 @@
+# ADR-0028: Schema-driven extensible metadata model
+
+## Status
+Accepted
+
+## Context
+Memory-mcp's metadata is hardcoded: `MemoryMetadata` carries a fixed set of fields (tags, scope, source, timestamps), and adding a new field requires changes in 5+ locations (struct definition, two inline `Frontmatter` structs for ser/deser, tool args, server handlers). This makes the metadata model brittle and couples it to the YAML frontmatter serialization format.
+
+We need to add retention, classification, and deployment-specific custom fields. Different deployments (personal, team, enterprise) need different metadata schemas. External tools (Obsidian) consume the frontmatter directly.
+
+## Decision
+Split metadata into three tiers:
+- **Core** (server-managed, always present): id, name, scope, created_at, updated_at
+- **Standard** (well-known, optional): tags, source, retention, classification
+- **Custom** (deployment-defined): arbitrary fields validated against a deployment schema config
+
+Custom fields are stored in a `custom:` subsection of YAML frontmatter to prevent collision with core/standard field names. The deployment config (TOML) defines valid custom field names, types, required/optional status, and defaults. Schema validation runs on every write; defaults are applied on read for missing fields.
+
+## Consequences
+- Adding a new standard field is a code change; adding a custom field is a config change
+- Backward compatible: existing memories without new fields load with defaults
+- Schema validation adds a code path to every write operation
+- Custom fields are intentionally flat (string, number, bool, list) — no nested objects

--- a/docs/adr/0029-scope-as-namespace.md
+++ b/docs/adr/0029-scope-as-namespace.md
@@ -1,0 +1,24 @@
+# ADR-0029: Scope as pure namespace, access as policy
+
+## Status
+Accepted
+
+## Context
+The current `Scope` enum (`Global`, `Project(String)`) conflates two concerns: where a memory is organized (namespace) and who can access it. `Project("foo")` means both "lives in foo" and "only visible when querying foo." This can't express hierarchies, and access control is implicit in the namespace rather than explicit in policy.
+
+Users already work around this with naming conventions (e.g. `project:person-<name>` as a pseudo-namespace).
+
+## Decision
+Replace the scope enum with a path-based namespace model:
+- `Scope::Root` (was `Global`) — the `/` namespace
+- `Scope::Path(String)` — hierarchical, e.g. `org/team/project`
+
+Backward compatibility: `"global"` parses to `Root`, `"project:foo"` parses to `Path("foo")`.
+
+Scope is purely organizational — it determines where the memory lives (directory structure in git, namespace in queries). Access control is a separate policy-layer concern that references scope, classification, and identity. `ScopeFilter` gains subtree matching: querying `engineering` matches `engineering/ml` and `engineering/infra`.
+
+## Consequences
+- Scope paths validated against traversal attacks (`..`, absolute paths) at both write and read time
+- On-disk directory structure follows namespace path
+- Access control deferred to policy engine (#115) rather than being baked into scope
+- Subtree queries enable hierarchical organization without breaking flat usage

--- a/docs/adr/0030-memory-serializer-trait.md
+++ b/docs/adr/0030-memory-serializer-trait.md
@@ -1,0 +1,29 @@
+# ADR-0030: MemorySerializer trait separating model from format
+
+## Status
+Accepted
+
+## Context
+The metadata model is currently fused with its serialization format. `Memory::to_markdown()` and `Memory::from_markdown()` contain hardcoded `Frontmatter` structs that define both the logical fields and their YAML representation. This means:
+- A database backend would need entirely different code despite storing the same logical data
+- The YAML format can't evolve independently of the data model
+- Obsidian compatibility is tangled with business logic
+
+## Decision
+Extract a `MemorySerializer` trait:
+```rust
+trait MemorySerializer {
+    fn serialize(&self, memory: &Memory) -> Result<Vec<u8>>;
+    fn deserialize(&self, bytes: &[u8]) -> Result<Memory>;
+}
+```
+
+`YamlFrontmatterSerializer` is the current (and only) implementation. The existing `to_markdown()`/`from_markdown()` methods become thin wrappers. Future backends (JSON for databases, alternative frontmatter formats) implement the same trait.
+
+The serializer is responsible for structural safety: custom field values are always double-quoted YAML scalars regardless of content (defense against YAML injection).
+
+## Consequences
+- One indirection layer between storage and model
+- Serializer owns format-specific safety (quoting, escaping) — not the caller's responsibility
+- Obsidian compatibility becomes a serializer concern, not a model concern
+- Future database backends slot in without touching the domain layer

--- a/docs/adr/0031-retention-metadata.md
+++ b/docs/adr/0031-retention-metadata.md
@@ -1,0 +1,23 @@
+# ADR-0031: Write-time retention metadata with split enforcement
+
+## Status
+Accepted
+
+## Context
+Memories accumulate forever. A session handoff and a persona definition are stored identically — both persist until manually deleted. The context for making retention decisions is richest at creation time and degrades across sessions and compactions. There is no mechanism to express at write time that a memory should expire.
+
+## Decision
+Retention is a standard metadata field set at write time with three variants:
+- **TTL** (`{ type: ttl, duration: 7d }`) — server computes `expires_at` from `created_at + duration` and mechanically excludes expired memories from results
+- **Condition** (`{ type: condition, expr: "PR #247 merged" }`) — server stores the condition as opaque metadata; the agent evaluates it at read time and calls `forget` when met
+- **Evergreen** (`{ type: evergreen }`) — explicit marker that the memory should never auto-expire
+
+Memories without retention metadata inherit the deployment's default (configured in TOML). The retention reaper evaluates against deployment config defaults, not frontmatter alone — if frontmatter is more permissive than policy, policy wins.
+
+Cleanup is lazy: TTL-expired memories are filtered at query time and eventually deleted by a background or on-access reaper. No big-bang sweep.
+
+## Consequences
+- Server handles TTL mechanically; agents handle conditions — clean split of responsibility
+- Deployment policy can override per-memory retention (prevents evergreen abuse)
+- External tools that edit retention frontmatter during server downtime are subject to policy override on next startup
+- Condition expressions are opaque strings — no server-side evaluation, no expression language to maintain

--- a/docs/adr/0032-user-defined-classification.md
+++ b/docs/adr/0032-user-defined-classification.md
@@ -1,0 +1,24 @@
+# ADR-0032: User-defined classification labels with policy-driven enforcement
+
+## Status
+Accepted
+
+## Context
+Memories have no sensitivity level. A private DM summary and a public architecture note look identical in the store. Privacy enforcement depends on the agent remembering provenance, which fails across sessions. Different deployments need different classification taxonomies (enterprise: public/internal/confidential/restricted; personal: public/group/private).
+
+## Decision
+Each memory has exactly one classification label (single-valued, not multi-label). Multi-label classification was rejected because it blurs sensitivity levels into taxonomy — one effective classification wins. The deployment config defines the valid label set with explicit rank ordering and a default. The server:
+- Validates the label against the config on write (rejects unknown labels)
+- Applies the default when no classification is specified
+- Returns classification in all read/recall/list responses
+- Supports optional classification-based filtering in recall (comparing rank)
+
+Classification has no hardcoded semantics — the server doesn't know what "confidential" means, only that it has rank 30. Policy enforcement (who can recall what) is a configurable layer that maps classification + namespace + identity to allow/deny decisions. Without the auth framework (#115), classification is retrieval control and operator guidance, not security isolation.
+
+Classification downgrades (e.g. confidential → public) are treated as sensitive operations: audit log entry must be durably written before the git commit.
+
+## Consequences
+- No hardcoded tiers — deployments define their own taxonomy
+- Classification is metadata, not access control (until #115 ships the policy engine)
+- Labels provide no filesystem-level protection — repo ACLs are a separate concern
+- Downgrade audit is a pre-write gate, not a post-write side effect

--- a/docs/adr/0033-newtype-validation-at-construction.md
+++ b/docs/adr/0033-newtype-validation-at-construction.md
@@ -1,0 +1,30 @@
+# ADR-0033: Newtype validation at construction, not at call sites
+
+## Status
+Accepted
+
+## Context
+Domain identifiers like memory names and scope+name pairs were passed as bare `String` and
+`(Scope, String)` tuples throughout the codebase. Validation happened at every function
+boundary via scattered `validate_name()` calls — 8+ in server.rs and repo.rs. This meant:
+- Forgetting a validation call was a silent bug
+- Internal code couldn't assume a name was already valid
+- Refactoring required auditing every call site
+
+## Decision
+Introduce validated newtypes (`MemoryName`, `MemoryRef`) that enforce invariants at
+construction. Once you hold a `MemoryName`, it is guaranteed valid — no re-checking needed.
+JSON deserialization still accepts `String` at the API boundary; conversion to `MemoryName`
+happens once in the handler. `MemoryRef` pairs a `Scope` with a `MemoryName` and provides
+`qualified_path()`, replacing ad-hoc `format!()` calls.
+
+This is part of a deliberate "TMFDYUT" (newtypes) pass across the codebase.
+
+## Consequences
+- Validation is impossible to skip — the type system enforces it
+- Internal functions accept newtypes, eliminating redundant checks
+- API boundary unchanged — serde still deserializes strings, conversion is explicit
+- `from_validated()` constructors allow `pub(crate)` fast paths where validity is known
+
+## References
+- #224 (MemoryName), #228 (MemoryRef)

--- a/docs/adr/0034-sqlite-recall-event-log.md
+++ b/docs/adr/0034-sqlite-recall-event-log.md
@@ -1,0 +1,31 @@
+# ADR-0034: SQLite recall event log for threshold calibration
+
+## Status
+Accepted
+
+## Context
+Recall returns results ranked by vector distance, but there is no empirical data on which
+distance thresholds produce useful results. Agents guess at cutoffs (e.g. "ignore above 0.42")
+with no feedback loop. Without ground truth on recall quality, the system cannot self-calibrate.
+
+## Decision
+Add a local SQLite database (via `rusqlite`, bundled) as an append-only event log for recall
+operations. Each recall result is logged with session_id, rank, distance, scope, and memory
+name. A `recall_id` (UUID prefixed with `r_`) is returned in every recall response for
+correlation. Schema includes `was_read`, `was_applied`, and `confidence` columns for the
+feedback loop (populated by `mark_applied` and read-recall correlation).
+
+Design choices:
+- **SQLite only** — single source of truth for telemetry; no frontmatter
+- **`Mutex<Connection>`** — rusqlite Connection is Send but not Sync; Mutex is minimal
+- **`Option<RecallLog>` in AppState** — tests pass `None`, prod initializes the real log
+- **WAL mode + NORMAL sync** — good write throughput for append-only workload
+- **Non-fatal logging** — failures are warned, never propagated to the caller
+
+## Consequences
+- New `rusqlite` dependency (bundled SQLite, no system library required)
+- Recall responses grow by one field (`recall_id`) — clients that ignore it are unaffected
+- Telemetry data is local-only and not synced via git (unlike memories)
+
+## References
+- #231

--- a/docs/adr/0035-recall-feedback-loop.md
+++ b/docs/adr/0035-recall-feedback-loop.md
@@ -1,0 +1,35 @@
+# ADR-0035: Recall feedback loop via mark_applied and recall-stats
+
+## Status
+Accepted
+
+## Context
+ADR-0034 introduced the recall event log with columns for feedback data, but no mechanism
+for agents to report whether recalled memories were actually useful. Without a closed loop,
+the telemetry data cannot drive threshold calibration.
+
+## Decision
+Three feedback mechanisms, layered:
+
+1. **`mark_applied` MCP tool** — agents explicitly report which recalled memories influenced
+   their session, with a confidence level (`applied`, `maybe`, `not_applied`) and optional
+   note. Keyed by `recall_id` from the recall response.
+
+2. **Read-recall correlation** — when `read` is called for a memory that was recently recalled
+   in the same session, the handler auto-marks `was_read=1` on the recall event. Fire-and-forget,
+   non-blocking. This provides passive signal without requiring agent cooperation.
+
+3. **`recall-stats` CLI** — `memory-mcp recall-stats` prints precision-by-distance buckets,
+   showing what fraction of recalls at each distance range were actually applied. Enables
+   empirical threshold tuning.
+
+Server instructions explicitly guide agents to call `mark_applied` after acting on recalls.
+
+## Consequences
+- Agents that ignore `mark_applied` still contribute passive signal via read correlation
+- Distance threshold recommendations become data-driven rather than guesswork
+- `recall_stats` output is human-readable — no dashboard infrastructure needed
+- The feedback data stays local (SQLite) — no privacy concerns from syncing usage patterns
+
+## References
+- #240, #246

--- a/docs/adr/0036-in-process-tower-tests.md
+++ b/docs/adr/0036-in-process-tower-tests.md
@@ -1,0 +1,26 @@
+# ADR-0036: In-process tower tests over subprocess integration tests
+
+## Status
+Accepted
+
+## Context
+Integration tests in `tests/allowed_hosts.rs`, `tests/readyz.rs`, and `tests/auth.rs` spawned
+the full binary, allocated ports, and polled `/healthz` with a 10s timeout. These flaked on CI
+due to cold-start latency under parallel test load — test durations ranged from ~10s to
+intermittent 10s timeout failures.
+
+## Decision
+Replace subprocess integration tests with in-process tests using `tower::ServiceExt::oneshot()`
+and stub backends (`StubEmbeddingBackend`, `InMemoryStore`). Shared test infrastructure lives
+in `tests/common/mod.rs` (`build_stub_state()`, `build_test_router()`). Subprocess tests that
+verify clap argument parsing were converted to unit tests in `src/main.rs`.
+
+## Consequences
+- Test execution dropped from ~10s per test to ~18-26ms (500x faster)
+- No port allocation, no process spawning, no polling — deterministic execution
+- Stubs are explicit about what they fake — no hidden behavior from full server startup
+- Shared `tests/common/mod.rs` establishes a pattern for future integration tests
+- Subprocess tests are still appropriate when testing the binary's actual startup behavior
+
+## References
+- #227

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,3 +8,4 @@ Each component or feature gets its own subdirectory.
 | [Tracing Scaffold](tracing/) | #52 | 2 | 2026-04-23 | Approved |
 | [Phase 2 Quality](phase2-quality/) | #94, #145, #146, #164 | 2 | 2026-04-25 | Approved |
 | [Session Lifecycle](session-lifecycle/) | #114 | 2 | 2026-05-14 | Approved (threat model skipped) |
+| [Metadata Framework](metadata-framework/) | #107, #116, #119, #248 | 5 | 2026-05-25 | Approved |

--- a/docs/design/metadata-framework/architecture.md
+++ b/docs/design/metadata-framework/architecture.md
@@ -1,0 +1,349 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-25
+phase: 3
+-->
+
+# Architecture: Memory Metadata Framework
+
+This document captures the architecture of the memory-mcp metadata framework redesign through a set of Mermaid diagrams. Each diagram targets a distinct architectural concern: system boundaries, internal structure, data flow with trust zones, the metadata schema, and the key write path.
+
+---
+
+### System Context
+
+Memory-mcp sits at the center of a three-actor system: AI agents drive the primary read/write workload via MCP tools, admins shape behavior through deployment config, and external tools access the underlying git repository directly. The MCP server mediates all structured access, while the git repo serves as the shared persistence layer that external tooling can reach without going through the server.
+
+```mermaid
+C4Context
+    title System Context — memory-mcp
+
+    Person(agent, "AI Agent", "Calls MCP tools to remember, recall, and manage memories during task execution")
+    Person(admin, "Admin", "Deploys and configures the server via TOML config files")
+    Person_Ext(external, "External Tools", "Obsidian, scripts, CI — read/write markdown files in the git repo directly")
+
+    System(mcp, "memory-mcp", "Semantic memory server. Accepts MCP tool calls, validates metadata against schema, stores markdown+YAML in git, indexes embeddings for semantic search.")
+
+    SystemDb(git, "Git Repository", "Bare or working repo containing markdown memory files. Namespace maps to directory structure.")
+    SystemDb(vectors, "Vector Index", "Embedding store for semantic recall (sled or qdrant)")
+    SystemDb(recalllog, "Recall Log", "SQLite-backed telemetry for mark_applied feedback loop")
+
+    Rel(agent, mcp, "MCP tool calls (remember/recall/read/edit/forget/list/sync/mark_applied)", "stdio / SSE")
+    Rel(admin, mcp, "Deployment config", "TOML file on disk")
+    Rel(mcp, git, "Read/write markdown files", "git2 / libgit2")
+    Rel(mcp, vectors, "Upsert and query embeddings", "internal")
+    Rel(mcp, recalllog, "Write recall events and verdicts", "SQLite")
+    Rel(external, git, "Direct file access", "filesystem / git")
+```
+
+---
+
+### Component Diagram
+
+The server is organized into four layers: the MCP interface (tool handlers), the domain model (types and validation), the infrastructure adapters (serialization, storage, indexing), and the telemetry subsystem. Each component has a narrow interface; the schema validator and serialization adapter are the main extension points for the new metadata design.
+
+```mermaid
+graph TD
+    subgraph MCP_Interface["MCP Interface Layer"]
+        TH["Tool Handlers<br/>(server.rs)<br/>remember · recall · read · edit<br/>forget · list · sync<br/>mark_applied · recall_stats"]
+    end
+
+    subgraph Domain["Domain Layer"]
+        MM["Metadata Model<br/>(types.rs)<br/>Memory · MemoryMetadata<br/>Scope · Retention · Classification"]
+        SV["Schema Validator<br/>Validates writes against<br/>deployment config schema"]
+        RE["Retention Evaluator<br/>TTL filter (server-side)<br/>Condition passthrough (agent-side)"]
+        PE["Policy Engine<br/>(future stub)<br/>classification + namespace + identity → allow/deny"]
+    end
+
+    subgraph Infra["Infrastructure Layer"]
+        SL["Serialization Layer<br/>MemorySerializer trait<br/>YamlFrontmatterSerializer (current)<br/>JsonSerializer (future)"]
+        GR["Git Repository<br/>(repo.rs)<br/>Markdown files<br/>namespace → directory path"]
+        VI["Vector Index<br/>Embedding upsert + query<br/>semantic recall"]
+        DC["Deployment Config<br/>(config.toml)<br/>valid classifications<br/>default retention<br/>custom field schema"]
+    end
+
+    subgraph Telemetry["Telemetry"]
+        RL["Recall Log<br/>(recall_log.rs)<br/>SQLite: recall events + verdicts<br/>precision calibration"]
+    end
+
+    TH --> MM
+    TH --> SV
+    TH --> RE
+    TH --> PE
+    MM --> SL
+    SL --> GR
+    TH --> VI
+    SV --> DC
+    RE --> DC
+    PE --> DC
+    TH --> RL
+```
+
+---
+
+### Data Flow with Trust Boundaries
+
+Three trust zones are in play: the agent environment (untrusted input), the mcp server process (trusted execution), and the storage tier (trusted but externally writable). The critical boundary crossing is the agent→server interface, where all inputs are validated against the schema config before any write reaches storage. The git→external path is unmediated, so schema invariants on externally-written files are only enforced at read time.
+
+```mermaid
+flowchart LR
+    subgraph AgentZone["Agent Environment (untrusted)"]
+        A["AI Agent"]
+    end
+
+    subgraph ServerZone["MCP Server Process (trusted)"]
+        TH["Tool Handlers"]
+        SV["Schema Validator"]
+        RE["Retention Evaluator"]
+        SL["YamlFrontmatter\nSerializer"]
+        VI["Vector Index"]
+        RL["Recall Log"]
+    end
+
+    subgraph StorageZone["Storage Tier (trusted, externally writable)"]
+        GR["Git Repo\n(markdown files)"]
+        SQ["SQLite\n(recall log)"]
+        DC["Deployment Config\n(config.toml)"]
+    end
+
+    subgraph ExternalZone["External Tools (unmediated)"]
+        EX["Obsidian / scripts / CI"]
+    end
+
+    A -- "MCP tool call\n(stdio/SSE)" --> TH
+    TH -- "validate metadata" --> SV
+    SV -- "read schema" --> DC
+    TH -- "check retention" --> RE
+    RE -- "read defaults" --> DC
+    TH -- "serialize" --> SL
+    SL -- "write markdown" --> GR
+    TH -- "upsert embedding" --> VI
+    TH -- "log recall event" --> RL
+    RL --> SQ
+
+    GR -- "read at recall/read time\n(validate on ingest)" --> TH
+    EX -- "direct file r/w\n(no schema enforcement)" --> GR
+
+    style AgentZone fill:#fef3c7,stroke:#d97706
+    style ServerZone fill:#dbeafe,stroke:#2563eb
+    style StorageZone fill:#dcfce7,stroke:#16a34a
+    style ExternalZone fill:#fce7f3,stroke:#db2777
+```
+
+---
+
+### Data Schema
+
+The metadata model is organized around a central `Memory` entity that composes a `MemoryMetadata` record. Metadata splits cleanly into three tiers — core (server-managed), standard (well-known optional), and custom (deployment-defined) — with `Scope`, `Retention`, and `Classification` as first-class value types. `DeploymentConfig` is the compile-time-external schema that governs validation and defaults; it is referenced by the server at startup, not embedded in individual memory records.
+
+```mermaid
+erDiagram
+    MEMORY {
+        string id PK "nanoid, server-assigned"
+        string content "markdown body"
+    }
+
+    MEMORY_METADATA {
+        string memory_id FK
+        string name "human-readable identifier"
+        string scope_path "e.g. /, /foo, /org/team/proj"
+        datetime created_at "server-assigned"
+        datetime updated_at "server-assigned"
+        string[] tags "standard: optional"
+        string source "standard: optional origin hint"
+        string classification_label FK "standard: optional"
+        json custom_fields "custom: deployment-defined"
+    }
+
+    SCOPE {
+        string path PK "path-based namespace"
+        string directory_path "maps to git repo path"
+    }
+
+    RETENTION {
+        string variant "Ttl | Condition | Evergreen"
+        duration ttl_duration "present when variant=Ttl"
+        string condition_expr "present when variant=Condition"
+    }
+
+    CLASSIFICATION {
+        string label PK "deployment-defined label"
+        int rank "ordering for sensitivity comparison"
+        string description "human-readable"
+    }
+
+    CUSTOM_FIELD_DEF {
+        string name PK
+        string field_type "string | integer | bool | string_list | enum"
+        bool required
+        string default_value "optional"
+    }
+
+    DEPLOYMENT_CONFIG {
+        int schema_version "starts at 1"
+        string config_path "path to config.toml"
+        string default_retention "Retention variant"
+        string default_classification "label"
+    }
+
+    MEMORY ||--|| MEMORY_METADATA : "has"
+    MEMORY_METADATA }o--|| SCOPE : "scoped to"
+    MEMORY_METADATA ||--o| RETENTION : "has retention"
+    MEMORY_METADATA }o--o| CLASSIFICATION : "labeled with"
+    DEPLOYMENT_CONFIG ||--o{ CLASSIFICATION : "defines valid"
+    DEPLOYMENT_CONFIG ||--o{ CUSTOM_FIELD_DEF : "defines"
+    MEMORY_METADATA }o--o{ CUSTOM_FIELD_DEF : "values conform to"
+```
+
+---
+
+### Sequence: `remember` Tool Call
+
+The `remember` flow is the primary write path and exercises all new framework components in order: schema validation (including default injection), retention evaluation, serialization to YAML frontmatter, git commit, and embedding upsert. Schema validation is a hard gate — any unknown field or type mismatch returns an error before touching storage. Default injection runs only on validated records, filling in absent optional fields from the deployment config.
+
+```mermaid
+sequenceDiagram
+    actor Agent
+    participant TH as Tool Handler<br/>(server.rs)
+    participant SV as Schema Validator
+    participant RE as Retention Evaluator
+    participant DC as Deployment Config
+    participant SL as YamlFrontmatterSerializer
+    participant GR as Git Repository
+    participant VI as Vector Index
+
+    Agent->>TH: remember(name, content, scope?, tags?, retention?, classification?, custom?)
+
+    TH->>DC: load schema (cached)
+    DC-->>TH: CustomFieldDefs, valid_classifications, default_retention
+
+    TH->>SV: validate(metadata, schema)
+    note over SV: Check required custom fields present<br/>Check types match definitions<br/>Check classification is in valid set
+    alt validation failure
+        SV-->>TH: Err(ValidationError)
+        TH-->>Agent: error response
+    end
+    SV-->>TH: Ok(validated_metadata)
+
+    TH->>RE: apply_defaults(metadata, schema)
+    note over RE: Inject default_retention if absent<br/>Inject custom field defaults if absent
+    RE-->>TH: metadata_with_defaults
+
+    TH->>TH: assign id (nanoid), set created_at / updated_at
+
+    TH->>SL: serialize(Memory { id, content, metadata })
+    note over SL: Build YAML frontmatter<br/>core fields → top-level<br/>standard fields → top-level<br/>custom fields → custom: section
+    SL-->>TH: markdown_string
+
+    TH->>GR: write_file(scope_path/name.md, markdown_string)
+    GR->>GR: git add + git commit
+    GR-->>TH: Ok(commit_sha)
+
+    TH->>VI: upsert_embedding(id, content + name)
+    VI-->>TH: Ok
+
+    TH-->>Agent: MemoryRecord { id, name, scope, created_at }
+```
+
+---
+
+### Observability: OpenTelemetry Spans
+
+All new components emit OTel spans. This is table stakes — the existing tracing scaffold (see [tracing design](../tracing/)) established the pattern; the metadata framework extends it.
+
+#### Spans per component
+
+| Component | Span name | Key attributes | Emitted on |
+|-----------|-----------|----------------|------------|
+| Schema Validator | `schema.validate` | `field_count`, `custom_field_count`, `result` (ok/error), `error_reason` | `remember`, `edit` |
+| Retention Evaluator | `retention.evaluate` | `variant` (ttl/condition/evergreen), `result` (fresh/expired/passthrough), `memories_filtered` | `recall`, `read`, `list` |
+| MemorySerializer | `serialize` | `format` (yaml_frontmatter), `total_fields`, `custom_fields` | `remember`, `edit` |
+| MemorySerializer | `deserialize` | `format`, `had_unknown_fields`, `applied_defaults` | `read`, `recall`, `list`, startup ingest |
+| Ingest Validator | `ingest.validate` | `files_scanned`, `files_passed`, `files_skipped`, `skip_reasons` | startup, read |
+| Classification Filter | `classification.filter` | `filter_applied`, `memories_excluded`, `classification_level` | `recall` |
+| Audit Logger | `audit.write` | `operation`, `commit_sha`, `classification_change` (if any), `source` | `remember`, `edit`, `forget` |
+| Retention Reaper | `retention.reap` | `expired_count`, `deleted_count`, `errors` | background/lazy cleanup |
+
+#### Span hierarchy
+
+Tool handler spans (already exist) become parents:
+```
+remember (existing)
+  └── schema.validate
+  └── retention.evaluate (apply defaults)
+  └── serialize
+  └── repo.write (existing)
+  └── index.upsert (existing)
+  └── audit.write
+
+recall (existing)
+  └── index.query (existing)
+  └── deserialize (per result)
+  └── retention.evaluate (per result)
+  └── classification.filter
+```
+
+#### Error attributes
+
+All spans record `otel.status_code` = `ERROR` on failure with `error.type` and `error.message`. Schema validation errors include the specific field and constraint that failed. Ingest validation errors include the file path and parse error.
+
+---
+
+### Implementation Notes
+
+#### MemorySerializer: trait object, not generic
+
+The serializer is stored as `Arc<dyn MemorySerializer + Send + Sync>` for runtime backend selection. Not generic — we expect few implementations and runtime config determines the serializer.
+
+#### Re-embedding rules
+
+| Change | Re-embed? | Rationale |
+|--------|-----------|-----------|
+| Content modified | Yes | Content participates in embedding |
+| Name changed | Yes | Name participates in embedding text |
+| Scope/classification/retention changed | No | Metadata-only, not in embedding text |
+| Tags/source changed | No | Not included in embedding input |
+| Custom fields changed | No | Not included in embedding input |
+
+This must be enforced as a documented invariant and tested. Accidental re-embedding on metadata-only changes degrades recall quality silently.
+
+#### Defaults: virtual, not materialized
+
+When reading a memory that lacks retention, classification, or custom field values, the server returns the deployment defaults in the response but does **not** rewrite the frontmatter file. Materialization only occurs on explicit `edit`. This prevents silent file modification that would confuse external tools (Obsidian) and create noisy git diffs.
+
+#### Classification: single-label, ordered
+
+Each memory has exactly one classification label, not a list. The deployment config defines labels with explicit rank ordering. Recall filtering compares ranks: "exclude memories with rank above N." This avoids the multi-label taxonomy trap.
+
+```toml
+schema_version = 1
+
+[classification]
+default = "internal"
+
+[[classification.labels]]
+name = "public"
+rank = 10
+
+[[classification.labels]]
+name = "internal"
+rank = 20
+
+[[classification.labels]]
+name = "confidential"
+rank = 30
+
+[[classification.labels]]
+name = "restricted"
+rank = 40
+```
+
+#### Unknown field preservation (four-bucket model)
+
+On deserialization, frontmatter fields are classified into four buckets:
+1. **Core fields** — server-managed, always present
+2. **Standard fields** — well-known optional (tags, source, retention, classification)
+3. **Schema-known custom fields** — validated against deployment config
+4. **Unknown legacy fields** — preserved on round-trip but not accepted in new writes
+
+Bucket 4 enables backward compatibility: old memories with pre-framework fields are preserved, but new `remember` calls cannot introduce arbitrary unknown fields outside the `custom:` section.

--- a/docs/design/metadata-framework/problem.md
+++ b/docs/design/metadata-framework/problem.md
@@ -1,0 +1,131 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-25
+phase: 1
+-->
+
+# Problem Space: Memory Metadata Framework
+
+## Issues
+
+- [#107](https://github.com/butterflyskies/memory-mcp/issues/107) — Memory expiry: TTL and completion-triggered deletion
+- [#116](https://github.com/butterflyskies/memory-mcp/issues/116) — Memory scope isolation for multi-user deployments
+- [#119](https://github.com/butterflyskies/memory-mcp/issues/119) — Enterprise memory scope hierarchy
+- [#248](https://github.com/butterflyskies/memory-mcp/issues/248) — Information classification metadata
+- [#149](https://github.com/butterflyskies/memory-mcp/issues/149) — Memory metadata enrichment (last-accessed, access count, confidence)
+
+## What problem exists today?
+
+Memory-mcp's metadata model is flat and minimal. A memory carries: name, scope (`Global` or `Project(String)`), tags (freeform strings), source (optional string), timestamps, and content. This creates three concrete gaps:
+
+### 1. Scopes are rigid
+
+The scope model supports exactly two variants: `Global` and `Project(String)`. This can't express hierarchies (org > team > project > individual), and users already work around it with naming conventions (`project:person-<name>` is not a real scope type — it's a string that happens to look like one). The `ScopeFilter` enum (`GlobalOnly`, `ProjectAndGlobal`, `All`) further constrains query patterns.
+
+### 2. Memories have no lifespan
+
+Every memory is implicitly evergreen. A session handoff note and a persona definition are stored identically — both persist until manually deleted. There is no way to express at write time that a memory should expire after a duration, be deleted when a condition is met, or be explicitly marked as permanent. The context for making retention decisions is richest at creation time and degrades from there.
+
+### 3. Memories have no sensitivity level
+
+A summary of a private DM and a public architecture note are indistinguishable in the store. Privacy enforcement depends entirely on the agent remembering provenance across sessions and compactions — which it cannot reliably do. In multi-agent deployments, there is no mechanism to restrict which agents can recall which memories based on sensitivity.
+
+### Meta-problem: the metadata model is hardcoded
+
+Adding any new metadata field requires code changes in multiple locations:
+
+1. `MemoryMetadata` struct (types.rs:258)
+2. Inline `Frontmatter` struct in `to_markdown()` (types.rs:344)
+3. Inline `Frontmatter` struct in `from_markdown()` (types.rs:390)
+4. Tool argument structs (`RememberArgs`, `EditArgs`, etc.)
+5. Server handlers in server.rs
+6. Tool descriptions
+
+This makes the metadata model brittle and couples it to the serialization format (YAML frontmatter). A database backend would need entirely different serialization code despite storing the same logical metadata.
+
+## Who experiences this?
+
+| Actor | Pain |
+|-------|------|
+| **Agents** | Can't filter by sensitivity at recall time. Can't express retention intent at write time. Accumulate stale memories that pollute recall results. |
+| **Operators/admins** | Can't enforce classification policies. Can't audit sensitivity levels. Can't define org-specific metadata schemas. |
+| **External tool users** (Obsidian, scripts) | Want rich, well-structured frontmatter. Currently limited by whatever fields we hardcode. |
+| **Multi-agent deployments** | No mechanism to scope memory visibility by classification. |
+| **memory-mcp developers** | Adding a metadata field requires touching 5+ files. No extension path for deployment-specific fields. |
+
+## Inputs and outputs
+
+### At write time (`remember`, `edit`)
+
+**Current:** content, name, tags, scope, source
+**Proposed:** + retention policy, classification label(s), custom metadata fields per org schema
+
+### At read/recall time (`recall`, `read`, `list`)
+
+**Current:** query, scope filter, limit
+**Proposed:** + classification filter, retention evaluation (expired? condition met?), custom field filtering
+
+### Transformations
+
+- Server evaluates TTL-based retention mechanically — expired memories are excluded from results
+- Agent evaluates condition-based retention at read time — the server stores the condition as opaque metadata, the agent decides whether to call `forget`
+- Classification filtering can be server-enforced (if policy is configured) or agent-enforced (if policy is advisory)
+
+## Architecture layers (separation of concerns)
+
+The design must separate three layers that are currently fused:
+
+1. **Metadata model** (abstract) — the schema defining what fields a memory can carry, their types, and validation rules. Backend-agnostic.
+2. **Serialization format** — how the metadata is rendered for a specific storage backend. YAML frontmatter for git/markdown files, JSON columns for a database, etc.
+3. **Policy engine** — what the metadata *means* at runtime. Retention evaluation, classification filtering, scope access rules. Configurable per deployment.
+
+Currently layers 1 and 2 are fused: `MemoryMetadata` is both the data model AND the YAML frontmatter structure. Separating them enables:
+- Database backends without touching the model
+- Obsidian-compatible frontmatter as a serializer concern
+- Deployment-specific fields without code changes
+
+## Boundaries
+
+### In scope
+
+- Extensible metadata model with core + custom fields
+- Schema-driven validation (configurable per deployment)
+- Retention metadata: TTL, condition-based, evergreen
+- Classification metadata: user-defined labels with configurable policies
+- Scope model evolution toward richer namespacing
+- Migration strategy for existing memories (lazy, backward-compatible)
+- Separation of metadata model from serialization format
+
+### Out of scope (for now)
+
+- Authentication/authorization framework (#115) — classification informs access control but the auth layer is a separate feature
+- Full multi-tenant RBAC — we're evolving the scope model but not building tenant isolation
+- Tag-based filtering in recall (#148) — related but orthogonal
+- Database backends — we design for them but implement git/markdown only
+- Obsidian-specific fixes — the serializer should be clean enough, but dedicated Obsidian testing is deferred
+
+### Adjacent systems
+
+- **Git repository** (repo.rs) — on-disk format changes affect every consumer of the markdown files
+- **Vector index** — re-embedding needed if scope representation changes affect content
+- **Recall log / SQLite** (recall_log.rs) — may want to log classification/retention for analytics
+- **MCP tool interface** — API surface changes (tool args, descriptions, responses)
+- **External consumers** — any tool reading the git repo directly (Obsidian, scripts, other agents)
+
+## Success criteria
+
+1. Existing memories load and work without manual migration
+2. New memories can carry retention, classification, and custom metadata
+3. Server enforces TTL mechanically; agents evaluate conditions at read time
+4. Classification policies are configurable per deployment, not hardcoded
+5. Frontmatter remains valid YAML and compatible with Obsidian-style tools
+6. Adding a new metadata field does not require code changes to the server (schema-driven)
+7. The metadata model is independent of the serialization format
+
+## Failure modes
+
+- **Over-engineering:** building a generic metadata framework that's harder to use than hardcoded fields for the 90% case
+- **Migration pain:** existing memories break or require a big-bang migration
+- **Schema complexity:** operators need a PhD to configure their metadata schema
+- **Performance:** schema validation on every read/write adds latency to the hot path
+- **Obsidian incompatibility:** frontmatter changes break external tool consumers

--- a/docs/design/metadata-framework/requirements.md
+++ b/docs/design/metadata-framework/requirements.md
@@ -1,0 +1,200 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-25
+phase: 2
+-->
+
+# Requirements: Memory Metadata Framework
+
+## Use Cases
+
+### Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Agent** | AI agent using MCP tools to store, recall, and manage memories |
+| **Admin** | Human operator configuring the deployment (schema, policies, retention rules) |
+| **Server** | memory-mcp process enforcing policies mechanically |
+| **External tool** | Software reading the git repo directly (Obsidian, scripts, other agents) |
+
+### Normal Use Cases
+
+| ID | Actor | Use Case | Priority |
+|----|-------|----------|----------|
+| UC-01 | Agent | Store a memory with retention policy (TTL, condition, or evergreen) | Must |
+| UC-02 | Agent | Store a memory with classification label(s) | Must |
+| UC-03 | Agent | Store a memory with custom metadata fields defined by deployment schema | Should |
+| UC-04 | Agent | Recall memories with classification filter (exclude above a sensitivity level) | Should |
+| UC-05 | Agent | Read a memory and evaluate its retention condition, forget if met | Must |
+| UC-06 | Agent | Edit a memory's retention, classification, or custom metadata | Must |
+| UC-07 | Agent | Store a memory with a hierarchical namespace scope (e.g. `org/team/project`) | Must |
+| UC-08 | Agent | Recall memories across namespace subtrees (e.g. all of `engineering/*`) | Should |
+| UC-09 | Admin | Define a metadata schema for the deployment (required fields, valid classifications, field types) | Must |
+| UC-10 | Admin | Define retention policies per classification level (e.g. "confidential memories expire after 90 days") | Should |
+| UC-11 | Admin | Define access policies per namespace/classification combination | Should |
+| UC-12 | Admin | Set default values for classification and retention when not specified by agent | Must |
+| UC-13 | Server | Exclude TTL-expired memories from recall/read/list results | Must |
+| UC-14 | Server | Validate metadata against deployment schema on remember/edit | Must |
+| UC-15 | Server | Return retention and classification metadata in recall/read/list responses | Must |
+| UC-16 | External tool | Read memory files with well-formed YAML frontmatter containing all metadata | Must |
+| UC-17 | External tool | Navigate memories using frontmatter fields (tags, classification, scope) | Should |
+
+### Abuse Cases
+
+| ID | Actor | Abuse Case | Priority |
+|----|-------|------------|----------|
+| AC-01 | Agent | Store sensitive content with no classification, bypassing access controls | Must-mitigate |
+| AC-02 | Agent | Set retention to "evergreen" on ephemeral data to avoid cleanup | Should-mitigate |
+| AC-03 | Agent | Use custom metadata fields to inject malicious YAML that breaks frontmatter parsing | Must-mitigate |
+| AC-04 | Attacker | Read classified memories by querying a less-restricted namespace | Must-mitigate |
+| AC-05 | Attacker | Modify memory files on disk to escalate classification or remove retention | Should-mitigate |
+
+### Security Use Cases
+
+| ID | Actor | Use Case | Priority |
+|----|-------|----------|----------|
+| SC-01 | Server | Validate all metadata field values against schema before persisting | Must |
+| SC-02 | Server | Enforce classification-based filtering when access policy is configured | Must |
+| SC-03 | Server | Prevent namespace traversal (agent in `team-a/*` can't read `team-b/*` without policy) | Must |
+| SC-04 | Server | Sanitize custom metadata values to prevent YAML injection | Must |
+| SC-05 | Server | Log metadata changes (classification downgrades, retention overrides) for audit | Should |
+
+## Requirements
+
+### Metadata Model
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-01 | The metadata model shall define core fields (name, scope, timestamps, id) that are always present and server-managed | UC-15, UC-16 | Must |
+| R-02 | The metadata model shall define standard optional fields (tags, source, retention, classification) with well-known semantics | UC-01, UC-02, UC-05 | Must |
+| R-03 | The metadata model shall support custom fields defined by a deployment-level schema | UC-03, UC-09 | Must |
+| R-04 | The metadata model shall be independent of the serialization format (not coupled to YAML frontmatter) | Problem statement | Must |
+| R-05 | Custom field values shall be validated against the deployment schema on write operations | SC-01, AC-03 | Must |
+| R-06 | Unknown fields in existing memories (pre-migration) shall be preserved, not rejected | UC-16 | Must |
+
+### Namespace (Scope Evolution)
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-10 | Scopes shall support path-based namespaces (e.g. `org/team/project`) | UC-07 | Must |
+| R-11 | The existing `global` and `project:<name>` scope formats shall continue to parse and function, including the behavior that project-scoped recall includes global memories | Migration | Must |
+| R-12 | Recall/list shall support subtree queries (e.g. `engineering/*` matches `engineering/ml` and `engineering/infra`) | UC-08 | Should |
+| R-13 | Namespace paths shall be validated to prevent traversal attacks (no `..`, no absolute paths) | SC-03, AC-04 | Must |
+| R-14 | Scope shall be purely organizational (namespace) — access control is a policy layer concern, not a scope property. Namespaces organize recall; they are not a security boundary unless paired with policy enforcement and repository ACLs. | Problem statement | Must |
+
+### Retention
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-20 | Memories shall support a TTL-based retention policy (expires after a duration from creation) | UC-01, #107 | Must |
+| R-21 | Memories shall support condition-based retention (opaque string evaluated by the agent at read time) | UC-01, UC-05 | Must |
+| R-22 | Memories shall support an explicit "evergreen" retention marker indicating no automatic expiry | UC-01 | Must |
+| R-23 | Memories without retention metadata shall inherit the deployment's default retention policy | UC-12 | Must |
+| R-24 | The server shall exclude TTL-expired memories from recall, read, and list results (returning not-found, not an expired status) | UC-13, Review | Must |
+| R-25 | TTL-expired memories shall be eventually deleted from the git repo (lazy or background reaper) | UC-13 | Should |
+| R-26 | Condition-based retention shall be returned to the agent as metadata — the server stores but does not evaluate conditions. Server instructions shall nudge agents to evaluate conditions on read and call `forget` when met. | UC-05, Review | Must |
+| R-27 | `created_at` is server-managed and authoritative for TTL computation. External edits to `created_at` shall not extend TTL if a server-known record exists. | Review | Must |
+
+### Classification
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-30 | Each memory shall have exactly one classification label (single-valued, not multi-label) | UC-02, #248, Review | Must |
+| R-31 | Valid classification labels and their ordering (rank) shall be defined by the deployment schema, not hardcoded | UC-09, Review | Must |
+| R-32 | Memories without classification shall receive the deployment's default classification | UC-12, AC-01 | Must |
+| R-33 | Recall shall support an optional classification filter to exclude memories above a sensitivity rank | UC-04 | Should |
+| R-34 | Classification-based access policies shall be configurable per deployment (which agents/roles can recall which classifications) | UC-11, SC-02 | Should |
+| R-35 | Classification downgrades (e.g. confidential -> public) shall be logged for audit | SC-05 | Should |
+
+### Schema & Configuration
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-40 | Deployment configuration shall define: valid classification labels, default classification, default retention, custom field definitions | UC-09, UC-10, UC-12 | Must |
+| R-41 | Custom field definitions shall specify: field name, type (string, integer, bool, string list, enum — no float, no nested objects), required/optional, default value | UC-03, UC-09, Review | Must |
+| R-45 | Deployment config shall include a `schema_version` field (starting at 1) to support future migration | Review | Must |
+| R-42 | Schema validation shall run on `remember` and `edit` operations | SC-01 | Must |
+| R-43 | Schema changes shall not invalidate existing memories — new required fields must have defaults | Migration | Must |
+| R-44 | The schema configuration format shall be declarative (TOML, YAML, or similar) | UC-09 | Must |
+
+### Serialization
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-50 | The YAML frontmatter serializer shall render all metadata fields (core, standard, custom) | UC-16 | Must |
+| R-51 | Frontmatter shall remain valid YAML parseable by standard YAML libraries | UC-16 | Must |
+| R-52 | The serializer shall be a separate component from the metadata model (adapter pattern) | R-04 | Must |
+| R-53 | Custom metadata fields shall appear in a dedicated frontmatter section to avoid collision with core fields | AC-03, UC-17 | Should |
+| R-54 | The deserializer shall handle memories written before the metadata framework (backward compatibility) | R-06 | Must |
+
+### Migration
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-60 | Existing memories without retention/classification/custom metadata shall load without error | Migration | Must |
+| R-61 | Missing standard fields shall be populated with deployment defaults virtually at read time (response shows effective values, but frontmatter is not rewritten). Materialization only occurs on explicit `edit`. | UC-12, Review | Must |
+| R-62 | Agents and admins may enrich existing memories by editing metadata at any time | UC-06 | Must |
+| R-63 | A bulk migration tool is not required but may be provided as a convenience | Migration | Could |
+
+### Threat Model Requirements (from Phase 4)
+
+| ID | Requirement | Source | Priority |
+|----|-------------|--------|----------|
+| R-70 | The server shall record expected classification in git commit metadata and verify on read; mismatch logged as tamper event | T-01 | Should |
+| R-71 | Retention reaper shall evaluate against deployment config defaults, not frontmatter alone; deployment policy takes precedence over more-permissive frontmatter | T-02 | Must |
+| R-72 | Deserializer shall treat externally-written files as adversarial: catch YAML errors per-file, never halt namespace traversal, log and skip malformed files | T-03 | Must |
+| R-73 | Scope path validation (canonicalization, `..` rejection) shall run at both agent write time AND server read/ingest time independently | T-04, T-16 | Must |
+| R-74 | Audit log entries for write operations shall include the git commit SHA | T-05 | Must |
+| R-75 | Documentation shall state that classification labels provide no filesystem-level access control; deployments must apply repo ACLs independently | T-06 | Must |
+| R-76 | Server shall enforce configurable limits at ingest: max file size (default 1MB), max namespace depth (default 10 components) | T-07 | Should |
+| R-77 | Documentation shall state that external tool boundary has no policy enforcement; namespace isolation requires git-layer controls | T-08 | Must |
+| R-78 | YAML serializer shall always emit custom field string values as double-quoted scalars with proper escaping; block scalars and bare scalars forbidden for custom values | T-09, T-10 | Must |
+| R-79 | Schema loader shall reject custom field names that collide with core or standard field names; checked at server startup | T-11 | Must |
+| R-80 | Schema validation shall enforce max byte length on string fields (default 4096) and max element count on list fields (default 100); nested object types forbidden | T-12, T-13 | Must |
+| R-81 | Classification downgrade audit log writes shall be durable before git write commits; audit failure fails the operation. Audit rows shall include: operation intent, old classification, new classification, git commit SHA (nullable), outcome (started/committed/failed), and error if failed. | T-14, Review | Must |
+| R-82 | (Future) Policy engine shall return identical responses for "access denied" and "no results" to prevent namespace probing | T-15 | Could |
+| R-83 | Pending #115, server shall record agent-supplied source field in audit log for all writes; documented as non-cryptographic provenance | T-17 | Should |
+
+## ASVS Review
+
+| Category | Applicable? | Notes |
+|----------|-------------|-------|
+| V1: Architecture, design, threat modeling | Yes | Trust boundaries between agent/server, namespace isolation |
+| V4: Access control | Yes | Classification-based filtering, namespace access policies |
+| V5: Validation, sanitization, encoding | Yes | Schema validation, YAML injection prevention in custom fields |
+| V7: Error handling, logging | Yes | Audit logging for classification changes |
+| V8: Data protection | Yes | Classification is literally about data sensitivity |
+| V12: Files and resources | Yes | Frontmatter format, file naming, git repo integrity |
+| V2: Authentication | Deferred | Auth framework is #115, out of scope here |
+| V3: Session management | No | Not applicable — stateless MCP tools |
+| V6: Stored cryptography | No | No encryption at rest in current scope |
+| V9: Communication | No | Transport security is out of scope |
+| V10: Malicious code | No | Supply chain is out of scope |
+| V11: Business logic | Partial | Retention evaluation logic, but straightforward |
+| V13: API and web services | Partial | MCP tool interface changes |
+| V14: Configuration | Yes | Schema/policy configuration must be validated |
+
+## Security Requirements Traceability Matrix (SRTM)
+
+| Req ID | Requirement | Source UC | ASVS | Test Case |
+|--------|-------------|-----------|------|-----------|
+| R-05 | Custom field values validated against schema | SC-01, AC-03 | V5 | TC-01: invalid field value rejected |
+| R-06 | Unknown fields in pre-migration memories preserved | UC-16 | V12 | TC-02: legacy memory loads with unknown fields intact |
+| R-13 | Namespace traversal prevention | SC-03, AC-04 | V4 | TC-03: `../` in scope path rejected |
+| R-24 | TTL-expired memories excluded from results | UC-13 | V11 | TC-04: expired memory not returned by recall/read/list |
+| R-32 | Default classification applied when missing | AC-01 | V8 | TC-05: memory without classification gets default |
+| R-33 | Classification filter in recall | UC-04 | V4 | TC-06: recall with filter excludes higher-sensitivity memories |
+| R-34 | Classification-based access policies | SC-02 | V4 | TC-07: agent without clearance can't recall classified memory |
+| R-35 | Classification downgrade audit logging | SC-05 | V7 | TC-08: downgrade event appears in audit log |
+| R-43 | Schema changes don't invalidate existing memories | Migration | V14 | TC-09: adding required field with default doesn't break reads |
+| R-51 | Frontmatter is valid YAML | UC-16 | V12 | TC-10: all metadata fields round-trip through YAML parse |
+| R-53 | Custom fields in dedicated section | AC-03 | V5 | TC-11: custom field named "id" doesn't overwrite core field |
+| R-54 | Backward-compatible deserialization | R-06 | V12 | TC-12: pre-framework memory deserializes with defaults applied |
+| R-60 | Existing memories load without error | Migration | V12 | TC-13: full corpus of existing memories loads after upgrade |
+| R-72 | Adversarial YAML deserialization | T-03 | V5 | TC-14: malformed YAML in file doesn't halt namespace scan |
+| R-73 | Scope validation at ingest time | T-04, T-16 | V4 | TC-15: file with `../` in scope path rejected on read |
+| R-74 | Commit SHA in audit log | T-05 | V7 | TC-16: write operation audit entry contains commit SHA |
+| R-78 | Custom field YAML quoting | T-09 | V5 | TC-17: field value with YAML special chars round-trips safely |
+| R-79 | Custom field name collision rejection | T-11 | V5 | TC-18: schema with custom field named "id" rejected at startup |
+| R-80 | Field size limits | T-12 | V5 | TC-19: oversized string value rejected on write |
+| R-81 | Downgrade audit durability | T-14 | V7 | TC-20: classification downgrade with failed audit log returns error |

--- a/docs/design/metadata-framework/test-plan.md
+++ b/docs/design/metadata-framework/test-plan.md
@@ -1,0 +1,133 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-25
+phase: 5
+-->
+
+# Test Plan: Memory Metadata Framework
+
+Derived from the SRTM in [requirements.md](requirements.md). Tests are organized by concern area, with each test traceable to one or more requirements.
+
+## Unit Tests
+
+### Schema Validation
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-01 | R-05 | `remember` with invalid custom field value (wrong type, e.g. string where number expected) returns validation error | Yes |
+| TC-18 | R-79 | Schema config with custom field named `id` rejected at server startup with clear error message | Yes |
+| TC-19 | R-80 | `remember` with string custom field exceeding max byte length (default 4096) rejected | Yes |
+| TC-19b | R-80 | `remember` with list custom field exceeding max element count (default 100) rejected | Yes |
+| TC-19c | R-80 | Schema config with nested object type in custom field definition rejected at startup | Yes |
+
+### Scope / Namespace
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-03 | R-13 | `remember` with scope containing `../` rejected | Yes |
+| TC-03b | R-13 | `remember` with absolute path scope (`/etc/foo`) rejected | Yes |
+| TC-03c | R-13 | `remember` with scope containing null bytes rejected | Yes |
+| TC-21 | R-10 | `remember` with hierarchical scope `org/team/project` stores to correct directory path | Yes |
+| TC-22 | R-11 | Legacy scope `"global"` parses to `Scope::Root` | Yes |
+| TC-22b | R-11 | Legacy scope `"project:foo"` parses to `Scope::Path("foo")` | Yes |
+| TC-23 | R-12 | `recall` with subtree scope `engineering` matches memories in `engineering/ml` and `engineering/infra` | Yes |
+| TC-37 | R-11 | Legacy behavior: `recall` with `project:foo` scope still includes global memories (behavioral compat, not just parsing) | Yes |
+
+### Retention
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-04 | R-24 | TTL-expired memory excluded from `recall` results | Yes |
+| TC-04b | R-24 | TTL-expired memory excluded from `read` (returns not-found, not expired status) | Yes |
+| TC-04c | R-24 | TTL-expired memory excluded from `list` results | Yes |
+| TC-24 | R-20 | Memory with `retention: { type: ttl, duration: 7d }` computes correct `expires_at` from `created_at` | Yes |
+| TC-25 | R-21 | Memory with `retention: { type: condition, expr: "PR merged" }` returns condition in metadata on read | Yes |
+| TC-26 | R-22 | Memory with `retention: { type: evergreen }` never excluded by TTL filter | Yes |
+| TC-27 | R-23 | Memory without retention field gets deployment default applied at read time | Yes |
+| TC-28 | R-71 | Memory with frontmatter retention more permissive than deployment policy: deployment policy takes precedence | Yes |
+
+### Classification
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-05 | R-32 | Memory stored without classification gets deployment default label | Yes |
+| TC-06 | R-33 | `recall` with classification filter excludes memories with higher-sensitivity labels | Yes |
+| TC-29 | R-31 | `remember` with classification label not in deployment config rejected | Yes |
+| TC-30 | R-30 | Memory with multiple classification labels stores and retrieves correctly | Yes |
+
+### Serialization
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-10 | R-51 | All metadata fields (core, standard, custom) round-trip through YAML serialize/deserialize | Yes |
+| TC-11 | R-53 | Custom field values always appear under `custom:` section, never at top level | Yes |
+| TC-17 | R-78 | Custom field value containing `\n`, `:`, `---`, quotes serializes as double-quoted scalar and round-trips correctly | Yes |
+| TC-17b | R-78 | Custom field value containing YAML document separator `---` does not terminate frontmatter | Yes |
+| TC-31 | R-52 | `MemorySerializer` trait can be implemented independently (compile-time check: trait is object-safe or has clear bounds) | Yes |
+
+## Integration Tests
+
+### Migration / Backward Compatibility
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-02 | R-06 | Memory file with unknown frontmatter fields loads; unknown fields preserved in round-trip | Yes |
+| TC-09 | R-43 | Adding a required custom field with a default to the schema: existing memories without the field load with default applied | Yes |
+| TC-12 | R-54 | Pre-framework memory (no retention, no classification, no custom fields) deserializes with deployment defaults | Yes |
+| TC-13 | R-60 | Load the full existing memory corpus after upgrading — zero errors, all memories accessible | Yes |
+| TC-32 | R-61 | Read a pre-framework memory: response includes default retention and classification from deployment config | Yes |
+
+### Ingest Validation (External Tool Boundary)
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-14 | R-72 | Write a malformed YAML file directly to repo, then `list` the namespace: malformed file skipped, other memories returned, structured log emitted | Yes |
+| TC-15 | R-73 | Write a file with `../` in scope path directly to repo, then read: path rejected at ingest, logged | Yes |
+| TC-33 | R-76 | Write a file exceeding max size directly to repo, then `list`: oversized file skipped with log | Yes |
+| TC-34 | R-72 | Write a file with truncated YAML (missing closing `---`): deserializer handles gracefully | Yes |
+
+### Audit Logging
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-08 | R-35, R-81 | `edit` that downgrades classification: audit log entry written before git commit | Yes |
+| TC-16 | R-74 | `remember` operation: audit log entry contains git commit SHA | Yes |
+| TC-20 | R-81 | `edit` classification downgrade with simulated audit log failure: operation returns error, git repo unchanged | Yes |
+| TC-35 | R-83 | `remember` with source field: audit log entry contains the source value | Yes |
+
+### Access Policy (stub / future)
+
+| Test ID | Requirement | Description | Automated? |
+|---------|-------------|-------------|------------|
+| TC-07 | R-34 | With classification access policy configured: agent without clearance gets empty recall results for classified memories | Yes |
+| TC-36 | R-82 | (Future) Namespace probe: query for non-existent vs access-denied namespace returns identical responses | No (manual, deferred to policy engine) |
+
+## Test Fixtures
+
+### Required fixtures
+
+- **Pre-framework memory corpus**: a set of memory files in the old format (no retention, no classification, no custom fields, `scope: Global` and `scope: Project("foo")` format)
+- **Deployment config variants**: minimal (no custom fields), standard (retention + classification), full (custom fields with various types)
+- **Adversarial YAML files**: malformed frontmatter, oversized files, traversal paths, injection payloads
+- **Time-sensitive memories**: memories with TTL near expiry for retention filter tests (use test clock / mockable time)
+
+### Test environment
+
+- All tests use an in-memory git repo (existing test infrastructure)
+- Audit log tests use an in-memory SQLite database
+- Time-dependent tests use a mockable clock (inject `now()` function)
+- Schema validation tests load config from test-specific TOML files
+
+## Coverage Matrix
+
+| Concern | Requirements | Test Cases | Coverage |
+|---------|-------------|------------|----------|
+| Schema validation | R-05, R-79, R-80 | TC-01, TC-18, TC-19, TC-19b, TC-19c | Full |
+| Namespace/scope | R-10, R-11, R-12, R-13 | TC-03, TC-03b, TC-03c, TC-21, TC-22, TC-22b, TC-23 | Full |
+| Retention | R-20-R-26, R-71 | TC-04, TC-04b, TC-04c, TC-24-TC-28 | Full |
+| Classification | R-30-R-34 | TC-05, TC-06, TC-29, TC-30 | Full |
+| Serialization | R-50-R-54, R-78 | TC-10, TC-11, TC-17, TC-17b, TC-31 | Full |
+| Migration | R-06, R-43, R-54, R-60, R-61 | TC-02, TC-09, TC-12, TC-13, TC-32 | Full |
+| Ingest validation | R-72, R-73, R-76 | TC-14, TC-15, TC-33, TC-34 | Full |
+| Audit logging | R-35, R-74, R-81, R-83 | TC-08, TC-16, TC-20, TC-35 | Full |
+| Access policy | R-34, R-82 | TC-07, TC-36 | Partial (TC-36 deferred) |

--- a/docs/design/metadata-framework/threat-model.md
+++ b/docs/design/metadata-framework/threat-model.md
@@ -1,0 +1,153 @@
+<!-- design-meta
+status: approved
+last-updated: 2026-05-25
+phase: 4
+-->
+
+# Threat Model: Memory Metadata Framework (Lightweight)
+
+Focused STRIDE analysis on two key trust boundaries. Full systematic enumeration deferred — this is metadata infrastructure, not authentication.
+
+---
+
+## Scope
+
+This document analyzes two trust boundary crossings introduced by the metadata framework redesign. Out of scope: transport security (stdio/SSE), authentication and identity (#115), supply chain, and the vector index subsystem.
+
+**Actors:**
+
+| Actor | Trust level |
+|-------|-------------|
+| AI Agent | Untrusted — input is arbitrary |
+| MCP Server process | Trusted — controlled execution environment |
+| Git repo | Trusted at rest, but externally writable |
+| External tools (Obsidian, scripts, CI) | Unmediated — bypass server entirely |
+| Admin | Trusted — controls deployment config |
+
+---
+
+## Boundary 1: External Tools → Git Repo (unmediated)
+
+**Data flow:** External tools read and write markdown files directly to the git repo. No schema validation, no policy enforcement. The server encounters these files at recall/read time and must handle them gracefully.
+
+**Attack surface:** Filesystem + git. Any process with repo access can write arbitrary YAML frontmatter.
+
+### STRIDE Analysis
+
+| # | Category | Threat | Likelihood | Impact | Mitigation |
+|---|----------|--------|------------|--------|------------|
+| T-01 | **Tampering** | An attacker with repo access could modify a memory file's `classification` frontmatter field to downgrade sensitivity (e.g. `confidential → public`), causing the server to serve it to agents with lower clearance at next read. The server has no integrity check against the last-known classification. | Medium | High | Compute and persist a classification hash/signature on server-write; verify on server-read. Flag mismatch as a tamper event. See NEW-REQ-01. |
+| T-02 | **Tampering** | A malicious external write could replace `retention.variant: Ttl` (expires in 7d) with `retention.variant: Evergreen`, causing a memory that should have been deleted to persist indefinitely and pollute future recalls. | Medium | Medium | Server-side retention cannot be enforced for externally-written files. Mitigate by: (a) logging a warning when server reads a retention upgrade (TTL → Evergreen) on a file it previously committed with a stricter policy; (b) making the reaper re-validate retention against deployment defaults rather than trusting frontmatter values blindly. See NEW-REQ-02. |
+| T-03 | **Tampering** | An attacker could inject malformed or adversarial YAML into a memory file's body or frontmatter section, causing the server's YAML parser to crash, enter an error state, or misparse adjacent fields on ingest. (This is particularly relevant for `custom:` subsections with nested structures.) | Medium | Medium | The deserializer must treat externally-written files as untrusted: wrap YAML parse in a recoverable error boundary, never panic, log and skip malformed files rather than halting. Existing R-54 requires backward-compatible deserialization but doesn't address adversarial input. See NEW-REQ-03. |
+| T-04 | **Tampering** | A script or CI pipeline could write a memory file with a `scope_path` containing `../` or an absolute path component, which the server then resolves during a subtree query, potentially returning files outside the intended namespace or resolving to paths outside the repo. | Low | High | R-13 requires traversal prevention on agent-submitted scope values, but the same check must run at read/ingest time for externally-written files. Server must canonicalize and validate `scope_path` on every read, not only on write. See NEW-REQ-04. |
+| T-05 | **Repudiation** | External tools write directly to git without going through the MCP server, so no audit log entry is created. A classification downgrade or retention extension committed by a script is invisible to the server's audit trail. | High | Medium | Server cannot prevent this — git log is the only record. Mitigate by: (a) ensuring the audit log records the git `commit_sha` for every server-written memory (enabling diff-based detection of out-of-band changes); (b) documenting the gap explicitly. See NEW-REQ-05. |
+| T-06 | **Information Disclosure** | A misconfigured CI pipeline with read access to the repo could exfiltrate all memories regardless of their `classification` label, because classification is advisory metadata — the files are plaintext in the repo and there is no encryption at rest. | High | High | This is an architectural limitation acknowledged in requirements (V6: stored cryptography deferred). Mitigate by documenting clearly that classification labels are access-control hints enforced only through the MCP server path, not filesystem ACLs. Encryption at rest is a future requirement. See NEW-REQ-06 (documentation requirement). |
+| T-07 | **Denial of Service** | An external tool could write a very large number of files into the repo, or write extremely large files, causing the server's recall/list operations to time out or exhaust memory when scanning the namespace. | Low | Medium | Implement configurable limits: max file size on ingest (skip and log oversized files), max namespace depth traversal count. These complement but don't replace filesystem-level access controls. See NEW-REQ-07. |
+| T-08 | **Elevation of Privilege** | An external tool could write a memory into a namespace it shouldn't have access to (e.g. writing into `org/team-b/` from a CI pipeline scoped to `org/team-a/`). The server would then serve this memory to `team-b` agents on recall. | Medium | High | Namespace access policies (R-11, R-14) are enforced on the agent→server path, not at the git layer. This boundary has no policy enforcement. Mitigation requires either: (a) git-layer controls (branch protection, path-restricted tokens), or (b) the server treating any file not committed by its own service account as requiring re-validation against the namespace policy for the writing context. See NEW-REQ-08. |
+
+---
+
+## Boundary 2: Agent → Server (custom metadata fields)
+
+**Data flow:** The agent passes custom metadata field values as part of `remember` / `edit` tool calls. The server validates these against the deployment schema, then the serialization layer writes them into YAML frontmatter. Other tools (including Obsidian) later parse that frontmatter.
+
+**Attack surface:** The MCP tool call arguments. The agent is untrusted; its inputs may come from tool outputs, LLM generation, or user-provided content that has passed through an agent.
+
+### STRIDE Analysis
+
+| # | Category | Threat | Likelihood | Impact | Mitigation |
+|---|----------|--------|------------|--------|------------|
+| T-09 | **Tampering / YAML injection** | An agent passes a custom field value containing YAML special characters — newlines, colons, quote sequences, or block scalar markers — that break out of the scalar context in the rendered frontmatter. For example, a `description` field value of `"foo\nclassification: public"` could inject a second `classification` key into the frontmatter if the serializer doesn't properly quote the value. A downstream YAML parser (Obsidian, scripts) might then read the injected key instead of the legitimate one. | Medium | High | The serializer must always emit custom field scalar values as quoted strings (single or double), never bare scalars. Values containing characters that cannot be safely single-quoted must be double-quoted with proper escaping. This is a serializer implementation requirement, not just a schema validation requirement. AC-03 and R-53 address the namespace isolation (custom fields in a dedicated section) but don't specify quoting strategy. See NEW-REQ-09. |
+| T-10 | **Tampering / YAML injection** | An agent passes a custom field value that is a multi-line string containing `---` (YAML document separator). If the serializer emits it as a block scalar without careful handling, a downstream parser could interpret the separator as ending the frontmatter block prematurely, causing subsequent content to be treated as the memory body rather than frontmatter. | Low | Medium | Block scalars in frontmatter values must be forbidden or carefully escaped. The serializer should normalize multi-line values: either reject them (validation rule for string-typed fields) or fold them into a single line. See NEW-REQ-09 (same serializer hardening requirement). |
+| T-11 | **Tampering** | An agent passes a custom field named `id`, `created_at`, `updated_at`, or another core field name, attempting to overwrite a server-managed field via the custom namespace. If the serializer merges custom fields into the top-level frontmatter without a collision check, the injected value wins. | Medium | High | R-53 requires custom fields to appear in a dedicated `custom:` YAML subsection specifically to prevent this. This requirement must be enforced both at the schema definition level (custom field names must not collide with core/standard fields) and at serialization time (custom fields are always nested under `custom:`, never promoted). Confirm this is explicitly checked at schema load time, not assumed. See NEW-REQ-10. |
+| T-12 | **Denial of Service** | An agent passes an extremely large string value for a custom field (e.g. a base64-encoded blob as a "description"), causing the serialized frontmatter to grow to megabytes. This bloats the git commit, slows subsequent reads, and may exhaust memory in the YAML parser for any tool that opens the file. | Low | Medium | Schema validation must enforce a maximum byte length on string-typed custom field values. The limit should be configurable per field in `CustomFieldDef` with a safe default (e.g. 4 KB). See NEW-REQ-11. |
+| T-13 | **Denial of Service** | An agent passes a list-typed custom field with a very large number of elements, or a deeply nested structure that the schema's type system notionally supports but the serializer doesn't defend against. | Low | Low | Schema validation must enforce max-length on list-typed fields. Nested objects are not supported in `CustomFieldDef` (field types are flat: `string`, `number`, `bool`, `string[]`) — this should be enforced at schema load time to prevent future type creep from opening this vector. See NEW-REQ-11. |
+| T-14 | **Repudiation** | An agent downgrades a memory's classification from `confidential` to `public` via an `edit` call. R-35 says this should be logged, but if the audit log write fails (SQLite error, disk full), the downgrade is committed to git without any audit trail. | Low | High | Audit log writes for classification changes must be durably committed before the git write completes, or the operation must fail atomically. "Should" in R-35 should be promoted to "Must" for classification downgrades specifically. See NEW-REQ-12. |
+| T-15 | **Information Disclosure** | An agent crafts a `recall` query that uses scope path patterns to probe whether memories exist in namespaces it doesn't have access to (e.g. by observing whether a wildcard subtree query returns results vs. an empty set). Even if memory content is withheld, the presence/absence of a namespace can leak organizational structure. | Low | Low | Namespace probing via empty-result oracle is a low-severity information leak in most deployments. If namespace privacy is required, the policy engine (PE, stub in architecture) should return identical empty responses for both "no access" and "no results". This is a future policy engine concern; document the gap now. See NEW-REQ-13. |
+| T-16 | **Elevation of Privilege** | An agent supplies a `scope` value in `remember` or `edit` containing a `..` component or an absolute path (e.g. `/etc/`), attempting to write a file outside the repo's working directory. R-13 requires traversal prevention but this must also cover the serialization→git write path: the `scope_path → directory_path` mapping must canonicalize against the repo root and reject any path that escapes it. | Low | High | This is a defense-in-depth requirement: R-13 validates the scope value, and the git repository adapter must independently verify the resolved path is under the repo root before writing. Two independent checks, both must pass. This is already partially addressed by R-13 but deserves an explicit implementation requirement at the adapter layer. See NEW-REQ-04 (same requirement, both boundaries). |
+| T-17 | **Spoofing** | In a multi-agent deployment, Agent A cannot prove to the server that it is the same agent that wrote a memory. There is no per-agent identity at the MCP boundary (#115 deferred). An agent could read and re-write another agent's memory with a lower classification or different retention, impersonating the original writer. | Medium | High | This is a known gap pending #115 (auth framework). In the interim: the server should record the `source` field (agent-provided, not validated) in the audit log for all write operations. This provides weak provenance evidence. Document that without #115, classification and retention integrity rely on trust in the MCP client process, not cryptographic identity. See NEW-REQ-14. |
+
+---
+
+## Special Cases
+
+### Classification downgrade attacks
+
+Covered by T-01 (external write) and T-14 (agent edit). The shared mitigation: classification downgrades are a special write operation requiring (a) explicit operator acknowledgement in multi-agent deployments, (b) durable audit log entry before storage commit, and (c) ideally a tamper-evident record of the pre-downgrade label (commit hash is sufficient for git-backed storage).
+
+### Namespace traversal
+
+Covered by T-04 (external ingest path) and T-16 (agent write path). R-13 addresses the agent write path; NEW-REQ-04 extends this to the ingest path. Both the scope path validator and the git adapter must independently enforce the constraint — defense in depth is appropriate here because the consequences (file write outside repo) are severe.
+
+### YAML injection
+
+Covered by T-09 and T-10. The root cause is insufficient serializer hardening: schema validation alone is not sufficient because a valid string value can still contain YAML structural characters. The serializer must be the final line of defense and must always emit custom field values in a form that is structurally safe regardless of content.
+
+### Retention policy manipulation
+
+Covered by T-02 (external upgrade) and AC-02 from requirements (agent evergreen abuse). The server should not trust frontmatter retention values for externally-written files without comparison against deployment policy. An evergreen retention on a memory whose namespace has a 90-day policy maximum should trigger a warning or be overridden.
+
+---
+
+## New Requirements
+
+| ID | Requirement | Addresses | ASVS Category |
+|----|-------------|-----------|---------------|
+| NEW-REQ-01 | The server shall record the expected classification label in the git commit metadata (or a sidecar index) and verify it matches the frontmatter on read. Mismatch shall be logged as a tamper event and the memory shall be returned with a `tamper_suspected: true` flag. | T-01 | V12: Files and Resources |
+| NEW-REQ-02 | The retention reaper and recall filter shall evaluate retention policy against the deployment config defaults, not frontmatter alone. If a memory's frontmatter retention is more permissive than the deployment policy for its classification/namespace, the deployment policy takes precedence. | T-02 | V11: Business Logic |
+| NEW-REQ-03 | The memory deserializer shall treat all externally-written files as adversarial input: YAML parse errors must be caught and logged at the file level, must not propagate exceptions to the caller, and must not halt namespace traversal. Malformed files are skipped with a structured log entry. | T-03 | V5: Validation, Sanitization, Encoding |
+| NEW-REQ-04 | Scope path validation (canonicalization, `..` rejection, absolute path rejection) shall run at both (a) agent write time (schema validator) and (b) server read/ingest time (git adapter). These are independent checks. | T-04, T-16 | V4: Access Control |
+| NEW-REQ-05 | The server shall record the git commit SHA in all audit log entries for write operations. This enables detection of out-of-band changes by diffing the recorded SHA against the current commit for a file. | T-05 | V7: Error Handling and Logging |
+| NEW-REQ-06 | Documentation shall state explicitly that `classification` labels are enforced only through the MCP server path and provide no filesystem-level access control. Deployments storing sensitive memories must apply appropriate filesystem/repository ACLs independently. | T-06 | V8: Data Protection |
+| NEW-REQ-07 | The server shall apply configurable limits at ingest: max file size (default: 1 MB, skip and log files exceeding this) and max namespace depth (default: 10 path components, reject deeper paths). | T-07 | V12: Files and Resources |
+| NEW-REQ-08 | Documentation shall state that the external tool boundary has no policy enforcement and that namespace isolation for external tools requires git-layer access controls (e.g. path-restricted deploy tokens, repo ACLs). | T-08 | V4: Access Control |
+| NEW-REQ-09 | The YAML frontmatter serializer shall always emit custom field string values as quoted YAML scalars (double-quoted with proper escape sequences). Block scalars, bare scalars, and multi-line strings for custom field values are forbidden. The serializer must not rely on upstream validation to guarantee structural safety. | T-09, T-10 | V5: Validation, Sanitization, Encoding |
+| NEW-REQ-10 | The schema loader shall reject any `CustomFieldDef` whose name collides with a core field name (`id`, `name`, `scope`, `created_at`, `updated_at`) or a reserved standard field name (`tags`, `source`, `retention`, `classification`). This check runs at server startup, not at write time. | T-11 | V5: Validation, Sanitization, Encoding |
+| NEW-REQ-11 | Schema validation shall enforce a maximum byte length on string-typed custom field values (configurable, default: 4096 bytes) and a maximum element count on list-typed fields (configurable, default: 100). Nested object types shall not be permitted in `CustomFieldDef` — the type system is intentionally flat. | T-12, T-13 | V5: Validation, Sanitization, Encoding |
+| NEW-REQ-12 | Classification downgrade audit log writes shall be durable before the corresponding git write is committed. If the audit log write fails, the `edit` operation shall fail and return an error to the agent rather than committing the downgrade silently. This upgrades R-35 from "Should" to "Must" for downgrade operations specifically. | T-14 | V7: Error Handling and Logging |
+| NEW-REQ-13 | (Future / policy engine stub) When namespace access policy is configured, the server shall return identical empty-result responses for "access denied" and "no memories found" to prevent namespace probing via oracle. This applies to `recall`, `list`, and `read` operations. | T-15 | V4: Access Control |
+| NEW-REQ-14 | Pending #115 (auth framework), the server shall record the agent-supplied `source` field (or a configurable agent identity hint) in all audit log entries for write operations. This provides weak provenance evidence in multi-agent deployments and is explicitly documented as non-cryptographic. | T-17 | V7: Error Handling and Logging |
+
+---
+
+## Architectural Changes
+
+Two changes go beyond requirements and affect component boundaries:
+
+**1. Git adapter path canonicalization (defense in depth)**
+
+The git repository adapter (`repo.rs`) must independently validate that the resolved file path for any write or read operation falls within the repo root. This is separate from and in addition to the scope path validation in the schema validator. The rationale: the scope path validator operates on the logical namespace value; the git adapter operates on the physical filesystem path. A bug in the scope→path mapping (e.g. unexpected percent-encoding, Unicode normalization) could bypass scope validation but would be caught by a root-confinement check at the adapter.
+
+**2. Audit log as a pre-write gate for classification downgrades**
+
+The current architecture (sequence diagram) places audit logging as a post-write side effect. For classification downgrades specifically, the write order must change: audit log entry committed → git write committed. This requires the `remember`/`edit` tool handler to treat the audit log as a prerequisite, not a follower, for this class of operation. The architecture diagram's `TH → RL` edge should be annotated as "pre-write gate for classification changes."
+
+---
+
+## Implementation Detail: In-Memory Git Store
+
+The current implementation maintains the git repo in memory and overwrites the on-disk state on every mutation. This has significant implications for the external tools threat boundary:
+
+**While the server is running:** External writes to the on-disk repo are ephemeral — the next server mutation clobbers them from in-memory state. The external edit is silently lost. This **accidentally mitigates** T-01, T-02, T-04, and T-08 for the running-server case.
+
+**While the server is stopped:** External writes to the on-disk repo are durable — they are read into memory on the next server startup. This is the real attack window.
+
+**Implications for threat severity:**
+- T-01 through T-08 severity should be read as "during server downtime only" for write-based threats
+- Startup/ingest validation (NEW-REQ-03, NEW-REQ-04) becomes the critical defense point
+- The tamper detection mechanism (NEW-REQ-01) is most valuable at startup, comparing on-disk state against the last known good commit SHA
+- External tools like Obsidian have a read-only view while the server runs; their writes only persist if made during downtime
+
+This does NOT affect read-based threats (T-06: information disclosure via repo access) — those apply regardless of server state.
+
+---
+
+## Assumptions and Deferred Items
+
+| Item | Status |
+|------|--------|
+| Agent authentication and identity | Deferred to #115. Without it, all agent-provided identity claims (source, author) are advisory only. |
+| Encryption at rest for classified memories | Deferred. Classification labels are ACL hints, not encryption keys. |
+| Transport security (stdio, SSE) | Out of scope for this document. |
+| Vector index tamper resistance | Out of scope. The vector index is a cache; ground truth is the git repo. |
+| Supply chain (YAML parser vulnerabilities) | Out of scope. Pin dependency versions; monitor advisories. |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,4 +26,3 @@ pub mod repo;
 pub mod server;
 /// Domain types: memories, scopes, metadata, validation, and application state.
 pub mod types;
-// ci: trigger build after path-filter removal


### PR DESCRIPTION
## Summary

Full /design pass (Standard depth) for the memory metadata framework — covers scope evolution, retention, classification, and extensible schema-driven metadata.

### Design artifacts (`docs/design/metadata-framework/`)
- **problem.md** — problem space: rigid metadata, no lifespan, no sensitivity, hardcoded model
- **requirements.md** — 17 use cases, 47 requirements across 8 groups, SRTM with 20 test cases
- **architecture.md** — 6 decisions, 5 mermaid diagrams, OTel span definitions
- **threat-model.md** — lightweight STRIDE on 2 trust boundaries, 17 threats, 14 new requirements
- **test-plan.md** — 36 test cases with full coverage matrix

### Key architectural decisions (ADRs 0028-0032, Proposed)
- **0028** Schema-driven extensible metadata model (core/standard/custom tiers)
- **0029** Scope as pure namespace, access as policy
- **0030** MemorySerializer trait separating model from format
- **0031** Write-time retention with split enforcement (server TTL, agent conditions)
- **0032** User-defined classification labels with policy-driven enforcement

### ADR backfill (0033-0036, Accepted)
- **0033** Newtype validation at construction (MemoryName, MemoryRef)
- **0034** SQLite recall event log
- **0035** Recall feedback loop (mark_applied + recall_stats)
- **0036** In-process tower tests

### Issues covered
- #107 — Memory expiry (TTL + completion-triggered deletion)
- #116 — Memory scope isolation
- #119 — Enterprise scope hierarchy
- #248 — Information classification metadata
- #149 — Memory metadata enrichment