### PR TITLE
feat: add move tool to relocate memories between scopes

### DIFF
--- a/docs/adr/0037-move-tool-atomicity.md
+++ b/docs/adr/0037-move-tool-atomicity.md
@@ -1,0 +1,26 @@
+# ADR-0037: Move tool — single-commit repo primitive
+
+## Status
+Accepted
+
+## Context
+Issue #267 adds a `move` tool to relocate memories between scopes. The
+operation touches two files (write destination, delete source) and the
+vector index. We needed to decide whether to compose existing repo
+primitives (`save_memory` + `delete_memory`) or add a dedicated method.
+
+## Decision
+A dedicated `MemoryRepo::move_memory` method writes the destination,
+deletes the source, stages both changes, and commits — all in one git
+commit. If any step fails, `checkout_head --force` resets the working
+tree and index back to HEAD, leaving no dirty or untracked files.
+
+Embedding and index operations remain at the handler layer — they are
+not git concerns and don't benefit from the single-commit guarantee.
+
+## Consequences
+- **Single commit**: the git history shows one `chore: move memory
+  'X' → 'Y'` commit instead of a save followed by a delete.
+- **Clean failure**: on error, `checkout_head --force` restores the
+  working tree to the last good commit. No dirty files, no untracked
+  files, no partial state.

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -12,7 +12,7 @@ use crate::{
     auth::AuthProvider,
     error::MemoryError,
     health::SubsystemReporter,
-    types::{ChangedMemories, Memory, PullResult, Scope},
+    types::{ChangedMemories, Memory, MemoryMetadata, MemoryName, PullResult, Scope},
 };
 
 // ---------------------------------------------------------------------------
