### PR TITLE
ci: revert docs-only path filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths:
-      - '**.rs'
-      - '**.toml'
-      - 'Cargo.lock'
-      - 'Dockerfile*'
-      - '.github/**'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,4 @@ pub mod repo;
 pub mod server;
 /// Domain types: memories, scopes, metadata, validation, and application state.
 pub mod types;
+// ci: trigger build after path-filter removal


### PR DESCRIPTION
## Summary

- Remove the `paths` filter on the `pull_request` trigger in `.github/workflows/build.yml` so CI runs on all PRs unconditionally

The path filter was added in #237 to skip CI for docs-only PRs. However, it conflicts with branch protection required status checks — when a PR only touches docs/markdown files, the required CI jobs (lint, clippy, test, etc.) never run, so the PR can never satisfy the merge requirements and is stuck unmergeable.

Reverting the filter so all PRs trigger CI regardless of which files changed.

## Test plan

- [ ] This PR itself triggers CI (touches `.github/workflows/build.yml`)
- [ ] Docs-only PRs are no longer blocked by missing required status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)