### PR TITLE
feat: add batch_mark_applied tool for multi-verdict recall feedback

### DIFF
--- a/src/recall_log.rs
+++ b/src/recall_log.rs
@@ -168,6 +168,52 @@ impl RecallLog {
         Ok(rows as u64)
     }
 
+    /// Mark multiple recall events with agent verdicts in a single transaction.
+    ///
+    /// Each entry in `verdicts` is applied via the same `UPDATE` logic as
+    /// [`mark_applied`](Self::mark_applied): rows matching (`recall_id`,
+    /// `memory_name`, `session_id`) where `was_applied IS NULL` are updated
+    /// (first call wins). Returns a `Vec<u64>` with one element per input
+    /// entry — the number of rows affected by that verdict.
+    pub fn batch_mark_applied(
+        &self,
+        session_id: &str,
+        verdicts: &[BatchVerdict<'_>],
+    ) -> Result<Vec<u64>, MemoryError> {
+        let conn = self.conn()?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| MemoryError::Internal(format!("recall log batch tx: {e}")))?;
+        let mut results = Vec::with_capacity(verdicts.len());
+        {
+            let mut stmt = tx
+                .prepare(
+                    "UPDATE recall_events \
+                     SET was_applied = ?1, application_note = ?2, confidence = ?3 \
+                     WHERE recall_id = ?4 AND memory_name = ?5 AND session_id = ?6 AND was_applied IS NULL",
+                )
+                .map_err(|e| MemoryError::Internal(format!("recall log batch prepare: {e}")))?;
+            for v in verdicts {
+                let rows = stmt
+                    .execute(rusqlite::params![
+                        v.verdict,
+                        v.application_note,
+                        v.confidence,
+                        v.recall_id,
+                        v.memory_name,
+                        session_id
+                    ])
+                    .map_err(|e| {
+                        MemoryError::Internal(format!("recall log batch mark_applied: {e}"))
+                    })?;
+                results.push(rows as u64);
+            }
+        }
+        tx.commit()
+            .map_err(|e| MemoryError::Internal(format!("recall log batch commit: {e}")))?;
+        Ok(results)
+    }
+
     /// Mark all unread recall events for a given session and memory as read.
     ///
     /// Sets `was_read = 1` for every matching row where it was still `0`.
@@ -252,6 +298,20 @@ impl RecallLog {
 
         Ok(buckets)
     }
+}
+
+/// A single verdict for batch application.
+pub struct BatchVerdict<'a> {
+    /// The recall_id to match.
+    pub recall_id: &'a str,
+    /// Memory name to match.
+    pub memory_name: &'a str,
+    /// Verdict string: `"applied"`, `"maybe"`, or `"not_applied"`.
+    pub verdict: &'a str,
+    /// Optional note about how the memory was used.
+    pub application_note: Option<&'a str>,
+    /// Confidence level: `"high"`, `"medium"`, or `"low"`.
+    pub confidence: &'a str,
 }
 
 /// A single recall result for logging purposes.