@@ -279,9 +279,11 @@ impl MemoryRepo {
             let markdown = memory.to_markdown()?;
             arc.write_memory_file(&file_path, markdown.as_bytes())?;
 
-            let oid = arc.git_add_and_commit(
+            let mut index = repo.index()?;
+            arc.stage_add(&mut index, &file_path)?;
+            let oid = arc.commit_index(
                 &repo,
-                &file_path,
+                &mut index,
                 &format!("chore: save memory '{}'", memory.name),
             )?;
 
@@ -320,33 +322,17 @@ impl MemoryRepo {
                 .lock()
                 .expect("lock poisoned — prior panic corrupted state");
 
-            // Check existence and symlink status atomically via symlink_metadata.
-            match std::fs::symlink_metadata(&file_path_clone) {
-                Err(_) => return Err(MemoryError::NotFound { name: name.clone() }),
-                Ok(m) if m.file_type().is_symlink() => {
-                    return Err(MemoryError::InvalidInput {
-                        reason: format!(
-                            "path '{}' is a symlink, which is not permitted",
-                            file_path_clone.display()
-                        ),
-                    });
-                }
-                Ok(_) => {}
-            }
+            Self::assert_exists_no_symlink(&file_path_clone, &name)?;
 
             std::fs::remove_file(&file_path_clone)?;
-            // git rm equivalent: stage the removal
-            let relative =
-                file_path_clone
-                    .strip_prefix(&arc.root)
-                    .map_err(|e| MemoryError::InvalidInput {
-                        reason: format!("path strip error: {}", e),
-                    })?;
-            let mut index = repo.index()?;
-            index.remove_path(relative)?;
 
-            let message = format!("chore: delete memory '{}'", name);
-            let oid = arc.commit_index(&repo, &mut index, &message)?;
+            let mut index = repo.index()?;
+            arc.stage_remove(&mut index, &file_path_clone)?;
+            let oid = arc.commit_index(
+                &repo,
+                &mut index,
+                &format!("chore: delete memory '{}'", name),
+            )?;
 
             tracing::Span::current().record("oid", oid.to_string().as_str());
             info!(oid = %oid, "memory deleted from repo");
@@ -359,6 +345,113 @@ impl MemoryRepo {
         match &result {
             Ok(_) => self.reporter.report_ok(),
             Err(_) => self.reporter.report_err("delete_memory failed"),
+        }
+        result
+    }
+
+    /// Move a memory from one scope to another in a single git commit.
+    ///
+    /// Reads the source, builds a destination [`Memory`] with a new ID and
+    /// the given name/scope (preserving content, tags, and source hint),
+    /// writes the destination file, removes the source file, stages both
+    /// changes, and commits atomically. If any step fails, the working
+    /// tree is reset to HEAD via `checkout_head --force` so no dirty or
+    /// untracked files are left behind.
+    ///
+    /// Returns the newly created destination [`Memory`] on success.
+    pub async fn move_memory(
+        self: &Arc<Self>,
+        source_name: &str,
+        source_scope: &Scope,
+        dest_name: &MemoryName,
+        dest_scope: &Scope,
+    ) -> Result<Memory, MemoryError> {
+        let source_path = self.memory_path(source_name, source_scope);
+        self.assert_within_root(&source_path)?;
+
+        let dest_path = self.memory_path(dest_name, dest_scope);
+        self.assert_within_root(&dest_path)?;
+
+        let arc = Arc::clone(self);
+        let source_name = source_name.to_string();
+        let dest_name = dest_name.clone();
+        let dest_scope = dest_scope.clone();
+        let span = tracing::info_span!(
+            "repo.move",
+            source_name = %source_name,
+            dest_name = %dest_name,
+            oid = tracing::field::Empty,
+        );
+
+        let result = traced_spawn_blocking(move || -> Result<Memory, MemoryError> {
+            let _enter = span.entered();
+            let repo = arc
+                .inner
+                .lock()
+                .expect("lock poisoned — prior panic corrupted state");
+
+            Self::assert_exists_no_symlink(&source_path, &source_name)?;
+
+            // Read the source memory.
+            let raw = arc.read_memory_file(&source_path)?;
+            let source = Memory::from_markdown(&raw)?;
+
+            // Build destination: new ID, same content/tags/source, new scope/name.
+            let metadata = MemoryMetadata::new(
+                dest_scope,
+                source.metadata.tags.clone(),
+                source.metadata.source.clone(),
+            );
+            let dest = Memory::from_validated(dest_name, source.content.clone(), metadata);
+
+            // Write destination, delete source, stage both, commit.
+            // If anything fails after we start modifying the working tree,
+            // reset hard to HEAD so we never leave dirty/untracked files.
+            let commit_result = (|| -> Result<git2::Oid, MemoryError> {
+                if let Some(parent) = dest_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let markdown = dest.to_markdown()?;
+                arc.write_memory_file(&dest_path, markdown.as_bytes())?;
+                std::fs::remove_file(&source_path)?;
+
+                let mut index = repo.index()?;
+                arc.stage_add(&mut index, &dest_path)?;
+                arc.stage_remove(&mut index, &source_path)?;
+                arc.commit_index(
+                    &repo,
+                    &mut index,
+                    &format!("chore: move memory '{}' → '{}'", source_name, dest.name),
+                )
+            })();
+
+            match commit_result {
+                Ok(oid) => {
+                    tracing::Span::current().record("oid", oid.to_string().as_str());
+                    info!(oid = %oid, "memory moved in repo");
+                    Ok(dest)
+                }
+                Err(e) => {
+                    // Reset working tree + index to HEAD — restores source,
+                    // removes destination, clears staged changes.
+                    let mut checkout = git2::build::CheckoutBuilder::default();
+                    checkout.force();
+                    if let Err(reset_err) = repo.checkout_head(Some(&mut checkout)) {
+                        warn!(
+                            error = %reset_err,
+                            "failed to reset working tree after move failure"
+                        );
+                    }
+                    Err(e)
+                }
+            }
+        })
+        .await
+        .map_err(|e| MemoryError::Join(e.to_string()))?;
+
+        match &result {
+            Ok(_) => self.reporter.report_ok(),
+            Err(_) => self.reporter.report_err("move_memory failed"),
         }
         result
     }
@@ -377,19 +470,7 @@ impl MemoryRepo {
         let span = tracing::debug_span!("repo.read", name = %name);
         let result = traced_spawn_blocking(move || -> Result<Memory, MemoryError> {
             let _enter = span.entered();
-            // Check existence/symlink status before opening.
-            match std::fs::symlink_metadata(&file_path) {
-                Err(_) => return Err(MemoryError::NotFound { name }),
-                Ok(m) if m.file_type().is_symlink() => {
-                    return Err(MemoryError::InvalidInput {
-                        reason: format!(
-                            "path '{}' is a symlink, which is not permitted",
-                            file_path.display()
-                        ),
-                    });
-                }
-                Ok(_) => {}
-            }
+            Self::assert_exists_no_symlink(&file_path, &name)?;
             let raw = arc.read_memory_file(&file_path)?;
             Memory::from_markdown(&raw)
         })
@@ -1034,24 +1115,48 @@ impl MemoryRepo {
         Ok(oid)
     }
 
-    /// Stage `file_path` and create a commit.
-    fn git_add_and_commit(
-        &self,
-        repo: &Repository,
-        file_path: &Path,
-        message: &str,
-    ) -> Result<git2::Oid, MemoryError> {
+    /// Stage a file addition in the given index.
+    fn stage_add(&self, index: &mut git2::Index, file_path: &Path) -> Result<(), MemoryError> {
         let relative =
             file_path
                 .strip_prefix(&self.root)
                 .map_err(|e| MemoryError::InvalidInput {
                     reason: format!("path strip error: {}", e),
                 })?;
-
-        let mut index = repo.index()?;
         index.add_path(relative)?;
+        Ok(())
+    }
 
-        self.commit_index(repo, &mut index, message)
+    /// Stage a file removal in the given index.
+    fn stage_remove(&self, index: &mut git2::Index, file_path: &Path) -> Result<(), MemoryError> {
+        let relative =
+            file_path
+                .strip_prefix(&self.root)
+                .map_err(|e| MemoryError::InvalidInput {
+                    reason: format!("path strip error: {}", e),
+                })?;
+        index.remove_path(relative)?;
+        Ok(())
+    }
+
+    /// Assert that `path` exists on disk and is not a symlink.
+    ///
+    /// Returns `NotFound` if the file is absent, `InvalidInput` if it is a
+    /// symlink. This is the standard pre-check for operations that read or
+    /// remove an existing memory file.
+    fn assert_exists_no_symlink(path: &Path, name: &str) -> Result<(), MemoryError> {
+        match std::fs::symlink_metadata(path) {
+            Err(_) => Err(MemoryError::NotFound {
+                name: name.to_string(),
+            }),
+            Ok(m) if m.file_type().is_symlink() => Err(MemoryError::InvalidInput {
+                reason: format!(
+                    "path '{}' is a symlink, which is not permitted",
+                    path.display()
+                ),
+            }),
+            Ok(_) => Ok(()),
+        }
     }
 
     /// Assert that `path` remains under `self.root` after canonicalisation,

--- a/src/server.rs
+++ b/src/server.rs
@@ -38,8 +38,9 @@ use crate::{
     repo::{traced_spawn_blocking, MemoryRepo},
     types::{
         parse_qualified_name, AppState, ChangedMemories, EditArgs, ForgetArgs, ListArgs,
-        MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef, PullResult, ReadArgs,
-        RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, Scope, ScopeFilter, SyncArgs,
+        MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef, MoveArgs, PullResult,
+        ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, Scope, ScopeFilter,
+        SyncArgs,
     },
 };
 
@@ -711,6 +712,131 @@ impl MemoryServer {
                 "id": memory.id,
                 "name": memory.name,
                 "scope": memory.metadata.scope.to_string(),
+            })
+            .to_string())
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Move a memory from one scope to another, optionally renaming it.
+    ///
+    /// Reads the source memory, creates it in the destination scope (with a
+    /// new name if provided), re-indexes the embedding, then deletes the
+    /// source. Atomic: if the create fails, the source is preserved.
+    ///
+    /// Returns the new memory ID, name, and scope on success.
+    #[tool(
+        name = "move",
+        description = "Move a memory from one scope to another, optionally renaming it. \
+        Reads the source memory (content, tags, metadata), creates it in the destination scope, \
+        re-indexes the embedding, and deletes the original. Atomic: if the create fails, the \
+        source is preserved. Use 'new_name' to rename during the move. Returns the new memory \
+        ID, name, and scope."
+    )]
+    async fn move_memory(
+        &self,
+        Parameters(args): Parameters<MoveArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
+        let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
+        let new_name = match args.new_name {
+            Some(n) => MemoryName::new(n).map_err(ErrorData::from)?,
+            None => name.clone(),
+        };
+        let session_id = extract_session_id(&parts);
+        let span = tracing::info_span!(
+            "handler.move",
+            session_id = %session_id,
+            name = %name,
+            new_name = %new_name,
+            from_scope = ?args.from_scope,
+            to_scope = %args.to_scope,
+        );
+        let state = Arc::clone(&self.state);
+        async move {
+            let from_scope =
+                Scope::parse_or_default(args.from_scope.as_deref()).map_err(ErrorData::from)?;
+            let to_scope =
+                Scope::parse_or_default(Some(&args.to_scope)).map_err(ErrorData::from)?;
+
+            // Reject no-op moves (same scope + same name).
+            if from_scope == to_scope && name == new_name {
+                return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
+                    reason: "source and destination are identical — nothing to move".into(),
+                }));
+            }
+
+            let start = Instant::now();
+
+            // 1. Reject early if the destination already exists.
+            match state.repo.read_memory(&new_name, &to_scope).await {
+                Ok(_) => {
+                    return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
+                        reason: format!(
+                            "destination memory '{}' already exists in scope '{}' — \
+                             rename or delete it first",
+                            new_name, to_scope
+                        ),
+                    }));
+                }
+                Err(crate::error::MemoryError::NotFound { .. }) => {
+                    // Good — destination is clear.
+                }
+                Err(e) => {
+                    return Err(ErrorData::from(e));
+                }
+            }
+
+            // 2. Atomically read source, write destination, delete source
+            //    in one git commit. Must happen before index mutations so a
+            //    failure leaves the index consistent with the repo on disk.
+            let dest = state
+                .repo
+                .move_memory(&name, &from_scope, &new_name, &to_scope)
+                .await
+                .map_err(ErrorData::from)?;
+
+            // 3. Embed the content for the new scope's index entry.
+            let vector = state
+                .embedding
+                .embed_one(&dest.content)
+                .await
+                .map_err(ErrorData::from)?;
+
+            let dest_qualified = dest.mem_ref().qualified_path();
+
+            // 4. Add destination to the vector index.
+            state
+                .index
+                .add(&to_scope, &vector, dest_qualified)
+                .map_err(ErrorData::from)?;
+
+            // 5. Remove the source from the vector index (best-effort — stale
+            //    entries are skipped at recall time).
+            let source_qualified =
+                MemoryRef::new(from_scope.clone(), name.clone()).qualified_path();
+            if let Err(e) = state.index.remove(&from_scope, &source_qualified) {
+                warn!(
+                    name = %name,
+                    error = %e,
+                    "vector removal failed during move; stale source entry will be skipped at recall"
+                );
+            }
+
+            info!(
+                ms = start.elapsed().as_millis(),
+                name = %name,
+                new_name = %new_name,
+                from_scope = %from_scope,
+                to_scope = %to_scope,
+                "memory moved"
+            );
+
+            Ok(serde_json::json!({
+                "id": dest.id,
+                "name": dest.name,
+                "scope": dest.metadata.scope.to_string(),
             })
             .to_string())
         }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -69,6 +69,21 @@ pub struct EditArgs {
     pub scope: Option<String>,
 }
 
