### PR TITLE
chore: release v0.15.0

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,5 +2,5 @@
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = "test(candle_embedding::) | test(auth::memory_mcp_bind)"
+filter = "binary(candle_embedding) | (binary(auth) & test(memory_mcp_bind))"
 test-group = "embedding"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[test-groups.embedding]
+max-threads = 1
+
+[[profile.default.overrides]]
+filter = "test(candle_embedding::) | test(auth::memory_mcp_bind)"
+test-group = "embedding"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/huggingface
-          key: hf-model-${{ hashFiles('src/embedding.rs') }}
+          key: hf-model-${{ hashFiles('src/embedding/**') }}
       - name: Install cargo-nextest
         run: |
           curl -fsSL "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.136/cargo-nextest-0.9.136-x86_64-unknown-linux-gnu.tar.gz" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [0.15.0] - 2026-06-26
+
+### Added
+
+- `move` MCP tool — relocate memories between scopes, preserving content and metadata (#268)
+- `batch_mark_applied` MCP tool — submit multiple recall verdicts in a single call for multi-verdict recall feedback (#279)
+
+### Changed
+
+- Consolidate agent instructions into AGENTS.md (#269)
+- Remove private repo references from ROADMAP.md (#263)
+
+### Dependencies
+
+- Bump the rust-dependencies group with 2 updates (#265)
+- Bump the actions group with 7 updates (#264)
+- Batch dependabot dependency updates (#280)
+
 ## [0.14.0] - 2026-05-25
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -324,7 +324,12 @@ async fn memory_mcp_bind_env_var_sets_listen_address() {
     let client = reqwest::Client::new();
     let healthz_url = format!("http://{bind}/healthz");
     let mut ready = false;
-    for _ in 0..100 {
+    // The server loads the embedding model synchronously before binding the
+    // HTTP listener, so /healthz is unreachable until model load completes. On
+    // a cold HuggingFace cache that includes downloading ~130 MB, which can take
+    // tens of seconds on a loaded CI runner. Budget 60s to match the embedding
+    // integration tests' TEST_TIMEOUT.
+    for _ in 0..600 {
         if let Ok(resp) = client.get(&healthz_url).send().await {
             if resp.status().is_success() {
                 ready = true;


### PR DESCRIPTION
## Summary

- Bump version to 0.15.0 in Cargo.toml and Cargo.lock
- Update CHANGELOG.md with all changes since v0.14.0

**New since v0.14.0:**
- `move` MCP tool — relocate memories between scopes, preserving content and metadata (#268)
- `batch_mark_applied` MCP tool — submit multiple recall verdicts in a single call (#279)
- Consolidate agent instructions into AGENTS.md (#269)
- Remove private repo references from ROADMAP.md (#263)
- Dependency updates: rust-dependencies (#265, #280), CI actions (#264)

## Test plan

- [ ] CI passes (fmt, clippy, tests, semver-checks)
- [ ] Verify CHANGELOG entries match git log
- [ ] Tag release pipeline triggers correctly after merge