@@ -668,5 +728,309 @@ mod tests {
         assert_eq!(Verdict::Applied.as_str(), "applied");
         assert_eq!(Verdict::Maybe.as_str(), "maybe");
         assert_eq!(Verdict::NotApplied.as_str(), "not_applied");
+    }
+
+    #[test]
+    fn batch_mark_applied_processes_all_verdicts() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let recall_id = RecallLog::generate_recall_id();
+        let results = vec![
+            RecallResult {
+                memory_name: "m1".to_string(),
+                scope: "global".to_string(),
+                rank: 0,
+                distance: 0.1,
+            },
+            RecallResult {
+                memory_name: "m2".to_string(),
+                scope: "global".to_string(),
+                rank: 1,
+                distance: 0.2,
+            },
+            RecallResult {
+                memory_name: "m3".to_string(),
+                scope: "global".to_string(),
+                rank: 2,
+                distance: 0.3,
+            },
+        ];
+        log.log_results(&recall_id, "sess-batch", &results).unwrap();
+
+        let verdicts = vec![
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "m1",
+                verdict: "applied",
+                application_note: Some("used for init"),
+                confidence: "high",
+            },
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "m2",
+                verdict: "maybe",
+                application_note: None,
+                confidence: "medium",
+            },
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "m3",
+                verdict: "not_applied",
+                application_note: Some("noise"),
+                confidence: "low",
+            },
+        ];
+
+        let per_entry = log.batch_mark_applied("sess-batch", &verdicts).unwrap();
+        assert_eq!(per_entry, vec![1, 1, 1]);
+
+        let conn = log.conn().unwrap();
+        let verdict_m1: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'm1'",
+                [&recall_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(verdict_m1, "applied");
+
+        let verdict_m2: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'm2'",
+                [&recall_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(verdict_m2, "maybe");
+
+        let verdict_m3: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'm3'",
+                [&recall_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(verdict_m3, "not_applied");
+    }
+
+    #[test]
+    fn batch_mark_applied_empty_returns_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let per_entry = log.batch_mark_applied("sess", &[]).unwrap();
+        assert!(per_entry.is_empty());
+    }
+
+    #[test]
+    fn batch_mark_applied_no_match_returns_zeros() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let verdicts = vec![
+            BatchVerdict {
+                recall_id: "no-id",
+                memory_name: "no-mem",
+                verdict: "applied",
+                application_note: None,
+                confidence: "high",
+            },
+            BatchVerdict {
+                recall_id: "no-id-2",
+                memory_name: "no-mem-2",
+                verdict: "maybe",
+                application_note: None,
+                confidence: "low",
+            },
+        ];
+
+        let per_entry = log.batch_mark_applied("no-sess", &verdicts).unwrap();
+        assert_eq!(per_entry, vec![0, 0]);
+    }
+
+    #[test]
+    fn batch_mark_applied_idempotent_first_call_wins() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let recall_id = RecallLog::generate_recall_id();
+        let results = vec![RecallResult {
+            memory_name: "idem".to_string(),
+            scope: "global".to_string(),
+            rank: 0,
+            distance: 0.2,
+        }];
+        log.log_results(&recall_id, "sess", &results).unwrap();
+
+        let verdicts_first = vec![BatchVerdict {
+            recall_id: &recall_id,
+            memory_name: "idem",
+            verdict: "applied",
+            application_note: Some("first"),
+            confidence: "high",
+        }];
+        let per_entry = log.batch_mark_applied("sess", &verdicts_first).unwrap();
+        assert_eq!(per_entry, vec![1]);
+
+        let verdicts_second = vec![BatchVerdict {
+            recall_id: &recall_id,
+            memory_name: "idem",
+            verdict: "not_applied",
+            application_note: Some("second"),
+            confidence: "low",
+        }];
+        let per_entry2 = log.batch_mark_applied("sess", &verdicts_second).unwrap();
+        assert_eq!(per_entry2, vec![0], "second call must be a no-op");
+
+        let conn = log.conn().unwrap();
+        let verdict: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'idem'",
+                [&recall_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(verdict, "applied", "first verdict must be preserved");
+    }
+
+    #[test]
+    fn batch_mark_applied_mixed_recall_ids() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let recall_id_a = RecallLog::generate_recall_id();
+        let recall_id_b = RecallLog::generate_recall_id();
+
+        log.log_results(
+            &recall_id_a,
+            "sess",
+            &[RecallResult {
+                memory_name: "ma".to_string(),
+                scope: "global".to_string(),
+                rank: 0,
+                distance: 0.1,
+            }],
+        )
+        .unwrap();
+        log.log_results(
+            &recall_id_b,
+            "sess",
+            &[RecallResult {
+                memory_name: "mb".to_string(),
+                scope: "global".to_string(),
+                rank: 0,
+                distance: 0.2,
+            }],
+        )
+        .unwrap();
+
+        let verdicts = vec![
+            BatchVerdict {
+                recall_id: &recall_id_a,
+                memory_name: "ma",
+                verdict: "applied",
+                application_note: None,
+                confidence: "high",
+            },
+            BatchVerdict {
+                recall_id: &recall_id_b,
+                memory_name: "mb",
+                verdict: "not_applied",
+                application_note: None,
+                confidence: "medium",
+            },
+        ];
+
+        let per_entry = log.batch_mark_applied("sess", &verdicts).unwrap();
+        assert_eq!(per_entry, vec![1, 1]);
+
+        let conn = log.conn().unwrap();
+        let va: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'ma'",
+                [&recall_id_a],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(va, "applied");
+
+        let vb: String = conn
+            .query_row(
+                "SELECT was_applied FROM recall_events WHERE recall_id = ?1 AND memory_name = 'mb'",
+                [&recall_id_b],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(vb, "not_applied");
+    }
+
+    #[test]
+    fn batch_mark_applied_reflects_in_recall_stats() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("recall_log.sqlite");
+        let log = RecallLog::open(&path, Duration::from_secs(5)).unwrap();
+
+        let recall_id = RecallLog::generate_recall_id();
+        let results = vec![
+            RecallResult {
+                memory_name: "s1".to_string(),
+                scope: "global".to_string(),
+                rank: 0,
+                distance: 0.15,
+            },
+            RecallResult {
+                memory_name: "s2".to_string(),
+                scope: "global".to_string(),
+                rank: 1,
+                distance: 0.15,
+            },
+            RecallResult {
+                memory_name: "s3".to_string(),
+                scope: "global".to_string(),
+                rank: 2,
+                distance: 0.15,
+            },
+        ];
+        log.log_results(&recall_id, "sess", &results).unwrap();
+
+        let verdicts = vec![
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "s1",
+                verdict: "applied",
+                application_note: None,
+                confidence: "high",
+            },
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "s2",
+                verdict: "maybe",
+                application_note: None,
+                confidence: "medium",
+            },
+            BatchVerdict {
+                recall_id: &recall_id,
+                memory_name: "s3",
+                verdict: "not_applied",
+                application_note: None,
+                confidence: "low",
+            },
+        ];
+        log.batch_mark_applied("sess", &verdicts).unwrap();
+
+        let stats = log.recall_stats().unwrap();
+        // distance 0.15 -> bucket 3 [0.15, 0.20)
+        let bucket = &stats[3];
+        assert_eq!(bucket.total, 3);
+        assert_eq!(bucket.applied, 1);
+        assert_eq!(bucket.maybe, 1);
+        assert_eq!(bucket.not_applied, 1);
+        assert_eq!(bucket.unknown, 0);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1290,28 +1290,18 @@ impl MemoryServer {
             let total_rows = if let Some(ref log) = state.recall_log {
                 let log = Arc::clone(log);
                 let sid = session_id.clone();
-                let verdicts: Vec<_> = args
+
+                // Build owned copies directly from the deserialized args so we
+                // can move them into spawn_blocking.
+                let owned: Vec<OwnedBatchVerdict> = args
                     .verdicts
                     .iter()
-                    .map(|v| BatchVerdict {
-                        recall_id: &v.recall_id,
-                        memory_name: &v.memory,
-                        verdict: v.verdict.as_str(),
-                        application_note: v.application.as_deref(),
-                        confidence: &v.confidence,
-                    })
-                    .collect();
-
-                // The BatchVerdict borrows from args.verdicts, so we must build
-                // owned copies before moving into spawn_blocking.
-                let owned: Vec<OwnedBatchVerdict> = verdicts
-                    .iter()
                     .map(|v| OwnedBatchVerdict {
-                        recall_id: v.recall_id.to_owned(),
-                        memory_name: v.memory_name.to_owned(),
-                        verdict: v.verdict.to_owned(),
-                        application_note: v.application_note.map(|s| s.to_owned()),
-                        confidence: v.confidence.to_owned(),
+                        recall_id: v.recall_id.clone(),
+                        memory_name: v.memory.clone(),
+                        verdict: v.verdict.as_str().to_owned(),
+                        application_note: v.application.clone(),
+                        confidence: v.confidence.clone(),
                     })
                     .collect();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,15 +34,24 @@ use crate::{
     embedding::EmbeddingBackend,
     error::MemoryError,
     index::VectorStore,
-    recall_log::{RecallLog, RecallResult},
+    recall_log::{BatchVerdict, RecallLog, RecallResult},
     repo::{traced_spawn_blocking, MemoryRepo},
     types::{
-        parse_qualified_name, AppState, ChangedMemories, EditArgs, ForgetArgs, ListArgs,
-        MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef, MoveArgs, PullResult,
-        ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, Scope, ScopeFilter,
-        SyncArgs,
+        parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
+        ForgetArgs, ListArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef,
+        MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs,
+        Scope, ScopeFilter, SyncArgs,
     },
 };
+
+/// Owned counterpart of [`BatchVerdict`] for moving into `spawn_blocking`.
+struct OwnedBatchVerdict {
+    recall_id: String,
+    memory_name: String,
+    verdict: String,
+    application_note: Option<String>,
+    confidence: String,
+}
 
 /// MCP server implementation.
 ///
@@ -1228,6 +1237,139 @@ impl MemoryServer {
         .await
     }
 
+    /// Report verdicts for multiple recalled memories in a single call.
+    ///
+    /// Accepts an array of verdict entries and processes them in one database
+    /// transaction. Each entry follows the same semantics as `mark_applied`:
+    /// first call wins per (`recall_id`, `memory_name`, `session_id`) tuple.
+    ///
+    /// Returns per-entry row counts and an aggregate total.
+    #[tool(
+        name = "batch_mark_applied",
+        description = "Report verdicts for multiple recalled memories in a single call. Pass an \
+        array of verdict objects, each with recall_id, memory name, verdict ('applied', 'maybe', \
+        or 'not_applied'), optional application note, and confidence level. Processes all verdicts \
+        in one transaction. Use this instead of calling mark_applied repeatedly — it reduces \
+        round-trips from N calls to 1."
+    )]
+    async fn batch_mark_applied(
+        &self,
+        Parameters(args): Parameters<BatchMarkAppliedArgs>,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<String, ErrorData> {
+        let session_id = extract_session_id(&parts);
+        let count = args.verdicts.len();
+        let span = tracing::info_span!(
+            "handler.batch_mark_applied",
+            session_id = %session_id,
+            count,
+        );
+        let state = Arc::clone(&self.state);
+        async move {
+            if args.verdicts.is_empty() {
+                return Err(ErrorData::from(MemoryError::InvalidInput {
+                    reason: "verdicts array must not be empty".into(),
+                }));
+            }
+
+            // Validate all confidence values up front.
+            for (i, entry) in args.verdicts.iter().enumerate() {
+                match entry.confidence.as_str() {
+                    "high" | "medium" | "low" => {}
+                    other => {
+                        return Err(ErrorData::from(MemoryError::InvalidInput {
+                            reason: format!(
+                                "invalid confidence '{}' at index {}; expected 'high', 'medium', or 'low'",
+                                other, i
+                            ),
+                        }));
+                    }
+                }
+            }
+
+            let total_rows = if let Some(ref log) = state.recall_log {
+                let log = Arc::clone(log);
+                let sid = session_id.clone();
+                let verdicts: Vec<_> = args
+                    .verdicts
+                    .iter()
+                    .map(|v| BatchVerdict {
+                        recall_id: &v.recall_id,
+                        memory_name: &v.memory,
+                        verdict: v.verdict.as_str(),
+                        application_note: v.application.as_deref(),
+                        confidence: &v.confidence,
+                    })
+                    .collect();
+
+                // The BatchVerdict borrows from args.verdicts, so we must build
+                // owned copies before moving into spawn_blocking.
+                let owned: Vec<OwnedBatchVerdict> = verdicts
+                    .iter()
+                    .map(|v| OwnedBatchVerdict {
+                        recall_id: v.recall_id.to_owned(),
+                        memory_name: v.memory_name.to_owned(),
+                        verdict: v.verdict.to_owned(),
+                        application_note: v.application_note.map(|s| s.to_owned()),
+                        confidence: v.confidence.to_owned(),
+                    })
+                    .collect();
+
+                let per_entry = traced_spawn_blocking(move || {
+                    let refs: Vec<BatchVerdict<'_>> = owned
+                        .iter()
+                        .map(|o| BatchVerdict {
+                            recall_id: &o.recall_id,
+                            memory_name: &o.memory_name,
+                            verdict: &o.verdict,
+                            application_note: o.application_note.as_deref(),
+                            confidence: &o.confidence,
+                        })
+                        .collect();
+                    log.batch_mark_applied(&sid, &refs)
+                })
+                .await
+                .map_err(|e| {
+                    ErrorData::from(MemoryError::Internal(format!("spawn_blocking: {e}")))
+                })?
+                .map_err(ErrorData::from)?;
+
+                let total: u64 = per_entry.iter().sum();
+
+                // Warn for entries that matched nothing.
+                for (i, &rows) in per_entry.iter().enumerate() {
+                    if rows == 0 {
+                        warn!(
+                            recall_id = %args.verdicts[i].recall_id,
+                            memory = %args.verdicts[i].memory,
+                            index = i,
+                            "batch_mark_applied entry matched no rows"
+                        );
+                    }
+                }
+
+                info!(
+                    total_rows = total,
+                    entries = per_entry.len(),
+                    "batch_mark_applied"
+                );
+
+                total
+            } else {
+                warn!("batch_mark_applied called but recall log is not enabled");
+                0
+            };
+
+            Ok(serde_json::json!({
+                "total_rows_affected": total_rows,
+                "entries_processed": args.verdicts.len(),
+            })
+            .to_string())
+        }
+        .instrument(span)
+        .await
+    }
+
     /// Return recall precision statistics bucketed by distance range.
     ///
     /// Agents can use this to inspect their own recall quality and adjust
@@ -1314,7 +1456,9 @@ impl ServerHandler for MemoryServer {
             Recall feedback: after acting on recalled memories, call `mark_applied` for each result \
             with your verdict ('applied', 'maybe', or 'not_applied'). Every recall response includes \
             a `recall_id` — pass it back with each verdict. This bidirectional feedback calibrates \
-            recall thresholds. Use `recall_stats` to inspect precision by distance bucket.\n\n\
+            recall thresholds. Use `batch_mark_applied` to submit multiple verdicts in a single call \
+            instead of calling `mark_applied` repeatedly. Use `recall_stats` to inspect precision \
+            by distance bucket.\n\n\
             Breaking change (v0.14.0): the 'project:<name>' scope format is no longer accepted \
             as tool input. If your prompts or configuration pass scope values like \
             'project:my-project', replace them with the bare path: 'my-project'. The 'global' \

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -152,6 +152,30 @@ fn default_confidence() -> String {
     "medium".to_string()
 }
 
+/// A single verdict entry within a [`BatchMarkAppliedArgs`] request.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct VerdictEntry {
+    /// The recall_id from the recall response that returned this memory.
+    pub recall_id: String,
+    /// Name of the memory that was (or was not) applied.
+    pub memory: String,
+    /// Agent's assessment of whether the memory was useful: 'applied', 'maybe', or 'not_applied'.
+    pub verdict: Verdict,
+    /// Brief description of how the memory influenced the session.
+    #[serde(default)]
+    pub application: Option<String>,
+    /// Confidence level: "high", "medium", or "low".
+    #[serde(default = "default_confidence")]
+    pub confidence: String,
+}
+
+/// Arguments for the `batch_mark_applied` tool — report multiple memory verdicts in a single call.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct BatchMarkAppliedArgs {
+    /// Array of verdict entries, each containing a recall_id, memory name, verdict, and optional metadata.
+    pub verdicts: Vec<VerdictEntry>,
+}
+
 /// Arguments for the `sync` tool — push/pull the git remote.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct SyncArgs {