+/// Arguments for the `move` tool — relocate a memory between scopes.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct MoveArgs {
+    /// Exact name of the memory to move.
+    pub name: String,
+    /// Source scope. Defaults to 'global'. Use a bare namespace path like 'my-project' or 'org/team' for scoped memories.
+    #[serde(default)]
+    pub from_scope: Option<String>,
+    /// Destination scope. Required. Use a bare namespace path like 'my-project' or 'org/team', or 'global'.
+    pub to_scope: String,
+    /// Optional new name for the memory in the destination scope. Defaults to the original name.
+    #[serde(default)]
+    pub new_name: Option<String>,
+}
+
 /// Arguments for the `list` tool — browse stored memories.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListArgs {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,8 +10,9 @@ mod validated;
 // re-exported as `pub(crate)`.
 
 pub use args::{
-    AppState, ChangedMemories, EditArgs, ForgetArgs, ListArgs, MarkAppliedArgs, PullResult,
-    ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, SyncArgs, Verdict,
+    AppState, ChangedMemories, EditArgs, ForgetArgs, ListArgs, MarkAppliedArgs, MoveArgs,
+    PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, SyncArgs,
+    Verdict,
 };
 
 pub use memory::{parse_qualified_name, Memory, MemoryMetadata, MemoryName, MemoryRef};

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the memory repository — save, read, list, pull, delete.
+//! Integration tests for the memory repository — save, read, list, pull, delete, move.
 //!
 //! Uses `AuthProvider::with_token` to inject a known token without needing
 //! real credentials. The `push_pull_with_bare_remote` test exercises the full
@@ -10,7 +10,7 @@ use memory_mcp::auth::AuthProvider;
 #[cfg(unix)]
 use memory_mcp::error::MemoryError;
 use memory_mcp::repo::MemoryRepo;
-use memory_mcp::types::{Memory, MemoryMetadata, PullResult, Scope};
+use memory_mcp::types::{Memory, MemoryMetadata, MemoryName, PullResult, Scope};
 
 /// Full round-trip: init repo → save memory → read it back → list → delete → pull.
 ///
@@ -249,5 +249,111 @@ async fn push_rejected_by_server_hook() {
     assert!(
         msg.contains("refs/heads/main"),
         "rejection should name the rejected ref, got: {msg}",
+    );
+}
+
+/// Move a memory to a different scope with a new name via `repo.move_memory`.
+#[tokio::test]
+async fn move_memory_with_rename() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo =
+        Arc::new(MemoryRepo::init_or_open(tmp.path(), None).expect("should init fresh repo"));
+
+    let from_scope: Scope = "project-a".parse().unwrap();
+    let to_scope: Scope = "project-b".parse().unwrap();
+
+    // Save a memory.
+    let metadata = MemoryMetadata::new(from_scope.clone(), vec!["rename-test".into()], None);
+    let memory = Memory::new("old-name", "Content for rename test.", metadata).unwrap();
+    repo.save_memory(&memory)
+        .await
+        .expect("save should succeed");
+
+    let new_name = MemoryName::new("new-name").unwrap();
+    repo.move_memory("old-name", &from_scope, &new_name, &to_scope)
+        .await
+        .expect("move should succeed");
+
+    // Old name in old scope is gone.
+    assert!(repo.read_memory("old-name", &from_scope).await.is_err());
+
+    // New name in new scope exists with correct content.
+    let loaded = repo
+        .read_memory("new-name", &to_scope)
+        .await
+        .expect("renamed memory should exist");
+    assert_eq!(loaded.content, "Content for rename test.");
+    assert_eq!(loaded.metadata.tags, vec!["rename-test".to_string()]);
+}
+
+/// Exercise `repo.move_memory` directly — single-commit atomicity.
+///
+/// Verifies that after a successful move the source is gone, the
+/// destination exists with correct content, and the git log shows
+/// exactly one new commit (not two).
+#[tokio::test]
+async fn repo_move_memory_atomic_commit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo =
+        Arc::new(MemoryRepo::init_or_open(tmp.path(), None).expect("should init fresh repo"));
+
+    let from_scope = Scope::Root;
+    let to_scope: Scope = "target-project".parse().unwrap();
+
+    // Save source memory (creates first commit after init).
+    let metadata = MemoryMetadata::new(
+        from_scope.clone(),
+        vec!["atomic".into()],
+        Some("test".into()),
+    );
+    let source = Memory::new("atomic-mem", "Atomic move content.", metadata).unwrap();
+    repo.save_memory(&source)
+        .await
+        .expect("save should succeed");
+
+    // Count commits before move.
+    let pre_move_commits = {
+        let git = git2::Repository::open(tmp.path()).unwrap();
+        let mut revwalk = git.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+        revwalk.count()
+    };
+
+    // Move via the repo method.
+    let dest_name = MemoryName::new("atomic-mem").unwrap();
+    let dest = repo
+        .move_memory("atomic-mem", &from_scope, &dest_name, &to_scope)
+        .await
+        .expect("move should succeed");
+
+    // Returned memory has correct content and metadata.
+    assert_eq!(dest.content, "Atomic move content.");
+    assert_eq!(dest.metadata.tags, vec!["atomic".to_string()]);
+    assert_eq!(dest.metadata.source.as_deref(), Some("test"));
+
+    // Source should be gone.
+    assert!(
+        repo.read_memory("atomic-mem", &from_scope).await.is_err(),
+        "source should be deleted"
+    );
+
+    // Destination should be readable from repo.
+    let loaded = repo
+        .read_memory("atomic-mem", &to_scope)
+        .await
+        .expect("dest should exist");
+    assert_eq!(loaded.content, "Atomic move content.");
+
+    // Exactly one new commit should have been created (the move).
+    let post_move_commits = {
+        let git = git2::Repository::open(tmp.path()).unwrap();
+        let mut revwalk = git.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+        revwalk.count()
+    };
+    assert_eq!(
+        post_move_commits,
+        pre_move_commits + 1,
+        "move should produce exactly one git commit"
     );
 }