@@ -277,5 +301,141 @@ impl AppState {
             health,
             recall_log,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // Wire-contract tests — assert the JSON schema shape that MCP clients see.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn batch_mark_applied_schema_has_verdicts_array() {
+        let schema = schemars::schema_for!(BatchMarkAppliedArgs);
+        let root = serde_json::to_value(&schema).unwrap();
+
+        let props = root["properties"].as_object().unwrap();
+        assert!(
+            props.contains_key("verdicts"),
+            "schema must expose a 'verdicts' property"
+        );
+
+        let required = root["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            required_strs.contains(&"verdicts"),
+            "'verdicts' must be required"
+        );
+    }
+
+    #[test]
+    fn verdict_entry_schema_has_required_fields() {
+        let schema = schemars::schema_for!(VerdictEntry);
+        let root = serde_json::to_value(&schema).unwrap();
+
+        let props = root["properties"].as_object().unwrap();
+        for field in &["recall_id", "memory", "verdict"] {
+            assert!(
+                props.contains_key(*field),
+                "VerdictEntry schema must contain '{field}'"
+            );
+        }
+
+        let required = root["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        for field in &["recall_id", "memory", "verdict"] {
+            assert!(
+                required_strs.contains(field),
+                "'{field}' must be required in VerdictEntry"
+            );
+        }
+    }
+
+    #[test]
+    fn verdict_entry_optional_fields_not_required() {
+        let schema = schemars::schema_for!(VerdictEntry);
+        let root = serde_json::to_value(&schema).unwrap();
+
+        let required = root["required"].as_array().unwrap();
+        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            !required_strs.contains(&"application"),
+            "'application' must not be required"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Deserialization round-trip tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn batch_mark_applied_deserializes_minimal() {
+        let json = r#"{
+            "verdicts": [
+                { "recall_id": "r_abc", "memory": "foo", "verdict": "applied" }
+            ]
+        }"#;
+        let args: BatchMarkAppliedArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.verdicts.len(), 1);
+        assert_eq!(args.verdicts[0].recall_id, "r_abc");
+        assert_eq!(args.verdicts[0].memory, "foo");
+        assert_eq!(args.verdicts[0].verdict, Verdict::Applied);
+        assert_eq!(args.verdicts[0].confidence, "medium");
+        assert!(args.verdicts[0].application.is_none());
+    }
+
+    #[test]
+    fn batch_mark_applied_deserializes_full() {
+        let json = r#"{
+            "verdicts": [
+                {
+                    "recall_id": "r_1",
+                    "memory": "m1",
+                    "verdict": "applied",
+                    "application": "used for greeting",
+                    "confidence": "high"
+                },
+                {
+                    "recall_id": "r_2",
+                    "memory": "m2",
+                    "verdict": "not_applied",
+                    "confidence": "low"
+                },
+                {
+                    "recall_id": "r_3",
+                    "memory": "m3",
+                    "verdict": "maybe"
+                }
+            ]
+        }"#;
+        let args: BatchMarkAppliedArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.verdicts.len(), 3);
+        assert_eq!(args.verdicts[0].verdict, Verdict::Applied);
+        assert_eq!(args.verdicts[0].confidence, "high");
+        assert_eq!(
+            args.verdicts[0].application.as_deref(),
+            Some("used for greeting")
+        );
+        assert_eq!(args.verdicts[1].verdict, Verdict::NotApplied);
+        assert_eq!(args.verdicts[1].confidence, "low");
+        assert_eq!(args.verdicts[2].verdict, Verdict::Maybe);
+        assert_eq!(args.verdicts[2].confidence, "medium");
+    }
+
+    #[test]
+    fn batch_mark_applied_rejects_empty_json() {
+        let json = r#"{}"#;
+        let result: Result<BatchMarkAppliedArgs, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "missing 'verdicts' should fail");
+    }
+
+    #[test]
+    fn verdict_entry_rejects_invalid_verdict() {
+        let json = r#"{ "recall_id": "r_1", "memory": "m1", "verdict": "bogus" }"#;
+        let result: Result<VerdictEntry, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "invalid verdict variant should fail");
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,9 +10,9 @@ mod validated;
 // re-exported as `pub(crate)`.
 
 pub use args::{
-    AppState, ChangedMemories, EditArgs, ForgetArgs, ListArgs, MarkAppliedArgs, MoveArgs,
-    PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs, SyncArgs,
-    Verdict,
+    AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs, ForgetArgs, ListArgs,
+    MarkAppliedArgs, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
+    RememberArgs, SyncArgs, Verdict, VerdictEntry,
 };
 
 pub use memory::{parse_qualified_name, Memory, MemoryMetadata, MemoryName, MemoryRef};


### PR DESCRIPTION
## Summary

- Adds a new `batch_mark_applied` MCP tool that accepts an array of verdict entries and processes them in a single SQLite transaction, reducing init-time recall feedback from N individual MCP round-trips to 1
- Existing `mark_applied` tool is unchanged for backwards compatibility
- New `BatchVerdict` struct and `RecallLog::batch_mark_applied()` method at the database layer
- Server handler validates all confidence values up front and warns per-entry for zero-match rows

## Test plan

- [x] Wire-contract tests asserting the `BatchMarkAppliedArgs` and `VerdictEntry` JSON schema shapes (required fields, optional fields)
- [x] Deserialization round-trip tests for minimal payload (defaults applied) and full payload (all fields explicit)
- [x] Rejection tests: missing `verdicts` key, invalid verdict variant
- [x] Database tests: all verdicts applied, empty batch, no-match returns zeros, idempotency (first call wins), mixed recall_ids across batches, recall_stats integration
- [x] All 263 existing tests pass (`cargo nextest run`)
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo doc --no-deps`, `cargo check --features k8s` all clean

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)