--- a/tests/tracing.rs
+++ b/tests/tracing.rs
@@ -251,6 +251,12 @@ fn canonical_fields() -> HashSet<&'static str> {
         "oid",
         "token_source",
         "duration_ms",
+        // Move-related fields (handler.move, repo.move)
+        "source_name",
+        "dest_name",
+        "new_name",
+        "from_scope",
+        "to_scope",
         // These are tracing internal / log fields we allow through:
         "message",
         "error",


### PR DESCRIPTION
## Summary

Adds a `move` MCP tool to relocate memories between scopes, with optional rename.

```
move(name, from_scope, to_scope, new_name?)
```

**New repo primitive** — `MemoryRepo::move_memory(source_name, source_scope, dest_name, dest_scope)` reads the source, builds the destination memory (new ID, same content/tags/source), writes the dest file, deletes the source file, stages both, and commits atomically in a single git commit. On failure, `checkout_head --force` resets the working tree — no dirty or untracked files.

**New MCP tool handler** — validates inputs, rejects no-ops (same scope + same name), rejects destination conflicts (dest already exists), calls `move_memory`, then embeds and indexes the destination and removes the source from the vector index.

**Repo refactoring** — extracted `stage_add`/`stage_remove` helpers from the old `git_add_and_commit`, so `save_memory`, `delete_memory`, and `move_memory` all share the same staging primitives. Extracted `assert_exists_no_symlink` from the three callsites that had identical existence + symlink checks.

Closes #267