### PR TITLE
feat: per-scope remote mapping for sync (#292)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitpacking"
@@ -296,9 +302,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "candle-core"
@@ -370,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -400,9 +406,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -480,9 +486,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -648,7 +654,7 @@ dependencies = [
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash 0.2.0",
+ "foldhash",
  "link-cplusplus",
 ]
 
@@ -811,6 +817,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1079,12 +1117,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1372,16 +1404,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1390,7 +1420,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1401,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1435,22 +1465,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -1461,7 +1482,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1557,9 +1578,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1588,11 +1609,11 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -1738,12 +1759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,15 +1793,13 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1833,10 +1846,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1846,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1867,13 +1881,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2015,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -2034,9 +2047,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -2102,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2182,15 +2195,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",
@@ -2272,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2397,7 +2410,7 @@ version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2419,7 +2432,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2452,9 +2465,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
@@ -2496,7 +2509,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -2755,10 +2768,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
@@ -2775,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2785,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2798,18 +2811,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2824,15 +2837,15 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2850,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2885,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2932,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2996,7 +3009,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3042,7 +3055,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3078,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3101,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3126,7 +3139,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.3",
+ "rustls-native-certs 0.8.4",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3141,14 +3154,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3191,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3222,9 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3249,7 +3262,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3289,7 +3302,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3298,9 +3311,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -3326,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -3347,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3460,7 +3473,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3473,7 +3486,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3655,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3692,15 +3705,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3780,9 +3793,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3826,7 +3839,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -3989,7 +4002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4055,12 +4068,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "0e48db7b415311b615f910b3dcaa4557bcd4bf1982379c95c223fd8c2a20e210"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4070,15 +4082,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4354,7 +4366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -4478,9 +4490,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -4529,21 +4541,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -4604,7 +4610,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4672,7 +4678,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4723,27 +4729,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4754,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4764,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4774,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4787,52 +4784,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4854,14 +4817,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5132,15 +5095,6 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
@@ -5232,9 +5186,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5255,18 +5209,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5296,18 +5250,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -670,7 +670,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -702,7 +702,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -755,7 +755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -845,7 +845,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -854,7 +854,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -876,7 +875,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -886,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -907,7 +906,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -949,7 +948,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1010,7 +1009,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1214,7 +1213,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1866,7 +1865,7 @@ checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1998,12 +1997,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "levenshtein_automata"
@@ -2313,7 +2306,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2448,7 +2441,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2524,7 +2517,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "thiserror 2.0.19",
  "tokio",
  "tonic",
@@ -2674,7 +2667,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2704,7 +2697,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2768,13 +2761,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2806,7 +2821,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3086,7 +3101,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3243,7 +3258,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3443,7 +3458,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3563,7 +3578,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3830,7 +3845,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4043,7 +4058,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4213,7 +4228,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4412,7 +4427,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4515,7 +4530,7 @@ checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4778,7 +4793,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -4881,7 +4896,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4892,7 +4907,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5100,85 +5115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5203,7 +5139,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5224,7 +5160,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5244,7 +5180,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5265,7 +5201,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5298,7 +5234,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
  "tokenizers 0.23.1",
  "tokio",
  "tokio-util",
+ "toml",
  "tower",
  "tracing",
  "tracing-opentelemetry",
@@ -3586,6 +3587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,6 +4238,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -5069,6 +5120,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tantivy = "0.26"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
+toml = "0.8"
 # Maintained fork of deprecated serde_yaml (dtolnay archived the original).
 serde_yaml_ng = "0.10"
 # Disable default features to trim unused chrono subsystems; clock provides

--- a/docs/adr/0038-per-scope-remote-mapping.md
+++ b/docs/adr/0038-per-scope-remote-mapping.md
@@ -1,0 +1,34 @@
+# ADR-0038: Per-scope remote mapping for sync
+
+## Status
+Accepted
+
+## Context
+memory-mcp uses a single git repo (`~/.memory-mcp`) with a single `origin` remote. All scopes share the same remote. This prevents constructs from isolating proprietary data: a construct working with NDA-covered code needs memories in certain scopes to sync to a private repo, while personal and shared memories continue syncing to the existing shared repos.
+
+Two memory-mcp instances would technically work but destroy the single-recall UX — constructs must remember which server to query, need two recall calls at boot, and face decision fatigue on every save. Behavioral discipline ("just don't write secrets to shared scopes") is structure-over-willpower in reverse.
+
+## Decision
+Support multiple independent git repos, one per configured scope mapping, with a unified read layer. A TOML config file (`~/.config/memory-mcp/config.toml` or `MEMORY_MCP_CONFIG`) defines scope-to-repo mappings:
+
+```toml
+[[remotes]]
+scope = "work"
+url = "git@github.com:private-org/memory-work.git"
+path = "~/.memory-mcp-work"
+```
+
+A new `RepoRouter` type holds a default `MemoryRepo` (the existing single-repo path) plus zero or more scope-mapped repos. Write operations (`save`, `delete`, `move`, `edit`) route to the repo that owns the scope. Read operations (`list`, `recall`) aggregate across all repos. `sync` pushes/pulls each repo independently.
+
+When no config file exists, behavior is identical to today: one repo, one remote.
+
+### Alternatives considered
+- **Single repo, multiple remotes with selective push:** Git doesn't natively support pushing a directory subset to a specific remote. Would require git-filter-branch or subtree splits — fragile and complex.
+- **Git submodules per scope:** Adds operational complexity (submodule init, recursive operations) for a use case that doesn't need shared history across scopes.
+
+## Consequences
+- Config file is optional — no breaking change for existing deployments
+- Each scope-mapped repo gets its own vector index subdirectory
+- `move` across repo boundaries requires delete-from-source + create-in-destination (not a single git commit)
+- Auth token must have access to all configured remotes
+- Health reporting aggregates across repos — any repo failure degrades the subsystem

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,7 @@ authoritative list.
 |---|---|---|---|
 | `--bind` | `MEMORY_MCP_BIND` | `127.0.0.1:8080` | HTTP listener address |
 | `--repo-path` | `MEMORY_MCP_REPO_PATH` | `~/.memory-mcp` | Git-backed memory repository |
+| `--config` | `MEMORY_MCP_CONFIG` | `~/.config/memory-mcp/config.toml` | TOML config file for per-scope remote mapping; empty string disables config loading |
 | `--mcp-path` | `MEMORY_MCP_PATH` | `/mcp` | Streamable HTTP MCP path |
 | `--remote-url` | `MEMORY_MCP_REMOTE_URL` | unset | Git remote; omit for local-only mode |
 | `--branch` | `MEMORY_MCP_BRANCH` | `main` | Branch used for push and pull |

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,212 @@
+//! Configuration file parsing for per-scope remote mapping.
+//!
+//! When a config file exists (`~/.config/memory-mcp/config.toml` or the path
+//! in `MEMORY_MCP_CONFIG`), it defines scope-to-repo mappings that route
+//! specific scopes to dedicated git repositories with their own remotes.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use tracing::info;
+
+use crate::error::MemoryError;
+
+/// A single scope-to-repo mapping from the config file.
+#[derive(Debug, Clone, Deserialize)]
+#[non_exhaustive]
+pub struct RemoteMapping {
+    /// Scope prefix that this mapping captures (e.g. `"work"` or `"org/team"`).
+    pub scope: String,
+    /// Git remote URL for this scope's repo.
+    pub url: String,
+    /// Local path for the git repo. Supports `~` expansion.
+    /// Defaults to `~/.memory-mcp-{scope}` if omitted.
+    pub path: Option<String>,
+    /// Branch name for push/pull. Defaults to the server-wide branch if omitted.
+    pub branch: Option<String>,
+}
+
+/// Top-level config file structure.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[non_exhaustive]
+pub struct Config {
+    /// Per-scope remote mappings.
+    #[serde(default)]
+    pub remotes: Vec<RemoteMapping>,
+}
+
+impl Config {
+    /// Load config from the given path, returning `Config::default()` if the
+    /// file does not exist.
+    pub fn load(path: &Path) -> Result<Self, MemoryError> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            MemoryError::Internal(format!(
+                "failed to read config file {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        let config: Config = toml::from_str(&content).map_err(|e| {
+            MemoryError::Internal(format!(
+                "failed to parse config file {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+        info!(
+            path = %path.display(),
+            remotes = config.remotes.len(),
+            "loaded config"
+        );
+        Ok(config)
+    }
+
+    /// Resolve the config file path from the environment or default location.
+    ///
+    /// Resolution order:
+    /// 1. `MEMORY_MCP_CONFIG` environment variable
+    /// 2. `~/.config/memory-mcp/config.toml`
+    pub fn resolve_path() -> Result<PathBuf, MemoryError> {
+        if let Ok(env_path) = std::env::var("MEMORY_MCP_CONFIG") {
+            return Ok(PathBuf::from(env_path));
+        }
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| MemoryError::Internal("could not determine config directory".into()))?;
+        Ok(config_dir.join("memory-mcp").join("config.toml"))
+    }
+}
+
+impl RemoteMapping {
+    /// Resolve the local repo path, expanding `~` and applying defaults.
+    pub fn resolved_path(&self) -> Result<PathBuf, MemoryError> {
+        match &self.path {
+            Some(p) => expand_tilde(p),
+            None => {
+                let home = dirs::home_dir().ok_or_else(|| {
+                    MemoryError::Internal("could not determine home directory".into())
+                })?;
+                let dir_name = format!(".memory-mcp-{}", self.scope.replace('/', "-"));
+                Ok(home.join(dir_name))
+            }
+        }
+    }
+}
+
+/// Expand leading `~` to the user's home directory.
+fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
+    match path.strip_prefix('~') {
+        Some(rest) if rest.is_empty() || rest.starts_with('/') => {
+            let home = dirs::home_dir().ok_or_else(|| {
+                MemoryError::Internal("could not expand '~': home directory unknown".into())
+            })?;
+            Ok(home.join(rest.strip_prefix('/').unwrap_or(rest)))
+        }
+        Some(_) => Err(MemoryError::Internal(
+            "~user expansion is not supported; use an absolute path or ~/...".into(),
+        )),
+        None => Ok(PathBuf::from(path)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_config() {
+        let toml = r#"
+[[remotes]]
+scope = "work"
+url = "git@github.com:org/repo.git"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.remotes.len(), 1);
+        assert_eq!(config.remotes[0].scope, "work");
+        assert_eq!(config.remotes[0].url, "git@github.com:org/repo.git");
+        assert!(config.remotes[0].path.is_none());
+        assert!(config.remotes[0].branch.is_none());
+    }
+
+    #[test]
+    fn parse_full_config() {
+        let toml = r#"
+[[remotes]]
+scope = "work"
+url = "git@github.com:org/repo.git"
+path = "~/.memory-mcp-work"
+branch = "main"
+
+[[remotes]]
+scope = "org/team"
+url = "git@github.com:org/team-memories.git"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.remotes.len(), 2);
+        assert_eq!(
+            config.remotes[0].path.as_deref(),
+            Some("~/.memory-mcp-work")
+        );
+        assert_eq!(config.remotes[0].branch.as_deref(), Some("main"));
+        assert_eq!(config.remotes[1].scope, "org/team");
+    }
+
+    #[test]
+    fn empty_config_has_no_remotes() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.remotes.is_empty());
+    }
+
+    #[test]
+    fn default_path_uses_scope() {
+        let mapping = RemoteMapping {
+            scope: "work".to_string(),
+            url: "https://example.com/repo.git".to_string(),
+            path: None,
+            branch: None,
+        };
+        let resolved = mapping.resolved_path().unwrap();
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(resolved, home.join(".memory-mcp-work"));
+    }
+
+    #[test]
+    fn default_path_replaces_slashes() {
+        let mapping = RemoteMapping {
+            scope: "org/team".to_string(),
+            url: "https://example.com/repo.git".to_string(),
+            path: None,
+            branch: None,
+        };
+        let resolved = mapping.resolved_path().unwrap();
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(resolved, home.join(".memory-mcp-org-team"));
+    }
+
+    #[test]
+    fn expand_tilde_home() {
+        let result = expand_tilde("~/foo/bar").unwrap();
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(result, home.join("foo/bar"));
+    }
+
+    #[test]
+    fn expand_tilde_absolute_passthrough() {
+        let result = expand_tilde("/tmp/repo").unwrap();
+        assert_eq!(result, PathBuf::from("/tmp/repo"));
+    }
+
+    #[test]
+    fn expand_tilde_user_rejected() {
+        let result = expand_tilde("~otheruser/path");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_missing_file_returns_default() {
+        let config = Config::load(Path::new("/nonexistent/path/config.toml")).unwrap();
+        assert!(config.remotes.is_empty());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,14 +58,12 @@ impl Config {
             ))
         })?;
         for mapping in &config.remotes {
-            ScopePath::new(&mapping.scope).map_err(|_| {
-                MemoryError::InvalidInput {
-                    reason: format!(
-                        "invalid scope '{}' in config file {}",
-                        mapping.scope,
-                        path.display()
-                    ),
-                }
+            ScopePath::new(&mapping.scope).map_err(|_| MemoryError::InvalidInput {
+                reason: format!(
+                    "invalid scope '{}' in config file {}",
+                    mapping.scope,
+                    path.display()
+                ),
             })?;
         }
         info!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use tracing::info;
 
 use crate::error::MemoryError;
+use crate::types::ScopePath;
 
 /// A single scope-to-repo mapping from the config file.
 #[derive(Debug, Clone, Deserialize)]
@@ -56,6 +57,17 @@ impl Config {
                 e
             ))
         })?;
+        for mapping in &config.remotes {
+            ScopePath::new(&mapping.scope).map_err(|_| {
+                MemoryError::InvalidInput {
+                    reason: format!(
+                        "invalid scope '{}' in config file {}",
+                        mapping.scope,
+                        path.display()
+                    ),
+                }
+            })?;
+        }
         info!(
             path = %path.display(),
             remotes = config.remotes.len(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,21 @@ impl Config {
                     path.display()
                 ),
             })?;
+            // Every mapped branch is validated, not just the server-wide
+            // default (#293 review, round 3): an invalid override must be
+            // rejected here, not discovered at the first push/pull.
+            if let Some(branch) = &mapping.branch {
+                crate::types::validate_branch_name(branch).map_err(|_| {
+                    MemoryError::InvalidInput {
+                        reason: format!(
+                            "invalid branch '{}' for scope '{}' in config file {}",
+                            branch,
+                            mapping.scope,
+                            path.display()
+                        ),
+                    }
+                })?;
+            }
         }
         info!(
             path = %path.display(),
@@ -203,5 +218,35 @@ url = "git@github.com:org/team-memories.git"
     fn load_missing_file_returns_default() {
         let config = Config::load(Path::new("/nonexistent/path/config.toml")).unwrap();
         assert!(config.remotes.is_empty());
+    }
+
+    /// Every mapped branch is validated at config load (#293 review,
+    /// round 3) — an invalid override must be rejected here, not discovered
+    /// at the first push/pull against that repo.
+    #[test]
+    fn load_rejects_invalid_mapped_branch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[[remotes]]
+scope = "ok"
+url = "https://example.com/ok.git"
+branch = "main"
+
+[[remotes]]
+scope = "work"
+url = "https://example.com/repo.git"
+branch = "bad..branch"
+"#,
+        )
+        .unwrap();
+        let err = Config::load(&path).expect_err("an invalid mapped branch must fail the load");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bad..branch") && msg.contains("work"),
+            "the error must name the offending branch and scope: {msg}"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use tracing::info;
 
 use crate::error::MemoryError;
+use crate::fs_util::expand_tilde;
 use crate::types::ScopePath;
 
 /// A single scope-to-repo mapping from the config file.
@@ -102,22 +103,6 @@ impl RemoteMapping {
                 Ok(home.join(dir_name))
             }
         }
-    }
-}
-
-/// Expand leading `~` to the user's home directory.
-fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
-    match path.strip_prefix('~') {
-        Some(rest) if rest.is_empty() || rest.starts_with('/') => {
-            let home = dirs::home_dir().ok_or_else(|| {
-                MemoryError::Internal("could not expand '~': home directory unknown".into())
-            })?;
-            Ok(home.join(rest.strip_prefix('/').unwrap_or(rest)))
-        }
-        Some(_) => Err(MemoryError::Internal(
-            "~user expansion is not supported; use an absolute path or ~/...".into(),
-        )),
-        None => Ok(PathBuf::from(path)),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,8 @@ pub struct RemoteMapping {
     /// Git remote URL for this scope's repo.
     pub url: String,
     /// Local path for the git repo. Supports `~` expansion.
-    /// Defaults to `~/.memory-mcp-{scope}` if omitted.
+    /// Defaults to `~/.memory-mcp-{scope}` if omitted, with `/` in the scope
+    /// encoded as `%2F` so distinct scopes always default to distinct paths.
     pub path: Option<String>,
     /// Branch name for push/pull. Defaults to the server-wide branch if omitted.
     pub branch: Option<String>,
@@ -114,7 +115,12 @@ impl RemoteMapping {
                 let home = dirs::home_dir().ok_or_else(|| {
                     MemoryError::Internal("could not determine home directory".into())
                 })?;
-                let dir_name = format!(".memory-mcp-{}", self.scope.replace('/', "-"));
+                // Encode `/` as `%2F`. Scope components cannot contain `%`,
+                // so this is injective: mapping `/` to `-` made the scopes
+                // `org/team` and `org-team` collide on the same default path
+                // — and therefore the same physical repo (#293 review,
+                // round 4).
+                let dir_name = format!(".memory-mcp-{}", self.scope.replace('/', "%2F"));
                 Ok(home.join(dir_name))
             }
         }
@@ -183,7 +189,7 @@ url = "git@github.com:org/team-memories.git"
     }
 
     #[test]
-    fn default_path_replaces_slashes() {
+    fn default_path_encodes_slashes() {
         let mapping = RemoteMapping {
             scope: "org/team".to_string(),
             url: "https://example.com/repo.git".to_string(),
@@ -192,7 +198,26 @@ url = "git@github.com:org/team-memories.git"
         };
         let resolved = mapping.resolved_path().unwrap();
         let home = dirs::home_dir().unwrap();
-        assert_eq!(resolved, home.join(".memory-mcp-org-team"));
+        assert_eq!(resolved, home.join(".memory-mcp-org%2Fteam"));
+    }
+
+    /// Default path encoding must be injective (#293 review, round 4):
+    /// mapping `/` to `-` sent the scopes `org/team` and `org-team` to the
+    /// same default path, so two nominally isolated scopes shared one
+    /// physical repo under separate mutexes.
+    #[test]
+    fn default_paths_distinguish_slash_from_dash_scopes() {
+        let path_for = |scope: &str| {
+            RemoteMapping {
+                scope: scope.to_string(),
+                url: "https://example.com/repo.git".to_string(),
+                path: None,
+                branch: None,
+            }
+            .resolved_path()
+            .unwrap()
+        };
+        assert_ne!(path_for("org/team"), path_for("org-team"));
     }
 
     #[test]

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -47,6 +47,16 @@ pub fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
 /// keeps previously valid spellings like `existing/missing/../repo`
 /// working (#293 review, round 6; ADR-0038 compatibility).
 ///
+/// "Missing" means **proven absent**: at each step of the upward walk a
+/// component joins the missing suffix only if `symlink_metadata` fails
+/// with `NotFound`. A component that *exists* but cannot be resolved — a
+/// regular file where a directory is needed, a dangling symlink, a
+/// permission-denied directory — is an error preserving the underlying
+/// [`std::io::ErrorKind`], never silently reclassified as missing (#293
+/// review, round 7: `file/../repo` used to fail with `ENOTDIR` at
+/// `create_dir_all`; treating the unresolvable prefix as missing would
+/// lexically cancel the `..` and silently redirect to sibling `repo`).
+///
 /// A `..` that leads the missing suffix climbs into the canonicalized
 /// ancestor instead. That is also resolved lexically — safe because the
 /// ancestor is already fully resolved, so its lexical parent is its
@@ -86,32 +96,79 @@ pub fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
     let canonical_base = loop {
         match base.canonicalize() {
             Ok(resolved) => break resolved,
-            Err(_) => match (base.file_name(), base.parent()) {
-                (Some(name), Some(parent)) => {
-                    tail.push(Tail::Normal(name.to_os_string()));
-                    base = parent;
+            Err(canonicalize_err) => {
+                // `canonicalize` failing does NOT prove `base` is missing
+                // (#293 review, round 7): it also fails when the path
+                // *exists* but cannot resolve — a regular file in
+                // directory position, a dangling symlink, a
+                // permission-denied directory. Classifying those as
+                // missing would lexically cancel a later `..` against a
+                // component the filesystem would have interpreted
+                // differently (or refused), silently redirecting to a
+                // sibling path. Only a `NotFound` from `symlink_metadata`
+                // proves absence; anything else fails closed, preserving
+                // the underlying error kind.
+                match std::fs::symlink_metadata(base) {
+                    Ok(_) => {
+                        // The component itself exists (lstat succeeded)
+                        // yet cannot be canonicalized — e.g. a dangling
+                        // symlink whose target is gone.
+                        return Err(MemoryError::Io(std::io::Error::new(
+                            canonicalize_err.kind(),
+                            format!(
+                                "path component '{}' exists but cannot be resolved \
+                                 (while canonicalizing '{}'): {canonicalize_err}",
+                                base.display(),
+                                absolute.display(),
+                            ),
+                        )));
+                    }
+                    Err(meta_err) if meta_err.kind() == std::io::ErrorKind::NotFound => {
+                        // Proven absent — record the component below and
+                        // keep walking upward.
+                    }
+                    Err(meta_err) => {
+                        // Exists-but-untraversable prefix: a regular file
+                        // where a directory is needed (`NotADirectory`),
+                        // permission denied, etc.
+                        return Err(MemoryError::Io(std::io::Error::new(
+                            meta_err.kind(),
+                            format!(
+                                "cannot access path component '{}' \
+                                 (while canonicalizing '{}'): {meta_err}",
+                                base.display(),
+                                absolute.display(),
+                            ),
+                        )));
+                    }
                 }
-                // `file_name()` returns `None` when `base` terminates in
-                // `..` (a bare root always canonicalizes, so it cannot
-                // reach the `Err` arm). Had the prefix before this `..`
-                // existed as a directory, `canonicalize` would have
-                // resolved the pair through the filesystem; since it
-                // failed, the `..` sits on a non-existent (or
-                // non-directory) prefix with no symlink to reinterpret
-                // it, so it is safe to cancel lexically during rebuild.
-                (None, Some(parent)) => {
-                    tail.push(Tail::Parent);
-                    base = parent;
+                match (base.file_name(), base.parent()) {
+                    (Some(name), Some(parent)) => {
+                        tail.push(Tail::Normal(name.to_os_string()));
+                        base = parent;
+                    }
+                    // `file_name()` returns `None` when `base` terminates
+                    // in `..` (a bare root always canonicalizes, so it
+                    // cannot reach the `Err` arm). The metadata check
+                    // above proved this `..`-terminated path names
+                    // nothing: its prefix is absent (a file or dangling
+                    // symlink in the prefix errors out instead), so
+                    // there is no symlink to reinterpret the `..` and it
+                    // is safe to cancel lexically during rebuild.
+                    (None, Some(parent)) => {
+                        tail.push(Tail::Parent);
+                        base = parent;
+                    }
+                    _ => {
+                        return Err(MemoryError::InvalidInput {
+                            reason: format!(
+                                "cannot resolve any existing ancestor of path '{}'",
+                                absolute.display()
+                            ),
+                        });
+                    }
                 }
-                _ => {
-                    return Err(MemoryError::InvalidInput {
-                        reason: format!(
-                            "cannot resolve any existing ancestor of path '{}'",
-                            absolute.display()
-                        ),
-                    });
-                }
-            },
+            }
         }
     };
 
@@ -452,6 +509,62 @@ mod tests {
         assert_eq!(
             canonicalize_allow_missing(&alias.join("sub")).unwrap(),
             canonicalize_allow_missing(&real.join("sub")).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_file_in_prefix_fails_closed_not_redirected() {
+        // Syne's round-7 repro: `file/../repo1` where `file` is an existing
+        // regular file. Before startup canonicalization, `create_dir_all`
+        // failed with ENOTDIR; classifying the unresolvable prefix as
+        // "missing" would lexically cancel the `..` and silently redirect
+        // to sibling `repo1`. The helper must fail closed instead,
+        // preserving the underlying error kind.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("file"), b"plain file").unwrap();
+
+        let spelled = dir.path().join("file/../repo1");
+        let err = canonicalize_allow_missing(&spelled).unwrap_err();
+        match &err {
+            MemoryError::Io(io_err) => assert_eq!(
+                io_err.kind(),
+                std::io::ErrorKind::NotADirectory,
+                "must preserve the underlying error kind: {io_err}"
+            ),
+            other => panic!("expected MemoryError::Io, got: {other}"),
+        }
+        assert!(
+            err.to_string().contains("cannot access path component"),
+            "error must name the unresolvable component: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn broken_symlink_in_prefix_fails_closed_not_redirected() {
+        // Syne's round-7 repro: `broken/../repo2` where `broken` is a
+        // dangling symlink. Traversal used to fail at open time; treating
+        // the existing-but-unresolvable symlink as missing would return
+        // sibling `repo2` — a silent redirect that startup would then open
+        // as a different (possibly empty) repo. The helper must fail
+        // closed on the existing symlink instead.
+        let dir = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(dir.path().join("nowhere"), dir.path().join("broken")).unwrap();
+
+        let spelled = dir.path().join("broken/../repo2");
+        let err = canonicalize_allow_missing(&spelled).unwrap_err();
+        match &err {
+            MemoryError::Io(io_err) => assert_eq!(
+                io_err.kind(),
+                std::io::ErrorKind::NotFound,
+                "canonicalize of a dangling symlink fails NotFound: {io_err}"
+            ),
+            other => panic!("expected MemoryError::Io, got: {other}"),
+        }
+        assert!(
+            err.to_string().contains("exists but cannot be resolved"),
+            "error must state the component exists but is unresolvable: {err}"
         );
     }
 

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -26,6 +26,76 @@ pub fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
     }
 }
 
+/// Resolve a path to a canonical absolute form, tolerating missing suffixes.
+///
+/// `std::fs::canonicalize` fails when the path does not exist yet, but repo
+/// paths are frequently created only by the init that follows a collision
+/// check. This canonicalizes the deepest existing ancestor (resolving
+/// symlinks) and appends the remaining components, so two spellings of the
+/// same physical location — via symlinks, `.`/`..` segments, or a
+/// not-yet-created tail — resolve to the same value (#293 review, round 4).
+///
+/// `.` and `..` components are normalized lexically before canonicalization;
+/// this is sound here because the non-existing tail contains no symlinks to
+/// mis-resolve, and a lexical mismatch only ever rejects a config, never
+/// silently merges two repos.
+pub(crate) fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
+    use std::path::Component;
+
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| {
+                MemoryError::Internal(format!("cannot resolve current working directory: {e}"))
+            })?
+            .join(path)
+    };
+
+    // Lexically normalize `.` and `..` so the ancestor walk below only ever
+    // sees plain named components.
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other),
+        }
+    }
+
+    // Walk up to the deepest existing ancestor, canonicalize it, then
+    // re-append the missing tail.
+    let mut base = normalized.as_path();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let canonical_base = loop {
+        match base.canonicalize() {
+            Ok(resolved) => break resolved,
+            Err(_) => match (base.file_name(), base.parent()) {
+                (Some(name), Some(parent)) => {
+                    tail.push(name.to_os_string());
+                    base = parent;
+                }
+                _ => {
+                    return Err(MemoryError::InvalidInput {
+                        reason: format!(
+                            "cannot resolve any existing ancestor of path '{}'",
+                            normalized.display()
+                        ),
+                    });
+                }
+            },
+        }
+    };
+
+    let mut resolved = canonical_base;
+    for component in tail.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
 /// RAII guard that removes a temp file on drop unless defused.
 struct TempGuard<'a> {
     path: &'a Path,
@@ -218,6 +288,53 @@ mod tests {
 
         let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600, "overwritten file should be 0600, got {mode:o}");
+    }
+
+    // -- canonicalize_allow_missing (#293 review, round 4) -----------------
+    //
+    // Repo-path collision detection depends on distinct spellings of the
+    // same physical location resolving identically, including paths whose
+    // tail does not exist yet.
+
+    #[test]
+    fn canonicalize_allow_missing_resolves_missing_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().canonicalize().unwrap();
+        let missing = dir.path().join("not-yet/created");
+        let resolved = canonicalize_allow_missing(&missing).unwrap();
+        assert_eq!(resolved, existing.join("not-yet/created"));
+    }
+
+    #[test]
+    fn canonicalize_allow_missing_normalizes_dot_segments() {
+        let dir = tempfile::tempdir().unwrap();
+        let spelled = dir.path().join("a/../b/./c");
+        let plain = dir.path().join("b/c");
+        assert_eq!(
+            canonicalize_allow_missing(&spelled).unwrap(),
+            canonicalize_allow_missing(&plain).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_allow_missing_resolves_symlink_aliases() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        fs::create_dir(&real).unwrap();
+        let alias = dir.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+
+        // Both an existing symlink and a missing tail beneath it resolve to
+        // the physical location.
+        assert_eq!(
+            canonicalize_allow_missing(&alias).unwrap(),
+            canonicalize_allow_missing(&real).unwrap()
+        );
+        assert_eq!(
+            canonicalize_allow_missing(&alias.join("sub")).unwrap(),
+            canonicalize_allow_missing(&real.join("sub")).unwrap()
+        );
     }
 
     #[cfg(unix)]

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -30,16 +30,22 @@ pub fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
 ///
 /// `std::fs::canonicalize` fails when the path does not exist yet, but repo
 /// paths are frequently created only by the init that follows a collision
-/// check. This canonicalizes the deepest existing ancestor (resolving
-/// symlinks) and appends the remaining components, so two spellings of the
-/// same physical location — via symlinks, `.`/`..` segments, or a
-/// not-yet-created tail — resolve to the same value (#293 review, round 4).
+/// check. This canonicalizes the deepest **existing** ancestor of the
+/// unnormalized path — letting the OS resolve symlinks and `..` together —
+/// then appends the genuinely missing components, so two spellings of the
+/// same physical location resolve to the same value (#293 review, rounds
+/// 4–6).
 ///
-/// `.` and `..` components are normalized lexically before canonicalization;
-/// this is sound here because the non-existing tail contains no symlinks to
-/// mis-resolve, and a lexical mismatch only ever rejects a config, never
-/// silently merges two repos.
-pub(crate) fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
+/// `..` is never stripped lexically: in `link/../x` where `link` is a
+/// symlink, the `..` resolves against the symlink *target*, so only the
+/// filesystem may interpret a `..` that touches anything existing. A `..`
+/// inside the missing tail has no filesystem meaning yet, so it is rejected
+/// with an error rather than guessed at lexically (#293 review, round 5).
+///
+/// Public because the server binary must canonicalize the default repo path
+/// with the exact same rules *before* opening it, so the opened location and
+/// the router's collision-detection key can never diverge.
+pub fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
     use std::path::Component;
 
     let absolute = if path.is_absolute() {
@@ -52,38 +58,40 @@ pub(crate) fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryE
             .join(path)
     };
 
-    // Lexically normalize `.` and `..` so the ancestor walk below only ever
-    // sees plain named components.
-    let mut normalized = PathBuf::new();
-    for component in absolute.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            other => normalized.push(other),
-        }
-    }
-
-    // Walk up to the deepest existing ancestor, canonicalize it, then
-    // re-append the missing tail.
-    let mut base = normalized.as_path();
+    // Walk up to the deepest existing ancestor of the *unnormalized* path,
+    // canonicalize it, then re-append the missing tail. `..` components in
+    // the existing portion are resolved by `canonicalize` itself; `.` is
+    // identity and is normalized away by `file_name`/`parent`.
+    let mut base = absolute.as_path();
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
     let canonical_base = loop {
         match base.canonicalize() {
             Ok(resolved) => break resolved,
+            // `file_name()` returns `None` when `base` is a bare root or
+            // terminates in `..`. Since `base` failed to canonicalize, a
+            // trailing `..` here sits on top of a non-existent path — there
+            // is no filesystem entry to resolve it against.
             Err(_) => match (base.file_name(), base.parent()) {
                 (Some(name), Some(parent)) => {
                     tail.push(name.to_os_string());
                     base = parent;
                 }
                 _ => {
-                    return Err(MemoryError::InvalidInput {
-                        reason: format!(
-                            "cannot resolve any existing ancestor of path '{}'",
-                            normalized.display()
-                        ),
-                    });
+                    let reason =
+                        if matches!(base.components().next_back(), Some(Component::ParentDir)) {
+                            format!(
+                                "path '{}' uses '..' inside a non-existent segment, which \
+                                 cannot be resolved against the filesystem; spell the path \
+                                 without '..' or create the intermediate directories first",
+                                absolute.display()
+                            )
+                        } else {
+                            format!(
+                                "cannot resolve any existing ancestor of path '{}'",
+                                absolute.display()
+                            )
+                        };
+                    return Err(MemoryError::InvalidInput { reason });
                 }
             },
         }
@@ -306,13 +314,59 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_allow_missing_normalizes_dot_segments() {
+    fn canonicalize_allow_missing_resolves_existing_dot_segments() {
+        // `..` over an *existing* directory is resolved by the filesystem,
+        // and a missing tail may still follow it.
         let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("a")).unwrap();
         let spelled = dir.path().join("a/../b/./c");
         let plain = dir.path().join("b/c");
         assert_eq!(
             canonicalize_allow_missing(&spelled).unwrap(),
             canonicalize_allow_missing(&plain).unwrap()
+        );
+    }
+
+    #[test]
+    fn canonicalize_allow_missing_rejects_dot_dot_in_missing_tail() {
+        // A `..` on top of a non-existent segment has no filesystem meaning;
+        // resolving it lexically would guess. It must be rejected, not
+        // normalized (#293 review, round 5).
+        let dir = tempfile::tempdir().unwrap();
+        let spelled = dir.path().join("missing/../repo");
+        let err = canonicalize_allow_missing(&spelled).unwrap_err();
+        assert!(
+            err.to_string().contains(".."),
+            "error must name the '..' problem: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_allow_missing_resolves_dot_dot_against_symlink_target() {
+        // Syne's round-5 repro: base/link -> else/dir. On a real filesystem
+        // base/link/../repo traverses to else/repo (`..` resolves against
+        // the symlink TARGET); a lexical normalization would answer
+        // base/repo, letting a mapped route at else/repo alias the same
+        // physical repo without tripping collision detection.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("base");
+        let else_dir = tmp.path().join("else");
+        fs::create_dir_all(else_dir.join("dir")).unwrap();
+        fs::create_dir(&base).unwrap();
+        std::os::unix::fs::symlink(else_dir.join("dir"), base.join("link")).unwrap();
+
+        let via_symlink = canonicalize_allow_missing(&base.join("link/../repo")).unwrap();
+        let direct = canonicalize_allow_missing(&else_dir.join("repo")).unwrap();
+        assert_eq!(
+            via_symlink, direct,
+            "`..` after a symlink must resolve against the target"
+        );
+
+        let lexical = canonicalize_allow_missing(&base.join("repo")).unwrap();
+        assert_ne!(
+            via_symlink, lexical,
+            "must not produce the lexical answer base/repo"
         );
     }
 

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -1,6 +1,30 @@
-//! Filesystem utilities — atomic writes with crash-safe temp-file-then-rename.
+//! Filesystem utilities — atomic writes, crash-safe temp-file-then-rename,
+//! and path helpers.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use crate::error::MemoryError;
+
+/// Expand a leading `~` to the user's home directory.
+///
+/// - `~/foo` → `$HOME/foo`
+/// - `~` alone → `$HOME`
+/// - `~user/...` → error (not supported)
+/// - Absolute or relative paths pass through unchanged.
+pub fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
+    match path.strip_prefix('~') {
+        Some(rest) if rest.is_empty() || rest.starts_with('/') => {
+            let home = dirs::home_dir().ok_or_else(|| {
+                MemoryError::Internal("could not expand '~': home directory unknown".into())
+            })?;
+            Ok(home.join(rest.strip_prefix('/').unwrap_or(rest)))
+        }
+        Some(_) => Err(MemoryError::Internal(
+            "~user expansion is not supported; use an absolute path or ~/...".into(),
+        )),
+        None => Ok(PathBuf::from(path)),
+    }
+}
 
 /// RAII guard that removes a temp file on drop unless defused.
 struct TempGuard<'a> {

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -36,17 +36,36 @@ pub fn expand_tilde(path: &str) -> Result<PathBuf, MemoryError> {
 /// same physical location resolve to the same value (#293 review, rounds
 /// 4–6).
 ///
-/// `..` is never stripped lexically: in `link/../x` where `link` is a
-/// symlink, the `..` resolves against the symlink *target*, so only the
-/// filesystem may interpret a `..` that touches anything existing. A `..`
-/// inside the missing tail has no filesystem meaning yet, so it is rejected
-/// with an error rather than guessed at lexically (#293 review, round 5).
+/// A `..` that touches anything *existing* is never stripped lexically: in
+/// `link/../x` where `link` is a symlink, the `..` resolves against the
+/// symlink target, so only the filesystem may interpret it (#293 review,
+/// round 5). A `..` inside the proven-missing suffix, however, *is*
+/// normalized lexically: nothing in that suffix exists, so it cannot
+/// contain a symlink, and the `..` can only cancel the missing component
+/// spelled before it — exactly what `create_dir_all` followed by kernel
+/// path resolution would have produced once the components existed. This
+/// keeps previously valid spellings like `existing/missing/../repo`
+/// working (#293 review, round 6; ADR-0038 compatibility).
+///
+/// A `..` that leads the missing suffix climbs into the canonicalized
+/// ancestor instead. That is also resolved lexically — safe because the
+/// ancestor is already fully resolved, so its lexical parent is its
+/// physical parent. A `..` that would climb above the filesystem root is
+/// an error.
 ///
 /// Public because the server binary must canonicalize the default repo path
 /// with the exact same rules *before* opening it, so the opened location and
 /// the router's collision-detection key can never diverge.
 pub fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
-    use std::path::Component;
+    /// One component of the not-yet-existing suffix, recorded during the
+    /// upward walk and replayed onto the canonicalized ancestor.
+    enum Tail {
+        /// A named component to re-append.
+        Normal(std::ffi::OsString),
+        /// A `..` proven to sit on a non-existent prefix; cancels one
+        /// component lexically during rebuild.
+        Parent,
+    }
 
     let absolute = if path.is_absolute() {
         path.to_path_buf()
@@ -63,43 +82,58 @@ pub fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, MemoryError> {
     // the existing portion are resolved by `canonicalize` itself; `.` is
     // identity and is normalized away by `file_name`/`parent`.
     let mut base = absolute.as_path();
-    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut tail: Vec<Tail> = Vec::new();
     let canonical_base = loop {
         match base.canonicalize() {
             Ok(resolved) => break resolved,
-            // `file_name()` returns `None` when `base` is a bare root or
-            // terminates in `..`. Since `base` failed to canonicalize, a
-            // trailing `..` here sits on top of a non-existent path — there
-            // is no filesystem entry to resolve it against.
             Err(_) => match (base.file_name(), base.parent()) {
                 (Some(name), Some(parent)) => {
-                    tail.push(name.to_os_string());
+                    tail.push(Tail::Normal(name.to_os_string()));
+                    base = parent;
+                }
+                // `file_name()` returns `None` when `base` terminates in
+                // `..` (a bare root always canonicalizes, so it cannot
+                // reach the `Err` arm). Had the prefix before this `..`
+                // existed as a directory, `canonicalize` would have
+                // resolved the pair through the filesystem; since it
+                // failed, the `..` sits on a non-existent (or
+                // non-directory) prefix with no symlink to reinterpret
+                // it, so it is safe to cancel lexically during rebuild.
+                (None, Some(parent)) => {
+                    tail.push(Tail::Parent);
                     base = parent;
                 }
                 _ => {
-                    let reason =
-                        if matches!(base.components().next_back(), Some(Component::ParentDir)) {
-                            format!(
-                                "path '{}' uses '..' inside a non-existent segment, which \
-                                 cannot be resolved against the filesystem; spell the path \
-                                 without '..' or create the intermediate directories first",
-                                absolute.display()
-                            )
-                        } else {
-                            format!(
-                                "cannot resolve any existing ancestor of path '{}'",
-                                absolute.display()
-                            )
-                        };
-                    return Err(MemoryError::InvalidInput { reason });
+                    return Err(MemoryError::InvalidInput {
+                        reason: format!(
+                            "cannot resolve any existing ancestor of path '{}'",
+                            absolute.display()
+                        ),
+                    });
                 }
             },
         }
     };
 
+    // Replay the missing suffix onto the canonicalized ancestor. `Parent`
+    // cancels either the missing component pushed just before it or — when
+    // the `..` leads the suffix — one component of the canonicalized
+    // ancestor, whose lexical parent is its physical parent.
     let mut resolved = canonical_base;
     for component in tail.iter().rev() {
-        resolved.push(component);
+        match component {
+            Tail::Normal(name) => resolved.push(name),
+            Tail::Parent => {
+                if !resolved.pop() {
+                    return Err(MemoryError::InvalidInput {
+                        reason: format!(
+                            "path '{}' uses '..' to climb above the filesystem root",
+                            absolute.display()
+                        ),
+                    });
+                }
+            }
+        }
     }
     Ok(resolved)
 }
@@ -328,16 +362,46 @@ mod tests {
     }
 
     #[test]
-    fn canonicalize_allow_missing_rejects_dot_dot_in_missing_tail() {
-        // A `..` on top of a non-existent segment has no filesystem meaning;
-        // resolving it lexically would guess. It must be rejected, not
-        // normalized (#293 review, round 5).
+    fn canonicalize_allow_missing_normalizes_dot_dot_in_missing_tail() {
+        // ADR-0038 compatibility (#293 review, round 6): before
+        // canonicalization was applied at startup, `existing/missing/../repo`
+        // worked — `create_dir_all` created `missing`, the kernel walked the
+        // `..` back out, and the repo landed at `existing/repo`. The missing
+        // suffix contains no symlinks (nothing in it exists), so the `..`
+        // cancels its preceding missing component lexically instead of
+        // aborting.
         let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().canonicalize().unwrap();
         let spelled = dir.path().join("missing/../repo");
+        assert_eq!(
+            canonicalize_allow_missing(&spelled).unwrap(),
+            existing.join("repo")
+        );
+    }
+
+    #[test]
+    fn canonicalize_allow_missing_resolves_leading_dot_dot_against_ancestor() {
+        // A `..` that leads the missing suffix climbs into the canonicalized
+        // ancestor. The ancestor is fully resolved, so its lexical parent is
+        // its physical parent — `dir/missing/../../repo` → parent-of-dir/repo.
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().canonicalize().unwrap();
+        let spelled = dir.path().join("missing/../../repo");
+        assert_eq!(
+            canonicalize_allow_missing(&spelled).unwrap(),
+            existing.parent().unwrap().join("repo")
+        );
+    }
+
+    #[test]
+    fn canonicalize_allow_missing_rejects_dot_dot_above_root() {
+        // Enough `..` in a missing suffix to climb above `/` cannot name any
+        // location; it must error, not wrap around or silently clamp.
+        let spelled = PathBuf::from("/memory-mcp-test-nonexistent-4f2a9c/../../still-missing/repo");
         let err = canonicalize_allow_missing(&spelled).unwrap_err();
         assert!(
-            err.to_string().contains(".."),
-            "error must name the '..' problem: {err}"
+            err.to_string().contains("root"),
+            "error must name the climb above root: {err}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
 
 /// Token resolution, OAuth device flow, and credential storage backends.
 pub mod auth;
+/// Configuration file parsing for per-scope remote mapping.
+pub mod config;
+
 /// Embedding backends for computing vector representations of text.
 pub mod embedding;
 /// Error types used throughout the crate.
@@ -24,6 +27,8 @@ pub mod recall_log;
 pub mod repo;
 /// Hybrid retrieval — semantic + BM25 lexical search merged via rank fusion.
 pub mod search;
+/// Routes memory operations to scope-specific git repositories.
+pub mod repo_router;
 /// MCP server implementation — tool handlers for the memory protocol.
 pub mod server;
 /// Domain types: memories, scopes, metadata, validation, and application state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,10 @@ pub mod index;
 pub mod recall_log;
 /// Git-backed memory repository — read, write, sync, and diff operations.
 pub mod repo;
-/// Hybrid retrieval — semantic + BM25 lexical search merged via rank fusion.
-pub mod search;
 /// Routes memory operations to scope-specific git repositories.
 pub mod repo_router;
+/// Hybrid retrieval — semantic + BM25 lexical search merged via rank fusion.
+pub mod search;
 /// MCP server implementation — tool handlers for the memory protocol.
 pub mod server;
 /// Domain types: memories, scopes, metadata, validation, and application state.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ pub mod config;
 pub mod embedding;
 /// Error types used throughout the crate.
 pub mod error;
-/// Filesystem utilities — atomic writes with crash-safe temp-file-then-rename.
-pub(crate) mod fs_util;
+/// Filesystem utilities — atomic writes, path helpers, crash-safe temp-file-then-rename.
+pub mod fs_util;
 /// HTTP health-check handlers (`/readyz`).
 pub mod health;
 /// HNSW vector index for approximate nearest-neighbour search.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,5 +31,8 @@ pub mod repo_router;
 pub mod search;
 /// MCP server implementation — tool handlers for the memory protocol.
 pub mod server;
+/// Test-only tracing capture helpers shared across unit-test modules.
+#[cfg(test)]
+pub(crate) mod test_log;
 /// Domain types: memories, scopes, metadata, validation, and application state.
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,12 +602,15 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         }
     }
 
-    // Mark git as healthy — if we reached this point, git init/open succeeded.
-    health.git.report_ok();
-    // Only mark embedding and vector_index healthy if the reindex succeeded or
-    // was skipped (SHA matched). If the reindex had errors, the subsystems have
-    // already reported their own state via their reporters.
+    // Only mark subsystems healthy if the reindex succeeded or was skipped
+    // (SHA matched). If the reindex had errors, the subsystems have already
+    // reported their own state via their reporters — an unconditional
+    // `health.git.report_ok()` here erased a strict-list/reindex repo
+    // failure recorded during the rebuild (#293 review, round 4). Git
+    // init/open succeeding earlier is not evidence that every repo listed
+    // cleanly.
     if reindex_ok {
+        health.git.report_ok();
         health.embedding.report_ok();
         health.vector_index.report_ok();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -554,45 +554,17 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
                 .expect("failed to create index"),
         );
 
-        reindex_ok =
-            match memory_mcp::server::full_reindex(&router, embedding.as_ref(), index.as_ref())
-                .instrument(tracing::info_span!("startup.full_reindex"))
-                .await
-            {
-                Ok(stats) => {
-                    info!(
-                        added = stats.added,
-                        errors = stats.errors,
-                        "startup reindex complete"
-                    );
-                    if stats.added > 0 || stats.errors == 0 {
-                        if stats.errors > 0 {
-                            tracing::warn!(
-                            added = stats.added,
-                            errors = stats.errors,
-                            "startup reindex partially failed — some memories may not be searchable"
-                        );
-                        }
-                        if let Some(sha) = &head_sha {
-                            index.set_commit_sha(Some(sha));
-                        }
-                        stats.errors == 0
-                    } else {
-                        tracing::warn!(
-                            errors = stats.errors,
-                            "all embeds failed — SHA not stamped, will retry on next startup"
-                        );
-                        false
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        "startup reindex failed — SHA not stamped, will retry on next startup"
-                    );
-                    false
-                }
-            };
+        // Certification requires errors == 0 (#293 review, round 3): a
+        // partial rebuild must not stamp the SHA, or the next startup would
+        // see index SHA == HEAD and skip the reindex that repairs the gap.
+        reindex_ok = memory_mcp::server::startup_reindex_and_certify(
+            &router,
+            embedding.as_ref(),
+            index.as_ref(),
+            head_sha.as_deref(),
+        )
+        .instrument(tracing::info_span!("startup.full_reindex"))
+        .await;
     } else {
         tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
         reindex_ok = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
             }),
     );
 
-    let head_sha = repo.head_sha().await;
+    let head_sha = router.head_sha().await;
     let needs_reindex = head_sha != index.commit_sha();
     // Track whether the reindex (if it ran) completed without errors.
     // Used below to gate startup report_ok for embedding and vector_index.
@@ -555,7 +555,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         );
 
         reindex_ok =
-            match memory_mcp::server::full_reindex(&repo, embedding.as_ref(), index.as_ref())
+            match memory_mcp::server::full_reindex(&router, embedding.as_ref(), index.as_ref())
                 .instrument(tracing::info_span!("startup.full_reindex"))
                 .await
             {
@@ -757,7 +757,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Persist the scoped vector index so the next startup can skip a full reindex.
     std::fs::create_dir_all(&index_dir)
         .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
-    if let Some(sha) = state_for_shutdown.repo.head_sha().await {
+    if let Some(sha) = state_for_shutdown.router.head_sha().await {
         state_for_shutdown.index.set_commit_sha(Some(&sha));
     }
     if let Err(e) = state_for_shutdown.index.save(&index_dir) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,12 @@ struct ServeArgs {
     #[arg(long, default_value = "~/.memory-mcp", env = "MEMORY_MCP_REPO_PATH")]
     repo_path: String,
 
+    /// Path to the TOML config file for per-scope remote mapping.
+    /// Defaults to `~/.config/memory-mcp/config.toml`. Set to an empty
+    /// string to disable config loading.
+    #[arg(long, env = "MEMORY_MCP_CONFIG")]
+    config: Option<String>,
+
     /// URL path at which the MCP service is mounted.
     #[arg(long, default_value = "/mcp", env = "MEMORY_MCP_PATH")]
     mcp_path: String,
@@ -493,6 +499,33 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     let repo = Arc::new(repo);
 
+    // Load per-scope remote config and build the repo router.
+    let router = {
+        let config_path = match &args.config {
+            Some(p) if p.is_empty() => None,
+            Some(p) => Some(expand_path(p)?),
+            None => memory_mcp::config::Config::resolve_path().ok(),
+        };
+
+        if let Some(ref path) = config_path {
+            let config = memory_mcp::config::Config::load(path)
+                .with_context(|| format!("failed to load config from {}", path.display()))?;
+            if config.remotes.is_empty() {
+                memory_mcp::repo_router::RepoRouter::single(Arc::clone(&repo))
+            } else {
+                memory_mcp::repo_router::RepoRouter::from_config(
+                    Arc::clone(&repo),
+                    &config.remotes,
+                    &health.git,
+                    &health.sync,
+                )
+                .context("failed to initialise scope-specific repos from config")?
+            }
+        } else {
+            memory_mcp::repo_router::RepoRouter::single(Arc::clone(&repo))
+        }
+    };
+
     // Load the persisted index and check freshness against repo HEAD.
     // If the SHA doesn't match, discard the loaded index entirely and start
     // fresh — this prevents ghost entries from deleted memories lingering.
@@ -606,8 +639,9 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         }
     };
 
-    let state = Arc::new(AppState::new(
+    let state = Arc::new(AppState::with_router(
         repo,
+        router,
         args.branch.clone(),
         embedding,
         index,

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,13 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     // Expand `~` in repo_path, failing loudly if HOME is not set and the
     // path requires it (i.e. the user did not provide --repo-path explicitly).
+    // Canonicalize BEFORE opening so the location the repo is opened at and
+    // the router's collision-detection key can never diverge (#293 review,
+    // round 5: a symlink-plus-`..` spelling otherwise opens one physical
+    // repo while collision detection records another).
     let repo_path = expand_path(&args.repo_path)?;
+    let repo_path = memory_mcp::fs_util::canonicalize_allow_missing(&repo_path)
+        .context("failed to canonicalize repo path")?;
     info!("repo path: {}", repo_path.display());
 
     // Filter out empty string to treat MEMORY_MCP_REMOTE_URL="" as unset.

--- a/src/main.rs
+++ b/src/main.rs
@@ -654,7 +654,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // text is cheap, unlike embedding it — so it is rebuilt from the repo on
     // every startup and never persisted or migrated. Failure degrades recall
     // to semantic-only; it never blocks startup.
-    match memory_mcp::search::rebuild_lexical_from_repo(&state.repo, &state.lexical)
+    match memory_mcp::search::rebuild_lexical_from_router(&state.router, &state.lexical)
         .instrument(tracing::info_span!("startup.lexical_rebuild"))
         .await
     {
@@ -671,7 +671,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
                 "lexical index startup rebuild failed — keyword search \
                  degraded until background repair converges"
             );
-            memory_mcp::search::spawn_lexical_repair(&state.repo, &state.lexical);
+            memory_mcp::search::spawn_lexical_repair_for_router(&state.router, &state.lexical);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -873,22 +873,7 @@ fn parse_nonzero_u64(s: &str) -> Result<u64, String> {
 }
 
 fn expand_path(path: &str) -> anyhow::Result<PathBuf> {
-    match path.strip_prefix('~') {
-        Some(rest) if rest.is_empty() || rest.starts_with('/') => {
-            let home = dirs::home_dir().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "could not expand '~': home directory could not be determined; \
-                     please provide --repo-path explicitly or set HOME"
-                )
-            })?;
-            Ok(home.join(rest.strip_prefix('/').unwrap_or(rest)))
-        }
-        Some(_) => anyhow::bail!(
-            "~user path expansion is not supported; \
-             please use an absolute path or ~/..."
-        ),
-        None => Ok(PathBuf::from(path)),
-    }
+    memory_mcp::fs_util::expand_tilde(path).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -600,6 +600,11 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     let auth = AuthProvider::new();
 
+    // Tracks whether the vector index verifiably mirrors git truth at startup.
+    // A reindex that did not complete cleanly is a gap only the next full
+    // reindex closes, so SHA advancement must stay blocked for this process.
+    let mut startup_mirror_gap = !reindex_ok;
+
     // When --require-remote-sync is set, perform an initial pull so the sync
     // reporter starts with a known state (and the local repo is up-to-date).
     if args.require_remote_sync && remote_url.is_some() {
@@ -607,6 +612,17 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         match repo.pull(&auth, &args.branch).await {
             Ok(result) => {
                 info!(?result, "initial pull completed");
+                if matches!(
+                    result,
+                    memory_mcp::types::PullResult::FastForward { .. }
+                        | memory_mcp::types::PullResult::Merged { .. }
+                ) {
+                    // The pull moved git HEAD past the SHA the index was just
+                    // verified against without mirroring the pulled changes.
+                    // Block SHA advancement so the next startup reindexes them
+                    // instead of a later stamp hiding the gap.
+                    startup_mirror_gap = true;
+                }
             }
             Err(e) => {
                 tracing::warn!(error = %e, "initial pull failed — sync reporter will show degraded");
@@ -649,6 +665,9 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         health,
         recall_log,
     ));
+    if startup_mirror_gap {
+        state.mark_index_mirror_incomplete();
+    }
 
     // Populate the lexical (BM25) index. It lives in RAM only — indexing
     // text is cheap, unlike embedding it — so it is rebuilt from the repo on
@@ -754,13 +773,13 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         .await
         .context("server error")?;
 
-    // Persist the scoped vector index so the next startup can skip a full reindex.
-    std::fs::create_dir_all(&index_dir)
-        .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
-    if let Some(sha) = state_for_shutdown.router.head_sha().await {
-        state_for_shutdown.index.set_commit_sha(Some(&sha));
-    }
-    if let Err(e) = state_for_shutdown.index.save(&index_dir) {
+    // Persist the scoped vector index so the next startup can skip a full
+    // reindex. The stored SHA only advances when the in-process mirror is
+    // intact — a recorded mirror gap keeps the last verified SHA so the next
+    // startup rebuilds from git truth.
+    if let Err(e) =
+        memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
+    {
         tracing::warn!("failed to persist vector index on shutdown: {}", e);
     } else {
         info!("vector index saved to {}", index_dir.display());

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -24,7 +24,7 @@ use crate::{
 /// Strip userinfo (credentials) from a URL before logging.
 ///
 /// `https://user:token@host/path` → `https://[REDACTED]@host/path`
-fn redact_url(url: &str) -> String {
+pub(crate) fn redact_url(url: &str) -> String {
     if let Some(at_pos) = url.find('@') {
         if let Some(scheme_end) = url.find("://") {
             let scheme = &url[..scheme_end + 3];
@@ -224,6 +224,11 @@ impl MemoryRepo {
             reporter,
             sync_reporter,
         })
+    }
+
+    /// Root directory of the working tree.
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
     }
 
     /// Return the current HEAD commit SHA as a hex string, or `None` if the

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -394,9 +394,42 @@ impl RepoRouter {
         Ok(result)
     }
 
-    /// Get the HEAD SHA for the default repo (used for index persistence).
+    /// Get a composite HEAD SHA covering all repos.
+    ///
+    /// When no scope-specific routes are configured, returns the default repo's
+    /// SHA directly (backward compatible). When routes exist, returns a
+    /// deterministic string built from all repos' HEADs so that a change in
+    /// *any* repo invalidates the stored index SHA and triggers a reindex.
     pub async fn head_sha(&self) -> Option<String> {
-        self.default_repo.head_sha().await
+        if self.routes.is_empty() {
+            return self.default_repo.head_sha().await;
+        }
+
+        // Collect (label, sha) from all repos. Labels are already unique
+        // ("default" + each route prefix) and we sort for determinism.
+        let mut parts: Vec<(String, String)> = Vec::with_capacity(1 + self.routes.len());
+
+        if let Some(sha) = self.default_repo.head_sha().await {
+            parts.push(("default".to_string(), sha));
+        }
+        for route in &self.routes {
+            if let Some(sha) = route.repo.head_sha().await {
+                parts.push((route.prefix.clone(), sha));
+            }
+        }
+
+        if parts.is_empty() {
+            return None;
+        }
+
+        parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let composite = parts
+            .iter()
+            .map(|(label, sha)| format!("{label}={sha}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        Some(composite)
     }
 
     /// Return a reference to the repo for a given scope (for direct access when needed).

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -53,6 +53,8 @@ pub struct MultiSyncResult {
 pub struct SyncEntry {
     /// Human-readable label (`"default"` or the scope prefix).
     pub label: String,
+    /// The scope used to resolve this repo (for reindex routing).
+    pub scope: Scope,
     /// Pull result, if pull was performed.
     pub pull: Option<PullResult>,
     /// Whether push succeeded.
@@ -158,11 +160,14 @@ impl RepoRouter {
     }
 
     /// Iterate over all repos (default + scope-mapped).
-    fn all_repos(&self) -> impl Iterator<Item = (&str, &Arc<MemoryRepo>, Option<&str>)> {
-        std::iter::once(("default", &self.default_repo, None)).chain(
-            self.routes
-                .iter()
-                .map(|r| (r.prefix.as_str(), &r.repo, r.branch.as_deref())),
+    fn all_repos(&self) -> impl Iterator<Item = (&str, &Arc<MemoryRepo>, Option<&str>, Scope)> {
+        std::iter::once(("default", &self.default_repo, None, Scope::Root)).chain(
+            self.routes.iter().map(|r| {
+                let scope = crate::types::ScopePath::new(&r.prefix)
+                    .map(Scope::Path)
+                    .unwrap_or(Scope::Root);
+                (r.prefix.as_str(), &r.repo, r.branch.as_deref(), scope)
+            }),
         )
     }
 
@@ -218,8 +223,9 @@ impl RepoRouter {
                 warn!(
                     error = %e,
                     source = %source_name,
-                    "cross-repo move: failed to delete source after successful save to destination"
+                    "cross-repo move: failed to delete source after successful save to destination — data exists in both repos"
                 );
+                return Err(e);
             }
             Ok(dest)
         }
@@ -264,10 +270,11 @@ impl RepoRouter {
     ) -> Result<MultiSyncResult, MemoryError> {
         let mut result = MultiSyncResult::default();
 
-        for (label, repo, branch_override) in self.all_repos() {
+        for (label, repo, branch_override, scope) in self.all_repos() {
             let branch = branch_override.unwrap_or(default_branch);
             let mut entry = SyncEntry {
                 label: label.to_string(),
+                scope,
                 pull: None,
                 push_ok: false,
                 changes: None,

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -39,6 +39,14 @@ pub struct RepoRouter {
     /// Scope-specific repos, ordered by prefix length descending so longest
     /// prefix matches first.
     routes: Vec<ScopeRoute>,
+    /// Aggregate sync health reporter (#293 review, round 3).
+    ///
+    /// Each repo's pull/push reports per operation to a shared reporter, so
+    /// with multiple repos the last operation's outcome would overwrite
+    /// earlier failures. When present, [`RepoRouter::sync_all`] reports the
+    /// aggregate outcome of the completed sync once, so readiness reflects
+    /// every repo — not the last iteration.
+    sync_reporter: Option<SubsystemReporter>,
 }
 
 /// Result of a sync (push/pull) across all repos.
@@ -112,13 +120,17 @@ impl RepoRouter {
         Self {
             default_repo,
             routes: Vec::new(),
+            sync_reporter: None,
         }
     }
 
     /// Create a router from config, initialising scope-specific repos.
     ///
     /// Each `RemoteMapping` in the config produces a new `MemoryRepo` at the
-    /// resolved path with the mapping's URL as origin.
+    /// resolved path with the mapping's URL as origin. Every mapped branch
+    /// name is validated here (#293 review, round 3) — an invalid override
+    /// must be rejected at construction, not discovered at the first
+    /// push/pull.
     pub fn from_config(
         default_repo: Arc<MemoryRepo>,
         mappings: &[crate::config::RemoteMapping],
@@ -127,6 +139,16 @@ impl RepoRouter {
     ) -> Result<Self, MemoryError> {
         let mut routes = Vec::with_capacity(mappings.len());
         for mapping in mappings {
+            if let Some(branch) = &mapping.branch {
+                crate::types::validate_branch_name(branch).map_err(|_| {
+                    MemoryError::InvalidInput {
+                        reason: format!(
+                            "invalid branch '{}' for scope '{}'",
+                            branch, mapping.scope
+                        ),
+                    }
+                })?;
+            }
             let path = mapping.resolved_path()?;
             info!(
                 scope = %mapping.scope,
@@ -151,6 +173,7 @@ impl RepoRouter {
         Ok(Self {
             default_repo,
             routes,
+            sync_reporter: Some(sync_reporter.clone()),
         })
     }
 
@@ -363,7 +386,9 @@ impl RepoRouter {
     /// network blip on one remote must not block syncing the others. Each
     /// failure is recorded on that repo's [`SyncEntry`] (`pull_error` /
     /// `push_error`) so callers can surface partial failures instead of
-    /// reporting a clean sync; check [`MultiSyncResult::all_ok`].
+    /// reporting a clean sync; check [`MultiSyncResult::all_ok`]. When the
+    /// router carries a sync reporter, the aggregate outcome is reported
+    /// once after all repos complete.
     pub async fn sync_all(
         &self,
         auth: &AuthProvider,
@@ -494,6 +519,19 @@ impl RepoRouter {
             );
         }
 
+        // Aggregate sync health, reported once from the completed result
+        // (#293 review, round 3). The per-operation reports above are
+        // last-operation-wins: a failed repo followed by a clean one would
+        // leave the shared reporter healthy. The settled state must reflect
+        // every repo's pull/push outcome.
+        if let Some(reporter) = &self.sync_reporter {
+            if result.all_ok() {
+                reporter.report_ok();
+            } else {
+                reporter.report_err("one or more repos failed to sync");
+            }
+        }
+
         Ok(result)
     }
 
@@ -583,6 +621,7 @@ mod tests {
                 repo: Arc::clone(&work_repo),
                 branch: None,
             }],
+            sync_reporter: None,
         };
 
         // Root goes to default.
@@ -646,6 +685,7 @@ mod tests {
         let router = RepoRouter {
             default_repo: Arc::clone(&default_repo),
             routes,
+            sync_reporter: None,
         };
 
         // "org/team" matches the longer prefix.
@@ -677,6 +717,7 @@ mod tests {
                 repo: Arc::clone(&work_repo),
                 branch: Some("develop".to_string()),
             }],
+            sync_reporter: None,
         };
 
         assert_eq!(router.branch_for_scope(&Scope::Root, "main"), "main");
@@ -699,6 +740,7 @@ mod tests {
                 repo: work_repo,
                 branch: None,
             }],
+            sync_reporter: None,
         };
 
         let root = Memory::from_validated(
@@ -754,6 +796,7 @@ mod tests {
                 repo: Arc::clone(&work_repo),
                 branch: None,
             }],
+            sync_reporter: None,
         };
         (router, default_repo, work_repo)
     }
@@ -891,6 +934,182 @@ mod tests {
             names,
             vec!["root-note"],
             "root-scope listing must be unaffected"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Mapped-branch validation (#293 review, round 3)
+    //
+    // Every configured branch override goes through `validate_branch_name`
+    // at router construction — not just the server-wide default branch that
+    // `--branch` validates in main.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_config_rejects_invalid_mapped_branch() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+
+        for bad in [
+            "bad..branch",
+            "",
+            "branch with space",
+            "/leading",
+            "trailing/",
+        ] {
+            let mapping = crate::config::RemoteMapping {
+                scope: "work".to_string(),
+                url: "file:///nonexistent/remote.git".to_string(),
+                path: Some(work_dir.path().display().to_string()),
+                branch: Some(bad.to_string()),
+            };
+            let result = RepoRouter::from_config(
+                Arc::clone(&default_repo),
+                std::slice::from_ref(&mapping),
+                &health.git,
+                &health.sync,
+            );
+            match result {
+                Err(MemoryError::InvalidInput { .. }) => {}
+                Err(other) => panic!("branch {bad:?} must fail as InvalidInput: {other:?}"),
+                Ok(_) => panic!("branch {bad:?} must be rejected at construction"),
+            }
+        }
+
+        // A valid override still constructs, proving the gate rejects the
+        // name, not the presence of an override.
+        let mapping = crate::config::RemoteMapping {
+            scope: "work".to_string(),
+            url: "file:///nonexistent/remote.git".to_string(),
+            path: Some(work_dir.path().display().to_string()),
+            branch: Some("release/1.0".to_string()),
+        };
+        RepoRouter::from_config(
+            default_repo,
+            std::slice::from_ref(&mapping),
+            &health.git,
+            &health.sync,
+        )
+        .expect("a valid mapped branch must construct");
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate sync health (#293 review, round 3)
+    //
+    // Each repo's pull/push reports per operation to the shared sync
+    // reporter, so multi-repo readiness was last-operation-wins: a failed
+    // repo followed by a clean one left the reporter healthy. `sync_all`
+    // must settle the reporter once from the completed `MultiSyncResult`.
+    // -----------------------------------------------------------------------
+
+    fn sync_test_auth() -> AuthProvider {
+        AuthProvider::with_token("ghp_fake_token")
+    }
+
+    /// Create a bare origin seeded with one root-scope memory via a writer
+    /// clone, so a fresh repo can pull and push it cleanly.
+    async fn seeded_remote(seed_name: &str) -> (tempfile::TempDir, String) {
+        let remote_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(remote_dir.path()).unwrap();
+        let url = format!("file://{}", remote_dir.path().display());
+        let writer_dir = tempfile::tempdir().unwrap();
+        let writer = Arc::new(MemoryRepo::init_or_open(writer_dir.path(), Some(&url)).unwrap());
+        writer.save_memory(&memory_at("", seed_name)).await.unwrap();
+        writer.push(&sync_test_auth(), "main").await.unwrap();
+        (remote_dir, url)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sync_health_reflects_aggregate_not_last_repo() {
+        // The default repo — FIRST in sync order — has an unreachable
+        // origin, so its pull fails. The mapped repo — LAST — syncs
+        // cleanly, so per-operation reporting alone would leave the shared
+        // reporter healthy.
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = Arc::new(
+            MemoryRepo::init_or_open(
+                default_dir.path(),
+                Some("file:///nonexistent/memory-mcp-test-remote.git"),
+            )
+            .unwrap(),
+        );
+
+        let (_remote_dir, url) = seeded_remote("seed").await;
+        let work_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+        let mapping = crate::config::RemoteMapping {
+            scope: "work".to_string(),
+            url,
+            path: Some(work_dir.path().display().to_string()),
+            branch: None,
+        };
+        let router = RepoRouter::from_config(
+            default_repo,
+            std::slice::from_ref(&mapping),
+            &health.git,
+            &health.sync,
+        )
+        .unwrap();
+
+        let result = router
+            .sync_all(&sync_test_auth(), "main", true)
+            .await
+            .unwrap();
+        assert!(!result.all_ok());
+        assert!(
+            result.results[0].pull_error.is_some(),
+            "precondition: the first repo's pull must fail"
+        );
+        assert!(
+            result.results[1].is_ok(),
+            "precondition: the last repo must sync cleanly"
+        );
+
+        let sync = health.sync.load();
+        assert!(
+            !sync.healthy,
+            "aggregate sync health must reflect the failed repo, not the \
+             last repo's clean operations"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sync_health_ok_when_every_repo_syncs() {
+        let (_default_remote, default_url) = seeded_remote("seed-default").await;
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo =
+            Arc::new(MemoryRepo::init_or_open(default_dir.path(), Some(&default_url)).unwrap());
+
+        let (_work_remote, work_url) = seeded_remote("seed-work").await;
+        let work_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+        let mapping = crate::config::RemoteMapping {
+            scope: "work".to_string(),
+            url: work_url,
+            path: Some(work_dir.path().display().to_string()),
+            branch: None,
+        };
+        let router = RepoRouter::from_config(
+            default_repo,
+            std::slice::from_ref(&mapping),
+            &health.git,
+            &health.sync,
+        )
+        .unwrap();
+
+        let result = router
+            .sync_all(&sync_test_auth(), "main", true)
+            .await
+            .unwrap();
+        assert!(
+            result.all_ok(),
+            "precondition: every repo must sync cleanly"
+        );
+        assert!(
+            health.sync.load().healthy,
+            "a fully clean sync must settle the reporter healthy"
         );
     }
 }

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -287,16 +287,35 @@ impl RepoRouter {
     // Read operations — aggregate across all repos
     // -----------------------------------------------------------------------
 
+    /// `true` when `repo` is the repo that owns `scope` under the point-read
+    /// routing rules (`repo_for_scope`).
+    fn owns_scope(&self, repo: &Arc<MemoryRepo>, scope: &Scope) -> bool {
+        Arc::ptr_eq(self.repo_for_scope(scope), repo)
+    }
+
     /// List memories across all repos, filtered by scope.
+    ///
+    /// Each repo's results are filtered to the scopes that repo owns under
+    /// the same routing rules as point reads: the default repo owns every
+    /// scope not captured by a mapping, and each mapped repo owns exactly its
+    /// subtree. Without this, a memory stranded in the wrong repo (e.g. a
+    /// pre-existing `work/foo` in the default repo after `work` was mapped
+    /// elsewhere) would appear in listings while `read` reports it not found,
+    /// and duplicate `(scope, name)` keys could corrupt keyset pagination.
     pub async fn list_memories(&self, scope: Option<&Scope>) -> Result<Vec<Memory>, MemoryError> {
         if self.routes.is_empty() {
             return self.default_repo.list_memories(scope).await;
         }
 
         let mut all_memories = self.default_repo.list_memories(scope).await?;
+        all_memories.retain(|m| self.owns_scope(&self.default_repo, &m.metadata.scope));
         for route in &self.routes {
             match route.repo.list_memories(scope).await {
-                Ok(memories) => all_memories.extend(memories),
+                Ok(memories) => all_memories.extend(
+                    memories
+                        .into_iter()
+                        .filter(|m| self.owns_scope(&route.repo, &m.metadata.scope)),
+                ),
                 Err(e) => {
                     warn!(
                         scope = %route.prefix,
@@ -313,10 +332,23 @@ impl RepoRouter {
     ///
     /// Rebuilds use this strict form because accepting a partial aggregate as
     /// git truth would silently erase the missing repo from a derived index.
+    /// Ownership filtering applies here too: a memory stranded in a repo that
+    /// does not own its scope is unreachable through point reads, so derived
+    /// indexes must not serve it either.
     pub async fn list_memories_strict(&self) -> Result<Vec<Memory>, MemoryError> {
         let mut all_memories = self.default_repo.list_memories(None).await?;
+        if !self.routes.is_empty() {
+            all_memories.retain(|m| self.owns_scope(&self.default_repo, &m.metadata.scope));
+        }
         for route in &self.routes {
-            all_memories.extend(route.repo.list_memories(None).await?);
+            all_memories.extend(
+                route
+                    .repo
+                    .list_memories(None)
+                    .await?
+                    .into_iter()
+                    .filter(|m| self.owns_scope(&route.repo, &m.metadata.scope)),
+            );
         }
         Ok(all_memories)
     }
@@ -695,5 +727,170 @@ mod tests {
             .search(&ScopeFilter::All, "mappedneedle", 10)
             .unwrap();
         assert_eq!(mapped_hits[0].0, work.mem_ref().qualified_path());
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate-read ownership (#293 review, round 2)
+    //
+    // Point reads route a scope exclusively to its owning repo; the
+    // aggregate list operations must apply the same ownership rules, or a
+    // memory stranded in the wrong repo (e.g. a pre-existing `work/foo` in
+    // the default repo after `work` was mapped elsewhere) stays listed while
+    // `read` reports it not found, and duplicate `(scope, name)` keys can
+    // corrupt keyset pagination.
+    // -----------------------------------------------------------------------
+
+    /// Build a default+work router and return `(router, default_repo, work_repo)`.
+    fn two_repo_router(
+        default_dir: &tempfile::TempDir,
+        work_dir: &tempfile::TempDir,
+    ) -> (RepoRouter, Arc<MemoryRepo>, Arc<MemoryRepo>) {
+        let default_repo = test_repo(default_dir);
+        let work_repo = test_repo(work_dir);
+        let router = RepoRouter {
+            default_repo: Arc::clone(&default_repo),
+            routes: vec![ScopeRoute {
+                prefix: "work".to_string(),
+                repo: Arc::clone(&work_repo),
+                branch: None,
+            }],
+        };
+        (router, default_repo, work_repo)
+    }
+
+    fn memory_at(scope: &str, name: &str) -> Memory {
+        let scope = if scope.is_empty() {
+            Scope::Root
+        } else {
+            Scope::Path(ScopePath::new(scope).unwrap())
+        };
+        Memory::from_validated(
+            MemoryName::new(name).unwrap(),
+            format!("{name} content"),
+            MemoryMetadata::new(scope, vec![], None),
+        )
+    }
+
+    #[tokio::test]
+    async fn list_excludes_memories_a_repo_does_not_own() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let (router, default_repo, work_repo) = two_repo_router(&default_dir, &work_dir);
+
+        // Stranded: lives in the default repo under a scope the work repo
+        // owns — the pre-existing-before-mapping case.
+        let stranded = memory_at("work/foo", "stranded");
+        default_repo.save_memory(&stranded).await.unwrap();
+        // Stranded the other way: lives in the work repo under a scope the
+        // default repo owns.
+        let misplaced = memory_at("personal", "misplaced");
+        work_repo.save_memory(&misplaced).await.unwrap();
+        // Owned memories stay visible.
+        let owned_work = memory_at("work/foo", "owned-work");
+        router.save_memory(&owned_work).await.unwrap();
+        let owned_default = memory_at("personal", "owned-default");
+        router.save_memory(&owned_default).await.unwrap();
+
+        let names = |memories: &[Memory]| {
+            let mut names: Vec<String> = memories
+                .iter()
+                .map(|m| m.name.as_str().to_string())
+                .collect();
+            names.sort();
+            names
+        };
+
+        let listed = router.list_memories(None).await.unwrap();
+        assert_eq!(
+            names(&listed),
+            vec!["owned-default", "owned-work"],
+            "aggregate list must exclude memories the holding repo does not own"
+        );
+        let strict = router.list_memories_strict().await.unwrap();
+        assert_eq!(
+            names(&strict),
+            vec!["owned-default", "owned-work"],
+            "strict aggregate must apply the same ownership filter"
+        );
+
+        // Coherence receipt: the excluded entries are exactly the ones point
+        // reads cannot serve.
+        let stranded_read = router
+            .read_memory("stranded", &stranded.metadata.scope)
+            .await;
+        assert!(
+            matches!(stranded_read, Err(MemoryError::NotFound { .. })),
+            "read must not find the stranded memory: {stranded_read:?}"
+        );
+        let misplaced_read = router
+            .read_memory("misplaced", &misplaced.metadata.scope)
+            .await;
+        assert!(
+            matches!(misplaced_read, Err(MemoryError::NotFound { .. })),
+            "read must not find the misplaced memory: {misplaced_read:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_yields_unique_scope_name_keys_when_both_repos_hold_the_key() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let (router, default_repo, _work_repo) = two_repo_router(&default_dir, &work_dir);
+
+        // Same (scope, name) in both repos: the owner's copy must win and
+        // the aggregate must not contain duplicate keys that would break
+        // keyset pagination.
+        let shadowed = Memory::from_validated(
+            MemoryName::new("dup").unwrap(),
+            "default copy".to_string(),
+            MemoryMetadata::new(Scope::Path(ScopePath::new("work").unwrap()), vec![], None),
+        );
+        default_repo.save_memory(&shadowed).await.unwrap();
+        let owned = Memory::from_validated(
+            MemoryName::new("dup").unwrap(),
+            "work copy".to_string(),
+            MemoryMetadata::new(Scope::Path(ScopePath::new("work").unwrap()), vec![], None),
+        );
+        router.save_memory(&owned).await.unwrap();
+
+        let listed = router.list_memories(None).await.unwrap();
+        let dups: Vec<&Memory> = listed
+            .iter()
+            .filter(|m| m.mem_ref().qualified_path() == owned.mem_ref().qualified_path())
+            .collect();
+        assert_eq!(
+            dups.len(),
+            1,
+            "aggregate must contain exactly one entry per (scope, name) key"
+        );
+        assert_eq!(
+            dups[0].content, "work copy",
+            "the owning repo's copy must be the one listed"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_default_scopes_unaffected_by_ownership_filter() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let (router, _default_repo, _work_repo) = two_repo_router(&default_dir, &work_dir);
+
+        let root = memory_at("", "root-note");
+        router.save_memory(&root).await.unwrap();
+        let personal = memory_at("personal", "personal-note");
+        router.save_memory(&personal).await.unwrap();
+        let work = memory_at("work", "work-note");
+        router.save_memory(&work).await.unwrap();
+
+        let all = router.list_memories(None).await.unwrap();
+        assert_eq!(all.len(), 3, "normally-routed memories must all be listed");
+
+        let root_only = router.list_memories(Some(&Scope::Root)).await.unwrap();
+        let names: Vec<&str> = root_only.iter().map(|m| m.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["root-note"],
+            "root-scope listing must be unaffected"
+        );
     }
 }

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -1250,6 +1250,43 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn from_config_rejects_symlink_dot_dot_alias_of_default_repo() {
+        // Syne's round-5 repro: base/link -> else/dir, default repo opened
+        // from the raw spelling base/link/../repo. Real traversal opens
+        // else/repo (`..` resolves against the symlink TARGET), but a
+        // lexical normalization would record base/repo as the collision
+        // key — so a mapped route explicitly targeting else/repo would pass
+        // collision detection, open the same physical repo under a second
+        // mutex, and rewrite its origin. Construction must fail.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("base");
+        let else_dir = tmp.path().join("else");
+        std::fs::create_dir_all(else_dir.join("dir")).unwrap();
+        std::fs::create_dir(&base).unwrap();
+        std::os::unix::fs::symlink(else_dir.join("dir"), base.join("link")).unwrap();
+
+        // Open the default repo from the raw aliased spelling, as a caller
+        // that skipped canonicalization would.
+        let raw = base.join("link/../repo");
+        let default_repo = Arc::new(MemoryRepo::init_or_open(&raw, None).unwrap());
+        // Precondition for the repro: the raw spelling and the mapped
+        // target are the same physical directory.
+        assert_eq!(
+            std::fs::canonicalize(&raw).unwrap(),
+            std::fs::canonicalize(else_dir.join("repo")).unwrap(),
+            "precondition: raw spelling must traverse to else/repo"
+        );
+        let health = crate::health::HealthRegistry::new();
+
+        let mappings = vec![mapping_at("work", &else_dir.join("repo"))];
+        expect_collision(
+            RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync),
+            "a symlink+`..` spelling of the default repo",
+        );
+    }
+
     #[test]
     fn from_config_accepts_distinct_paths() {
         // Guard against the collision check over-rejecting: distinct

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -102,7 +102,7 @@ impl RepoRouter {
             });
         }
         // Sort by prefix length descending so longest match wins.
-        routes.sort_by(|a, b| b.prefix.len().cmp(&a.prefix.len()));
+        routes.sort_by_key(|r| std::cmp::Reverse(r.prefix.len()));
         Ok(Self {
             default_repo,
             routes,
@@ -129,6 +129,7 @@ impl RepoRouter {
     }
 
     /// Resolve the branch name for a given scope.
+    #[cfg(test)]
     fn branch_for_scope(&self, scope: &Scope, default_branch: &str) -> String {
         match scope {
             Scope::Root => default_branch.to_string(),
@@ -275,7 +276,6 @@ impl RepoRouter {
             let mut has_remote = true;
 
             if pull_first {
-                let old_head = repo.head_sha().await;
                 match repo.pull(auth, branch).await {
                     Ok(pull_result) => {
                         if matches!(pull_result, PullResult::NoRemote) {
@@ -463,7 +463,7 @@ mod tests {
                 branch: None,
             },
         ];
-        routes.sort_by(|a, b| b.prefix.len().cmp(&a.prefix.len()));
+        routes.sort_by_key(|r| std::cmp::Reverse(r.prefix.len()));
 
         let router = RepoRouter {
             default_repo: Arc::clone(&default_repo),

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -165,7 +165,7 @@ impl RepoRouter {
             self.routes.iter().map(|r| {
                 let scope = crate::types::ScopePath::new(&r.prefix)
                     .map(Scope::Path)
-                    .unwrap_or(Scope::Root);
+                    .expect("scope prefix validated at config load");
                 (r.prefix.as_str(), &r.repo, r.branch.as_deref(), scope)
             }),
         )
@@ -211,13 +211,22 @@ impl RepoRouter {
                 .await
         } else {
             // Cross-repo move: read from source, save to dest, delete from source.
+            // Preserve id and created_at from the source so recall_log references
+            // and memory identity survive the move.
             let source = source_repo.read_memory(source_name, source_scope).await?;
-            let metadata = crate::types::MemoryMetadata::new(
-                dest_scope.clone(),
-                source.metadata.tags.clone(),
-                source.metadata.source.clone(),
+            let metadata = crate::types::MemoryMetadata {
+                scope: dest_scope.clone(),
+                tags: source.metadata.tags.clone(),
+                source: source.metadata.source.clone(),
+                created_at: source.metadata.created_at,
+                updated_at: chrono::Utc::now(),
+            };
+            let dest = Memory::from_validated_with_id(
+                source.id,
+                dest_name.clone(),
+                source.content.clone(),
+                metadata,
             );
-            let dest = Memory::from_validated(dest_name.clone(), source.content.clone(), metadata);
             dest_repo.save_memory(&dest).await?;
             if let Err(e) = source_repo.delete_memory(source_name, source_scope).await {
                 warn!(

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -47,6 +47,15 @@ pub struct RepoRouter {
     /// aggregate outcome of the completed sync once, so readiness reflects
     /// every repo — not the last iteration.
     sync_reporter: Option<SubsystemReporter>,
+    /// Aggregate git health reporter (#293 review, round 4).
+    ///
+    /// The same last-operation-wins hazard applies to local git health: in
+    /// the skip-and-continue aggregate [`RepoRouter::list_memories`], a
+    /// failed route followed by a clean repo would leave the shared reporter
+    /// healthy while a scope's memories are missing from the aggregate. When
+    /// present, the aggregate list settles the reporter once from the
+    /// complete outcome.
+    git_reporter: Option<SubsystemReporter>,
 }
 
 /// Result of a sync (push/pull) across all repos.
@@ -121,6 +130,7 @@ impl RepoRouter {
             default_repo,
             routes: Vec::new(),
             sync_reporter: None,
+            git_reporter: None,
         }
     }
 
@@ -131,12 +141,26 @@ impl RepoRouter {
     /// name is validated here (#293 review, round 3) — an invalid override
     /// must be rejected at construction, not discovered at the first
     /// push/pull.
+    ///
+    /// Repo paths are canonicalized before init and collisions are rejected
+    /// (#293 review, round 4): two routes — or a route and the default repo —
+    /// resolving to the same physical location would open one repo under
+    /// separate mutexes, and the later init would rewrite `origin`, so
+    /// nominally isolated scopes would share a tree and push to the
+    /// last-configured remote.
     pub fn from_config(
         default_repo: Arc<MemoryRepo>,
         mappings: &[crate::config::RemoteMapping],
         git_reporter: &SubsystemReporter,
         sync_reporter: &SubsystemReporter,
     ) -> Result<Self, MemoryError> {
+        let mut claimed: std::collections::HashMap<std::path::PathBuf, String> =
+            std::collections::HashMap::new();
+        claimed.insert(
+            crate::fs_util::canonicalize_allow_missing(default_repo.root())?,
+            "the default repository".to_string(),
+        );
+
         let mut routes = Vec::with_capacity(mappings.len());
         for mapping in mappings {
             if let Some(branch) = &mapping.branch {
@@ -149,11 +173,22 @@ impl RepoRouter {
                     }
                 })?;
             }
-            let path = mapping.resolved_path()?;
+            let path = crate::fs_util::canonicalize_allow_missing(&mapping.resolved_path()?)?;
+            if let Some(owner) = claimed.get(&path) {
+                return Err(MemoryError::InvalidInput {
+                    reason: format!(
+                        "repo path collision: scope '{}' resolves to '{}', which is already used by {}",
+                        mapping.scope,
+                        path.display(),
+                        owner
+                    ),
+                });
+            }
+            claimed.insert(path.clone(), format!("scope '{}'", mapping.scope));
             info!(
                 scope = %mapping.scope,
                 path = %path.display(),
-                url = %mapping.url,
+                url = %crate::repo::redact_url(&mapping.url),
                 "initialising scope-specific repo"
             );
             let repo = MemoryRepo::init_or_open_with_reporter(
@@ -174,6 +209,7 @@ impl RepoRouter {
             default_repo,
             routes,
             sync_reporter: Some(sync_reporter.clone()),
+            git_reporter: Some(git_reporter.clone()),
         })
     }
 
@@ -332,6 +368,7 @@ impl RepoRouter {
 
         let mut all_memories = self.default_repo.list_memories(scope).await?;
         all_memories.retain(|m| self.owns_scope(&self.default_repo, &m.metadata.scope));
+        let mut failed = 0usize;
         for route in &self.routes {
             match route.repo.list_memories(scope).await {
                 Ok(memories) => all_memories.extend(
@@ -340,12 +377,25 @@ impl RepoRouter {
                         .filter(|m| self.owns_scope(&route.repo, &m.metadata.scope)),
                 ),
                 Err(e) => {
+                    failed += 1;
                     warn!(
                         scope = %route.prefix,
                         error = %e,
                         "list_memories: failed to list from scope-specific repo; skipping"
                     );
                 }
+            }
+        }
+        // Settle aggregate git health once from the complete outcome
+        // (#293 review, round 4). The per-operation reports are
+        // last-operation-wins: a skipped failing route followed by a clean
+        // repo would turn readiness green while a scope's memories are
+        // missing from the aggregate.
+        if let Some(reporter) = &self.git_reporter {
+            if failed == 0 {
+                reporter.report_ok();
+            } else {
+                reporter.report_err("one or more scope-specific repos failed to list");
             }
         }
         Ok(all_memories)
@@ -622,6 +672,7 @@ mod tests {
                 branch: None,
             }],
             sync_reporter: None,
+            git_reporter: None,
         };
 
         // Root goes to default.
@@ -686,6 +737,7 @@ mod tests {
             default_repo: Arc::clone(&default_repo),
             routes,
             sync_reporter: None,
+            git_reporter: None,
         };
 
         // "org/team" matches the longer prefix.
@@ -718,6 +770,7 @@ mod tests {
                 branch: Some("develop".to_string()),
             }],
             sync_reporter: None,
+            git_reporter: None,
         };
 
         assert_eq!(router.branch_for_scope(&Scope::Root, "main"), "main");
@@ -741,6 +794,7 @@ mod tests {
                 branch: None,
             }],
             sync_reporter: None,
+            git_reporter: None,
         };
 
         let root = Memory::from_validated(
@@ -797,6 +851,7 @@ mod tests {
                 branch: None,
             }],
             sync_reporter: None,
+            git_reporter: None,
         };
         (router, default_repo, work_repo)
     }
@@ -1110,6 +1165,231 @@ mod tests {
         assert!(
             health.sync.load().healthy,
             "a fully clean sync must settle the reporter healthy"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Repo-path collisions (#293 review, round 4)
+    //
+    // Two routes — or a route and the default repo — resolving to the same
+    // physical location open one repo under separate mutexes, and the later
+    // init rewrites `origin`, so nominally isolated scopes share a tree and
+    // push to the last-configured remote. Construction must reject every
+    // colliding spelling: explicit duplicates, symlink aliases, and paths
+    // aliasing the default repo.
+    // -----------------------------------------------------------------------
+
+    fn mapping_at(scope: &str, path: &std::path::Path) -> crate::config::RemoteMapping {
+        crate::config::RemoteMapping {
+            scope: scope.to_string(),
+            url: format!("https://example.com/{}.git", scope.replace('/', "-")),
+            path: Some(path.display().to_string()),
+            branch: None,
+        }
+    }
+
+    fn expect_collision(result: Result<RepoRouter, MemoryError>, case: &str) {
+        match result {
+            Err(MemoryError::InvalidInput { reason }) => {
+                assert!(
+                    reason.contains("collision"),
+                    "{case}: error must name the collision: {reason}"
+                );
+            }
+            Err(other) => panic!("{case}: must fail as InvalidInput: {other:?}"),
+            Ok(_) => panic!("{case}: colliding repo paths must be rejected at construction"),
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_explicit_path_collision() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let shared_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+
+        let mappings = vec![
+            mapping_at("work", shared_dir.path()),
+            mapping_at("play", shared_dir.path()),
+        ];
+        expect_collision(
+            RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync),
+            "two scopes with the same explicit path",
+        );
+    }
+
+    #[test]
+    fn from_config_rejects_mapped_path_aliasing_default_repo() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let health = crate::health::HealthRegistry::new();
+
+        let mappings = vec![mapping_at("work", default_dir.path())];
+        expect_collision(
+            RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync),
+            "a mapped path equal to the default repo",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_config_rejects_symlink_alias_collision() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let base = tempfile::tempdir().unwrap();
+        let real = base.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let alias = base.path().join("alias");
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let health = crate::health::HealthRegistry::new();
+
+        let mappings = vec![mapping_at("work", &real), mapping_at("play", &alias)];
+        expect_collision(
+            RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync),
+            "a symlink alias of an already-claimed path",
+        );
+    }
+
+    #[test]
+    fn from_config_accepts_distinct_paths() {
+        // Guard against the collision check over-rejecting: distinct
+        // physical locations must still construct.
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_dir = tempfile::tempdir().unwrap();
+        let play_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+
+        let mappings = vec![
+            mapping_at("work", work_dir.path()),
+            mapping_at("play", play_dir.path()),
+        ];
+        RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync)
+            .expect("distinct repo paths must construct");
+    }
+
+    // -----------------------------------------------------------------------
+    // Credential redaction in router-init logging (#293 review, round 4)
+    //
+    // `from_config` logged the raw mapping URL at INFO, so credential-bearing
+    // HTTPS userinfo bypassed the `redact_url` guard that repo-level logging
+    // already applies.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn from_config_logs_redact_mapped_credentials() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+        let mapping = crate::config::RemoteMapping {
+            scope: "work".to_string(),
+            url: "https://user:ghp_supersecret123@example.com/org/repo.git".to_string(),
+            path: Some(work_dir.path().display().to_string()),
+            branch: None,
+        };
+
+        let logs = crate::test_log::capture_info_logs(|| {
+            RepoRouter::from_config(
+                default_repo,
+                std::slice::from_ref(&mapping),
+                &health.git,
+                &health.sync,
+            )
+            .expect("router must construct");
+        });
+
+        assert!(
+            !logs.contains("ghp_supersecret123"),
+            "the credential must never reach the logs: {logs}"
+        );
+        assert!(
+            logs.contains("[REDACTED]"),
+            "the remote URL must still be logged in redacted form: {logs}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Aggregate git health (#293 review, round 4)
+    //
+    // All repos share one git reporter, and each repo reports per operation.
+    // In the skip-and-continue aggregate `list_memories`, a failed route
+    // followed by a clean repo left the shared reporter healthy while a
+    // scope's memories were missing from the aggregate. The router must
+    // settle git health once from the complete outcome, mirroring the
+    // round-3 `sync_all` treatment.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn aggregate_list_git_health_reflects_failed_route_not_last_operation() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let broken_dir = tempfile::tempdir().unwrap();
+        let ok_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+        let shared_repo = |dir: &tempfile::TempDir| {
+            Arc::new(
+                MemoryRepo::init_or_open_with_reporter(
+                    dir.path(),
+                    None,
+                    health.git.clone(),
+                    health.sync.clone(),
+                )
+                .unwrap(),
+            )
+        };
+        let default_repo = shared_repo(&default_dir);
+        let broken_repo = shared_repo(&broken_dir);
+        let ok_repo = shared_repo(&ok_dir);
+
+        // Sabotage the broken repo: a regular file where the `projects`
+        // directory belongs makes the unscoped list fail (read_dir on a
+        // file), independent of filesystem permissions.
+        let sabotage = broken_dir.path().join("projects");
+        std::fs::write(&sabotage, "not a directory").unwrap();
+
+        // Order matters: the broken route lists BEFORE the ok route, so the
+        // last per-operation report is the ok route's clean list.
+        let router = RepoRouter {
+            default_repo,
+            routes: vec![
+                ScopeRoute {
+                    prefix: "broken".to_string(),
+                    repo: broken_repo,
+                    branch: None,
+                },
+                ScopeRoute {
+                    prefix: "okay".to_string(),
+                    repo: ok_repo,
+                    branch: None,
+                },
+            ],
+            sync_reporter: None,
+            git_reporter: Some(health.git.clone()),
+        };
+
+        // The aggregate itself succeeds (skip-and-continue is intentional) …
+        router
+            .list_memories(None)
+            .await
+            .expect("aggregate list skips the failed route");
+        // … but readiness must reflect the skipped repo, not the clean
+        // operation that happened to run last.
+        assert!(
+            !health.git.load().healthy,
+            "git health must reflect the failed route, not the last \
+             repo's clean list"
+        );
+
+        // Once the failed route recovers, the next aggregate settles the
+        // reporter healthy again.
+        std::fs::remove_file(&sabotage).unwrap();
+        router
+            .list_memories(None)
+            .await
+            .expect("repaired aggregate list succeeds");
+        assert!(
+            health.git.load().healthy,
+            "a fully clean aggregate must settle the reporter healthy"
         );
     }
 }

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -1,4 +1,4 @@
-//! Routes memory operations to the correct [`MemoryRepo`] based on scope.
+//! Routes memory operations to the correct [`crate::repo::MemoryRepo`] based on scope.
 //!
 //! When per-scope remote mappings are configured, each mapped scope prefix
 //! gets its own independent git repository. Unmapped scopes fall through to
@@ -13,10 +13,11 @@ use crate::{
     error::MemoryError,
     health::SubsystemReporter,
     repo::MemoryRepo,
-    types::{ChangedMemories, Memory, MemoryName, PullResult, Scope},
+    types::{ChangedMemories, Memory, MemoryName, PullResult, ResolvedChanges, Scope},
 };
 
 /// A scope-to-repo entry in the router.
+#[derive(Clone)]
 struct ScopeRoute {
     /// Scope prefix this route captures.
     prefix: String,
@@ -31,6 +32,7 @@ struct ScopeRoute {
 /// Holds a default repo for unmapped scopes and zero or more scope-specific
 /// repos. Write operations route to the repo that owns the scope. Read
 /// operations aggregate across all repos.
+#[derive(Clone)]
 pub struct RepoRouter {
     /// The default repo for scopes that don't match any configured mapping.
     default_repo: Arc<MemoryRepo>,
@@ -61,6 +63,10 @@ pub struct SyncEntry {
     pub push_ok: bool,
     /// Memories that changed during pull (for incremental reindex).
     pub changes: Option<ChangedMemories>,
+    /// Structured changed memories used by derived-index mirrors.
+    pub(crate) resolved_changes: Option<ResolvedChanges>,
+    /// Whether post-pull change discovery completed without gaps.
+    pub(crate) changes_complete: bool,
 }
 
 impl RepoRouter {
@@ -266,6 +272,18 @@ impl RepoRouter {
         Ok(all_memories)
     }
 
+    /// List memories across every repo, failing if any repo cannot be read.
+    ///
+    /// Rebuilds use this strict form because accepting a partial aggregate as
+    /// git truth would silently erase the missing repo from a derived index.
+    pub async fn list_memories_strict(&self) -> Result<Vec<Memory>, MemoryError> {
+        let mut all_memories = self.default_repo.list_memories(None).await?;
+        for route in &self.routes {
+            all_memories.extend(route.repo.list_memories(None).await?);
+        }
+        Ok(all_memories)
+    }
+
     // -----------------------------------------------------------------------
     // Sync operations — push/pull each repo independently
     // -----------------------------------------------------------------------
@@ -292,6 +310,8 @@ impl RepoRouter {
                 pull: None,
                 push_ok: false,
                 changes: None,
+                resolved_changes: None,
+                changes_complete: true,
             };
 
             let mut has_remote = true;
@@ -317,14 +337,22 @@ impl RepoRouter {
                             let oh = *oh;
                             let nh = *nh;
                             match crate::repo::traced_spawn_blocking(move || {
-                                repo_clone.diff_changed_memories(oh, nh)
+                                let changes = repo_clone.diff_changed_memories(oh, nh)?;
+                                let resolved = repo_clone.diff_changed_refs(oh, nh)?;
+                                Ok::<_, MemoryError>((changes, resolved))
                             })
                             .await
                             {
-                                Ok(Ok(changes)) if !changes.is_empty() => {
-                                    entry.changes = Some(changes);
+                                Ok(Ok((changes, resolved))) => {
+                                    if !changes.is_empty() {
+                                        entry.changes = Some(changes);
+                                    }
+                                    if !resolved.is_empty() || resolved.unresolved > 0 {
+                                        entry.resolved_changes = Some(resolved);
+                                    }
                                 }
                                 Ok(Err(e)) => {
+                                    entry.changes_complete = false;
                                     warn!(
                                         label = %label,
                                         error = %e,
@@ -332,13 +360,13 @@ impl RepoRouter {
                                     );
                                 }
                                 Err(e) => {
+                                    entry.changes_complete = false;
                                     warn!(
                                         label = %label,
                                         error = %e,
                                         "sync: spawn_blocking failed for diff"
                                     );
                                 }
-                                _ => {}
                             }
                         }
                         entry.pull = Some(pull_result);
@@ -446,7 +474,10 @@ impl RepoRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ScopePath;
+    use crate::{
+        search::{rebuild_lexical_from_router, LexicalIndex},
+        types::{MemoryMetadata, MemoryName, ScopeFilter, ScopePath},
+    };
 
     fn test_repo(dir: &tempfile::TempDir) -> Arc<MemoryRepo> {
         Arc::new(MemoryRepo::init_or_open(dir.path(), None).unwrap())
@@ -578,5 +609,48 @@ mod tests {
         assert_eq!(router.branch_for_scope(&Scope::Path(sp), "main"), "develop");
         let sp = ScopePath::new("other").unwrap();
         assert_eq!(router.branch_for_scope(&Scope::Path(sp), "main"), "main");
+    }
+
+    #[tokio::test]
+    async fn lexical_rebuild_uses_default_and_mapped_repo_truth() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_repo = test_repo(&work_dir);
+        let router = RepoRouter {
+            default_repo,
+            routes: vec![ScopeRoute {
+                prefix: "work".to_string(),
+                repo: work_repo,
+                branch: None,
+            }],
+        };
+
+        let root = Memory::from_validated(
+            MemoryName::new("root-note").unwrap(),
+            "rootneedle".to_string(),
+            MemoryMetadata::new(Scope::Root, vec![], None),
+        );
+        let work_scope = Scope::Path(ScopePath::new("work").unwrap());
+        let work = Memory::from_validated(
+            MemoryName::new("work-note").unwrap(),
+            "mappedneedle".to_string(),
+            MemoryMetadata::new(work_scope, vec![], None),
+        );
+        router.save_memory(&root).await.unwrap();
+        router.save_memory(&work).await.unwrap();
+
+        let lexical = Arc::new(LexicalIndex::new());
+        let count = rebuild_lexical_from_router(&router, &lexical)
+            .await
+            .unwrap();
+        assert_eq!(count, 2);
+
+        let root_hits = lexical.search(&ScopeFilter::All, "rootneedle", 10).unwrap();
+        assert_eq!(root_hits[0].0, root.mem_ref().qualified_path());
+        let mapped_hits = lexical
+            .search(&ScopeFilter::All, "mappedneedle", 10)
+            .unwrap();
+        assert_eq!(mapped_hits[0].0, work.mem_ref().qualified_path());
     }
 }

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -45,8 +45,15 @@ pub struct RepoRouter {
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct MultiSyncResult {
-    /// Per-repo sync results: `(scope_label, pull_result, push_ok)`.
+    /// Per-repo sync outcomes, one entry per repo (default + each route).
     pub results: Vec<SyncEntry>,
+}
+
+impl MultiSyncResult {
+    /// `true` when every repo's pull and push completed without error.
+    pub fn all_ok(&self) -> bool {
+        self.results.iter().all(SyncEntry::is_ok)
+    }
 }
 
 /// Outcome of syncing a single repo.
@@ -57,16 +64,46 @@ pub struct SyncEntry {
     pub label: String,
     /// The scope used to resolve this repo (for reindex routing).
     pub scope: Scope,
-    /// Pull result, if pull was performed.
+    /// Pull result when the pull was performed and succeeded.
     pub pull: Option<PullResult>,
-    /// Whether push succeeded.
+    /// Error message when the pull was attempted and failed.
+    pub pull_error: Option<String>,
+    /// Whether push succeeded. `true` in local-only mode (no remote means
+    /// nothing to push); `false` when the push failed or was not attempted
+    /// because the pull failed first.
     pub push_ok: bool,
+    /// Error message when the push was attempted and failed.
+    pub push_error: Option<String>,
     /// Memories that changed during pull (for incremental reindex).
     pub changes: Option<ChangedMemories>,
     /// Structured changed memories used by derived-index mirrors.
     pub(crate) resolved_changes: Option<ResolvedChanges>,
     /// Whether post-pull change discovery completed without gaps.
     pub(crate) changes_complete: bool,
+}
+
+impl SyncEntry {
+    /// `true` when neither the pull nor the push recorded an error.
+    pub fn is_ok(&self) -> bool {
+        self.pull_error.is_none() && self.push_error.is_none()
+    }
+
+    /// Describe the recorded pull/push errors, or `None` when the entry
+    /// completed without error.
+    pub fn failure_summary(&self) -> Option<String> {
+        let mut ops = Vec::new();
+        if let Some(e) = &self.pull_error {
+            ops.push(format!("pull failed: {e}"));
+        }
+        if let Some(e) = &self.push_error {
+            ops.push(format!("push failed: {e}"));
+        }
+        if ops.is_empty() {
+            None
+        } else {
+            Some(ops.join("; "))
+        }
+    }
 }
 
 impl RepoRouter {
@@ -290,9 +327,11 @@ impl RepoRouter {
 
     /// Sync all repos: pull then push each one.
     ///
-    /// Errors on individual repos are logged and recorded but do not abort
-    /// the remaining repos — a network blip on one remote must not block
-    /// syncing the others.
+    /// Errors on individual repos do not abort the remaining repos — a
+    /// network blip on one remote must not block syncing the others. Each
+    /// failure is recorded on that repo's [`SyncEntry`] (`pull_error` /
+    /// `push_error`) so callers can surface partial failures instead of
+    /// reporting a clean sync; check [`MultiSyncResult::all_ok`].
     pub async fn sync_all(
         &self,
         auth: &AuthProvider,
@@ -300,7 +339,6 @@ impl RepoRouter {
         pull_first: bool,
     ) -> Result<MultiSyncResult, MemoryError> {
         let mut result = MultiSyncResult::default();
-        let mut errors: Vec<(String, MemoryError)> = Vec::new();
 
         for (label, repo, branch_override, scope) in self.all_repos() {
             let branch = branch_override.unwrap_or(default_branch);
@@ -308,7 +346,9 @@ impl RepoRouter {
                 label: label.to_string(),
                 scope,
                 pull: None,
+                pull_error: None,
                 push_ok: false,
+                push_error: None,
                 changes: None,
                 resolved_changes: None,
                 changes_complete: true,
@@ -377,7 +417,7 @@ impl RepoRouter {
                             error = %e,
                             "sync: pull failed — continuing with remaining repos"
                         );
-                        errors.push((label.to_string(), e));
+                        entry.pull_error = Some(e.to_string());
                         result.results.push(entry);
                         continue;
                     }
@@ -393,7 +433,7 @@ impl RepoRouter {
                             error = %e,
                             "sync: push failed — continuing with remaining repos"
                         );
-                        errors.push((label.to_string(), e));
+                        entry.push_error = Some(e.to_string());
                     }
                 }
             } else {
@@ -403,19 +443,22 @@ impl RepoRouter {
             result.results.push(entry);
         }
 
-        if !errors.is_empty() {
-            let summary = errors
-                .iter()
-                .map(|(label, e)| format!("{label}: {e}"))
-                .collect::<Vec<_>>()
-                .join("; ");
+        let failures: Vec<String> = result
+            .results
+            .iter()
+            .filter_map(|e| {
+                e.failure_summary()
+                    .map(|summary| format!("{}: {summary}", e.label))
+            })
+            .collect();
+        if !failures.is_empty() {
             warn!(
-                failed = errors.len(),
+                failed = failures.len(),
                 total = result.results.len(),
                 "sync: {}/{} repos had errors: {}",
-                errors.len(),
+                failures.len(),
                 result.results.len(),
-                summary
+                failures.join("; ")
             );
         }
 

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -271,6 +271,10 @@ impl RepoRouter {
     // -----------------------------------------------------------------------
 
     /// Sync all repos: pull then push each one.
+    ///
+    /// Errors on individual repos are logged and recorded but do not abort
+    /// the remaining repos — a network blip on one remote must not block
+    /// syncing the others.
     pub async fn sync_all(
         &self,
         auth: &AuthProvider,
@@ -278,6 +282,7 @@ impl RepoRouter {
         pull_first: bool,
     ) -> Result<MultiSyncResult, MemoryError> {
         let mut result = MultiSyncResult::default();
+        let mut errors: Vec<(String, MemoryError)> = Vec::new();
 
         for (label, repo, branch_override, scope) in self.all_repos() {
             let branch = branch_override.unwrap_or(default_branch);
@@ -342,9 +347,11 @@ impl RepoRouter {
                         warn!(
                             label = %label,
                             error = %e,
-                            "sync: pull failed"
+                            "sync: pull failed — continuing with remaining repos"
                         );
-                        return Err(e);
+                        errors.push((label.to_string(), e));
+                        result.results.push(entry);
+                        continue;
                     }
                 }
             }
@@ -356,9 +363,9 @@ impl RepoRouter {
                         warn!(
                             label = %label,
                             error = %e,
-                            "sync: push failed"
+                            "sync: push failed — continuing with remaining repos"
                         );
-                        return Err(e);
+                        errors.push((label.to_string(), e));
                     }
                 }
             } else {
@@ -366,6 +373,22 @@ impl RepoRouter {
             }
 
             result.results.push(entry);
+        }
+
+        if !errors.is_empty() {
+            let summary = errors
+                .iter()
+                .map(|(label, e)| format!("{label}: {e}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            warn!(
+                failed = errors.len(),
+                total = result.results.len(),
+                "sync: {}/{} repos had errors: {}",
+                errors.len(),
+                result.results.len(),
+                summary
+            );
         }
 
         Ok(result)

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -1,0 +1,510 @@
+//! Routes memory operations to the correct [`MemoryRepo`] based on scope.
+//!
+//! When per-scope remote mappings are configured, each mapped scope prefix
+//! gets its own independent git repository. Unmapped scopes fall through to
+//! the default repo. Read operations aggregate across all repos.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use crate::{
+    auth::AuthProvider,
+    error::MemoryError,
+    health::SubsystemReporter,
+    repo::MemoryRepo,
+    types::{ChangedMemories, Memory, MemoryName, PullResult, Scope},
+};
+
+/// A scope-to-repo entry in the router.
+struct ScopeRoute {
+    /// Scope prefix this route captures.
+    prefix: String,
+    /// The git repository for this scope.
+    repo: Arc<MemoryRepo>,
+    /// Branch name for push/pull (overrides the server-wide default).
+    branch: Option<String>,
+}
+
+/// Routes memory operations to scope-specific git repositories.
+///
+/// Holds a default repo for unmapped scopes and zero or more scope-specific
+/// repos. Write operations route to the repo that owns the scope. Read
+/// operations aggregate across all repos.
+pub struct RepoRouter {
+    /// The default repo for scopes that don't match any configured mapping.
+    default_repo: Arc<MemoryRepo>,
+    /// Scope-specific repos, ordered by prefix length descending so longest
+    /// prefix matches first.
+    routes: Vec<ScopeRoute>,
+}
+
+/// Result of a sync (push/pull) across all repos.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct MultiSyncResult {
+    /// Per-repo sync results: `(scope_label, pull_result, push_ok)`.
+    pub results: Vec<SyncEntry>,
+}
+
+/// Outcome of syncing a single repo.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct SyncEntry {
+    /// Human-readable label (`"default"` or the scope prefix).
+    pub label: String,
+    /// Pull result, if pull was performed.
+    pub pull: Option<PullResult>,
+    /// Whether push succeeded.
+    pub push_ok: bool,
+    /// Memories that changed during pull (for incremental reindex).
+    pub changes: Option<ChangedMemories>,
+}
+
+impl RepoRouter {
+    /// Create a router with only a default repo (no scope mappings).
+    pub fn single(default_repo: Arc<MemoryRepo>) -> Self {
+        Self {
+            default_repo,
+            routes: Vec::new(),
+        }
+    }
+
+    /// Create a router from config, initialising scope-specific repos.
+    ///
+    /// Each `RemoteMapping` in the config produces a new `MemoryRepo` at the
+    /// resolved path with the mapping's URL as origin.
+    pub fn from_config(
+        default_repo: Arc<MemoryRepo>,
+        mappings: &[crate::config::RemoteMapping],
+        git_reporter: &SubsystemReporter,
+        sync_reporter: &SubsystemReporter,
+    ) -> Result<Self, MemoryError> {
+        let mut routes = Vec::with_capacity(mappings.len());
+        for mapping in mappings {
+            let path = mapping.resolved_path()?;
+            info!(
+                scope = %mapping.scope,
+                path = %path.display(),
+                url = %mapping.url,
+                "initialising scope-specific repo"
+            );
+            let repo = MemoryRepo::init_or_open_with_reporter(
+                &path,
+                Some(&mapping.url),
+                git_reporter.clone(),
+                sync_reporter.clone(),
+            )?;
+            routes.push(ScopeRoute {
+                prefix: mapping.scope.clone(),
+                repo: Arc::new(repo),
+                branch: mapping.branch.clone(),
+            });
+        }
+        // Sort by prefix length descending so longest match wins.
+        routes.sort_by(|a, b| b.prefix.len().cmp(&a.prefix.len()));
+        Ok(Self {
+            default_repo,
+            routes,
+        })
+    }
+
+    /// Find the repo that owns a given scope.
+    fn repo_for_scope(&self, scope: &Scope) -> &Arc<MemoryRepo> {
+        match scope {
+            Scope::Root => &self.default_repo,
+            Scope::Path(sp) => {
+                let path = sp.as_str();
+                for route in &self.routes {
+                    if path == route.prefix
+                        || (path.starts_with(&route.prefix)
+                            && path.as_bytes().get(route.prefix.len()) == Some(&b'/'))
+                    {
+                        return &route.repo;
+                    }
+                }
+                &self.default_repo
+            }
+        }
+    }
+
+    /// Resolve the branch name for a given scope.
+    fn branch_for_scope(&self, scope: &Scope, default_branch: &str) -> String {
+        match scope {
+            Scope::Root => default_branch.to_string(),
+            Scope::Path(sp) => {
+                let path = sp.as_str();
+                for route in &self.routes {
+                    if path == route.prefix
+                        || (path.starts_with(&route.prefix)
+                            && path.as_bytes().get(route.prefix.len()) == Some(&b'/'))
+                    {
+                        return route
+                            .branch
+                            .as_deref()
+                            .unwrap_or(default_branch)
+                            .to_string();
+                    }
+                }
+                default_branch.to_string()
+            }
+        }
+    }
+
+    /// Get a reference to the default repo.
+    pub fn default_repo(&self) -> &Arc<MemoryRepo> {
+        &self.default_repo
+    }
+
+    /// Iterate over all repos (default + scope-mapped).
+    fn all_repos(&self) -> impl Iterator<Item = (&str, &Arc<MemoryRepo>, Option<&str>)> {
+        std::iter::once(("default", &self.default_repo, None)).chain(
+            self.routes
+                .iter()
+                .map(|r| (r.prefix.as_str(), &r.repo, r.branch.as_deref())),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Write operations — route to the correct repo
+    // -----------------------------------------------------------------------
+
+    /// Save a memory to the repo that owns its scope.
+    pub async fn save_memory(&self, memory: &Memory) -> Result<(), MemoryError> {
+        let repo = self.repo_for_scope(&memory.metadata.scope);
+        repo.save_memory(memory).await
+    }
+
+    /// Delete a memory from the repo that owns its scope.
+    pub async fn delete_memory(&self, name: &str, scope: &Scope) -> Result<(), MemoryError> {
+        let repo = self.repo_for_scope(scope);
+        repo.delete_memory(name, scope).await
+    }
+
+    /// Read a memory from the repo that owns its scope.
+    pub async fn read_memory(&self, name: &str, scope: &Scope) -> Result<Memory, MemoryError> {
+        let repo = self.repo_for_scope(scope);
+        repo.read_memory(name, scope).await
+    }
+
+    /// Move a memory, possibly across repos.
+    pub async fn move_memory(
+        &self,
+        source_name: &str,
+        source_scope: &Scope,
+        dest_name: &MemoryName,
+        dest_scope: &Scope,
+    ) -> Result<Memory, MemoryError> {
+        let source_repo = self.repo_for_scope(source_scope);
+        let dest_repo = self.repo_for_scope(dest_scope);
+
+        if Arc::ptr_eq(source_repo, dest_repo) {
+            // Same repo — use the atomic move.
+            source_repo
+                .move_memory(source_name, source_scope, dest_name, dest_scope)
+                .await
+        } else {
+            // Cross-repo move: read from source, save to dest, delete from source.
+            let source = source_repo.read_memory(source_name, source_scope).await?;
+            let metadata = crate::types::MemoryMetadata::new(
+                dest_scope.clone(),
+                source.metadata.tags.clone(),
+                source.metadata.source.clone(),
+            );
+            let dest = Memory::from_validated(dest_name.clone(), source.content.clone(), metadata);
+            dest_repo.save_memory(&dest).await?;
+            if let Err(e) = source_repo.delete_memory(source_name, source_scope).await {
+                warn!(
+                    error = %e,
+                    source = %source_name,
+                    "cross-repo move: failed to delete source after successful save to destination"
+                );
+            }
+            Ok(dest)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Read operations — aggregate across all repos
+    // -----------------------------------------------------------------------
+
+    /// List memories across all repos, filtered by scope.
+    pub async fn list_memories(&self, scope: Option<&Scope>) -> Result<Vec<Memory>, MemoryError> {
+        if self.routes.is_empty() {
+            return self.default_repo.list_memories(scope).await;
+        }
+
+        let mut all_memories = self.default_repo.list_memories(scope).await?;
+        for route in &self.routes {
+            match route.repo.list_memories(scope).await {
+                Ok(memories) => all_memories.extend(memories),
+                Err(e) => {
+                    warn!(
+                        scope = %route.prefix,
+                        error = %e,
+                        "list_memories: failed to list from scope-specific repo; skipping"
+                    );
+                }
+            }
+        }
+        Ok(all_memories)
+    }
+
+    // -----------------------------------------------------------------------
+    // Sync operations — push/pull each repo independently
+    // -----------------------------------------------------------------------
+
+    /// Sync all repos: pull then push each one.
+    pub async fn sync_all(
+        &self,
+        auth: &AuthProvider,
+        default_branch: &str,
+        pull_first: bool,
+    ) -> Result<MultiSyncResult, MemoryError> {
+        let mut result = MultiSyncResult::default();
+
+        for (label, repo, branch_override) in self.all_repos() {
+            let branch = branch_override.unwrap_or(default_branch);
+            let mut entry = SyncEntry {
+                label: label.to_string(),
+                pull: None,
+                push_ok: false,
+                changes: None,
+            };
+
+            let mut has_remote = true;
+
+            if pull_first {
+                let old_head = repo.head_sha().await;
+                match repo.pull(auth, branch).await {
+                    Ok(pull_result) => {
+                        if matches!(pull_result, PullResult::NoRemote) {
+                            has_remote = false;
+                        }
+                        // Compute changed memories for incremental reindex.
+                        if let PullResult::FastForward {
+                            old_head: oh,
+                            new_head: nh,
+                        }
+                        | PullResult::Merged {
+                            old_head: oh,
+                            new_head: nh,
+                            ..
+                        } = &pull_result
+                        {
+                            let repo_clone = Arc::clone(repo);
+                            let oh = *oh;
+                            let nh = *nh;
+                            match crate::repo::traced_spawn_blocking(move || {
+                                repo_clone.diff_changed_memories(oh, nh)
+                            })
+                            .await
+                            {
+                                Ok(Ok(changes)) if !changes.is_empty() => {
+                                    entry.changes = Some(changes);
+                                }
+                                Ok(Err(e)) => {
+                                    warn!(
+                                        label = %label,
+                                        error = %e,
+                                        "sync: failed to diff changed memories"
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        label = %label,
+                                        error = %e,
+                                        "sync: spawn_blocking failed for diff"
+                                    );
+                                }
+                                _ => {}
+                            }
+                        }
+                        entry.pull = Some(pull_result);
+                    }
+                    Err(e) => {
+                        warn!(
+                            label = %label,
+                            error = %e,
+                            "sync: pull failed"
+                        );
+                        return Err(e);
+                    }
+                }
+            }
+
+            if has_remote {
+                match repo.push(auth, branch).await {
+                    Ok(()) => entry.push_ok = true,
+                    Err(e) => {
+                        warn!(
+                            label = %label,
+                            error = %e,
+                            "sync: push failed"
+                        );
+                        return Err(e);
+                    }
+                }
+            } else {
+                entry.push_ok = true;
+            }
+
+            result.results.push(entry);
+        }
+
+        Ok(result)
+    }
+
+    /// Get the HEAD SHA for the default repo (used for index persistence).
+    pub async fn head_sha(&self) -> Option<String> {
+        self.default_repo.head_sha().await
+    }
+
+    /// Return a reference to the repo for a given scope (for direct access when needed).
+    pub fn repo(&self, scope: &Scope) -> &Arc<MemoryRepo> {
+        self.repo_for_scope(scope)
+    }
+
+    /// Check if there are any scope-specific routes configured.
+    pub fn has_routes(&self) -> bool {
+        !self.routes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ScopePath;
+
+    fn test_repo(dir: &tempfile::TempDir) -> Arc<MemoryRepo> {
+        Arc::new(MemoryRepo::init_or_open(dir.path(), None).unwrap())
+    }
+
+    #[test]
+    fn single_routes_everything_to_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = test_repo(&dir);
+        let router = RepoRouter::single(Arc::clone(&repo));
+
+        assert!(Arc::ptr_eq(router.repo_for_scope(&Scope::Root), &repo));
+        let sp = ScopePath::new("work").unwrap();
+        assert!(Arc::ptr_eq(router.repo_for_scope(&Scope::Path(sp)), &repo));
+    }
+
+    #[test]
+    fn routes_by_scope_prefix() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_repo = test_repo(&work_dir);
+
+        let router = RepoRouter {
+            default_repo: Arc::clone(&default_repo),
+            routes: vec![ScopeRoute {
+                prefix: "work".to_string(),
+                repo: Arc::clone(&work_repo),
+                branch: None,
+            }],
+        };
+
+        // Root goes to default.
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Root),
+            &default_repo
+        ));
+
+        // "work" goes to work repo.
+        let sp = ScopePath::new("work").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &work_repo
+        ));
+
+        // "work/subteam" goes to work repo (prefix match).
+        let sp = ScopePath::new("work/subteam").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &work_repo
+        ));
+
+        // "personal" goes to default.
+        let sp = ScopePath::new("personal").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &default_repo
+        ));
+
+        // "workflow" does NOT match "work" prefix (segment boundary).
+        let sp = ScopePath::new("workflow").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &default_repo
+        ));
+    }
+
+    #[test]
+    fn longest_prefix_wins() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let org_dir = tempfile::tempdir().unwrap();
+        let org_team_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let org_repo = test_repo(&org_dir);
+        let org_team_repo = test_repo(&org_team_dir);
+
+        let mut routes = vec![
+            ScopeRoute {
+                prefix: "org".to_string(),
+                repo: Arc::clone(&org_repo),
+                branch: None,
+            },
+            ScopeRoute {
+                prefix: "org/team".to_string(),
+                repo: Arc::clone(&org_team_repo),
+                branch: None,
+            },
+        ];
+        routes.sort_by(|a, b| b.prefix.len().cmp(&a.prefix.len()));
+
+        let router = RepoRouter {
+            default_repo: Arc::clone(&default_repo),
+            routes,
+        };
+
+        // "org/team" matches the longer prefix.
+        let sp = ScopePath::new("org/team").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &org_team_repo
+        ));
+
+        // "org/other" matches "org".
+        let sp = ScopePath::new("org/other").unwrap();
+        assert!(Arc::ptr_eq(
+            router.repo_for_scope(&Scope::Path(sp)),
+            &org_repo
+        ));
+    }
+
+    #[test]
+    fn branch_override() {
+        let default_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let default_repo = test_repo(&default_dir);
+        let work_repo = test_repo(&work_dir);
+
+        let router = RepoRouter {
+            default_repo: Arc::clone(&default_repo),
+            routes: vec![ScopeRoute {
+                prefix: "work".to_string(),
+                repo: Arc::clone(&work_repo),
+                branch: Some("develop".to_string()),
+            }],
+        };
+
+        assert_eq!(router.branch_for_scope(&Scope::Root, "main"), "main");
+        let sp = ScopePath::new("work").unwrap();
+        assert_eq!(router.branch_for_scope(&Scope::Path(sp), "main"), "develop");
+        let sp = ScopePath::new("other").unwrap();
+        assert_eq!(router.branch_for_scope(&Scope::Path(sp), "main"), "main");
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     error::MemoryError,
     index::VectorStore,
     repo::{traced_spawn_blocking, MemoryRepo},
+    repo_router::RepoRouter,
     types::ScopeFilter,
 };
 
@@ -151,6 +152,41 @@ pub async fn rebuild_lexical_from_repo(
     }
 }
 
+/// Rebuild the lexical index from every repository owned by a router.
+///
+/// Unlike the user-facing aggregate list operation, this is strict: failure
+/// to read any mapped repository leaves the index degraded instead of
+/// treating a partial aggregate as authoritative git truth.
+pub async fn rebuild_lexical_from_router(
+    router: &RepoRouter,
+    lexical: &Arc<LexicalIndex>,
+) -> Result<usize, MemoryError> {
+    let token = lexical.begin_rebuild();
+    let memories = match router.list_memories_strict().await {
+        Ok(memories) => memories,
+        Err(e) => {
+            lexical.mark_rebuild_required("repository listing for lexical rebuild failed");
+            return Err(e);
+        }
+    };
+    let docs: Vec<LexicalDoc> = memories
+        .into_iter()
+        .map(|m| LexicalDoc {
+            qualified_name: m.mem_ref().qualified_path(),
+            name: m.name.to_string(),
+            content: m.content,
+        })
+        .collect();
+    let index = Arc::clone(lexical);
+    match traced_spawn_blocking(move || index.rebuild_from(token, docs)).await {
+        Ok(result) => result,
+        Err(e) => {
+            lexical.mark_rebuild_required("lexical rebuild task did not run to completion");
+            Err(MemoryError::Join(e.to_string()))
+        }
+    }
+}
+
 /// Spawn a background repair rebuild if the lexical index is degraded and
 /// no repair is already running.
 ///
@@ -179,6 +215,29 @@ pub fn spawn_lexical_repair(repo: &Arc<MemoryRepo>, lexical: &Arc<LexicalIndex>)
                  the next trigger repairs again"
             ),
             Ok(count) => info!(count, "lexical index repaired from git truth"),
+            Err(e) => warn!(error = %e, "lexical repair failed — index stays degraded"),
+        }
+    });
+}
+
+/// Spawn a single-flight repair from all repositories owned by a router.
+pub fn spawn_lexical_repair_for_router(router: &RepoRouter, lexical: &Arc<LexicalIndex>) {
+    if !lexical.is_degraded() || !lexical.try_claim_repair() {
+        return;
+    }
+    let router = router.clone();
+    let lexical = Arc::clone(lexical);
+    tokio::spawn(async move {
+        let result = rebuild_lexical_from_router(&router, &lexical).await;
+        lexical.finish_repair();
+        match result {
+            Ok(count) if lexical.is_degraded() => info!(
+                count,
+                "lexical rebuild completed but the index was re-flagged during \
+                 the rebuild (raced mirror or new divergence) — still degraded, \
+                 the next trigger repairs again"
+            ),
+            Ok(count) => info!(count, "lexical index repaired from all git repositories"),
             Err(e) => warn!(error = %e, "lexical repair failed — index stays degraded"),
         }
     });

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@ use crate::{
     recall_log::{BatchVerdict, RecallLog, RecallResult},
     repo::{traced_spawn_blocking, MemoryRepo},
     search::{
-        bm25::DegradeOnDrop, hybrid_search, spawn_lexical_repair, FusedHit, LexicalDoc,
+        bm25::DegradeOnDrop, hybrid_search, spawn_lexical_repair_for_router, FusedHit, LexicalDoc,
         LexicalIndex, LexicalOp,
     },
     types::{
@@ -474,6 +474,7 @@ where
 /// repair, instead of committing the partial mirror as healthy.
 async fn incremental_reindex(
     repo: &Arc<MemoryRepo>,
+    router: &crate::repo_router::RepoRouter,
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
     lexical: &Arc<LexicalIndex>,
@@ -481,7 +482,10 @@ async fn incremental_reindex(
 ) -> ReindexStats {
     let mut stats = ReindexStats::default();
     let mut lexical_ops: Vec<LexicalOp> = Vec::new();
-    let mut lexical_gap = false;
+    let mut lexical_gap = changes.unresolved > 0;
+    if lexical_gap {
+        lexical.mark_rebuild_required("pulled changes contained unresolvable memory files");
+    }
 
     // ---- 1. Removals --------------------------------------------------------
     for mref in &changes.removed {
@@ -544,9 +548,9 @@ async fn incremental_reindex(
             "incremental_reindex: lexical batch update failed; keyword search \
              degraded until repair completes"
         );
-        spawn_lexical_repair(repo, lexical);
+        spawn_lexical_repair_for_router(router, lexical);
     } else if lexical_gap {
-        spawn_lexical_repair(repo, lexical);
+        spawn_lexical_repair_for_router(router, lexical);
     }
 
     if to_embed.is_empty() {
@@ -619,6 +623,7 @@ async fn incremental_reindex(
 /// dying, or pulled files that cannot be resolved to memory references —
 /// marks the lexical index rebuild-required and schedules repair, so a
 /// partial or stale mirror can never keep reporting `Available`.
+#[cfg(test)]
 async fn mirror_pulled_changes(
     state: &Arc<AppState>,
     old_head: [u8; 20],
@@ -635,14 +640,14 @@ async fn mirror_pulled_changes(
             state.lexical.mark_rebuild_required(
                 "post-pull change diff failed — pulled changes not mirrored",
             );
-            spawn_lexical_repair(&state.repo, &state.lexical);
+            spawn_lexical_repair_for_router(&state.router, &state.lexical);
             return Err(e);
         }
         Err(e) => {
             state
                 .lexical
                 .mark_rebuild_required("post-pull change diff task did not run to completion");
-            spawn_lexical_repair(&state.repo, &state.lexical);
+            spawn_lexical_repair_for_router(&state.router, &state.lexical);
             return Err(MemoryError::Join(e.to_string()));
         }
     };
@@ -668,6 +673,7 @@ async fn mirror_pulled_changes(
     if !changes.is_empty() {
         let stats = incremental_reindex(
             &state.repo,
+            &state.router,
             state.embedding.as_ref(),
             state.index.as_ref(),
             &state.lexical,
@@ -687,7 +693,7 @@ async fn mirror_pulled_changes(
     }
 
     if changes.unresolved > 0 {
-        spawn_lexical_repair(&state.repo, &state.lexical);
+        spawn_lexical_repair_for_router(&state.router, &state.lexical);
     }
 
     // Advance the stored SHA so the next startup doesn't trigger a full
@@ -716,7 +722,7 @@ pub async fn full_reindex(
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
 ) -> Result<ReindexStats, MemoryError> {
-    let memories = router.list_memories(None).await?;
+    let memories = router.list_memories_strict().await?;
     if memories.is_empty() {
         return Ok(ReindexStats::default());
     }
@@ -890,7 +896,7 @@ impl MemoryServer {
                         "lexical index update failed during remember; keyword search \
                          degraded until repair completes"
                     );
-                    spawn_lexical_repair(&unit_state.repo, &unit_state.lexical);
+                    spawn_lexical_repair_for_router(&unit_state.router, &unit_state.lexical);
                 }
                 Ok(memory)
             })
@@ -957,7 +963,7 @@ impl MemoryServer {
             // rebuild from git truth (single-flight). This query — and every
             // query until the rebuild converges — serves semantic-only.
             if state.lexical.is_degraded() {
-                spawn_lexical_repair(&state.repo, &state.lexical);
+                spawn_lexical_repair_for_router(&state.router, &state.lexical);
             }
 
             // Semantic and lexical retrieval run in parallel; ranked lists
@@ -1115,7 +1121,7 @@ impl MemoryServer {
                     .await
                 {
                     warn!(name = %unit_name, error = %e, "lexical removal failed during forget; keyword search degraded until repair completes");
-                    spawn_lexical_repair(&unit_state.repo, &unit_state.lexical);
+                    spawn_lexical_repair_for_router(&unit_state.router, &unit_state.lexical);
                 }
                 Ok(())
             })
@@ -1258,7 +1264,7 @@ impl MemoryServer {
                             "lexical index update failed during edit; keyword search \
                              degraded until repair completes"
                         );
-                        spawn_lexical_repair(&unit_state.repo, &unit_state.lexical);
+                        spawn_lexical_repair_for_router(&unit_state.router, &unit_state.lexical);
                     }
                 }
                 Ok((memory, timing))
@@ -1370,10 +1376,27 @@ impl MemoryServer {
                 // 2. Atomically read source, write destination, delete source
                 //    in one git commit. Must happen before index mutations so a
                 //    failure leaves the index consistent with the repo on disk.
-                let dest = unit_state
+                let dest = match unit_state
                     .router
                     .move_memory(&unit_name, &unit_from_scope, &unit_new_name, &unit_to_scope)
-                    .await?;
+                    .await
+                {
+                    Ok(dest) => dest,
+                    Err(e) => {
+                        // Cross-repo moves can fail after the destination was
+                        // committed but before the source was deleted. The
+                        // exact git outcome is then uncertain, so rebuild the
+                        // lexical index from all repository truth.
+                        unit_state
+                            .lexical
+                            .mark_rebuild_required("repo move failed with an uncertain git outcome");
+                        spawn_lexical_repair_for_router(
+                            &unit_state.router,
+                            &unit_state.lexical,
+                        );
+                        return Err(e);
+                    }
+                };
 
                 let dest_qualified = dest.mem_ref().qualified_path();
                 let source_qualified =
@@ -1401,7 +1424,7 @@ impl MemoryServer {
                         "lexical index update failed during move; keyword search degraded \
                          until repair completes"
                     );
-                    spawn_lexical_repair(&unit_state.repo, &unit_state.lexical);
+                    spawn_lexical_repair_for_router(&unit_state.router, &unit_state.lexical);
                 }
 
                 // 4. Embed the content for the new scope's index entry.
@@ -1608,57 +1631,80 @@ impl MemoryServer {
         let state = Arc::clone(&self.state);
         async move {
             let start = Instant::now();
-            let branch = &state.branch;
+            let branch = state.branch.clone();
 
-            let sync_result = state
-                .router
-                .sync_all(&state.auth, branch, pull_first)
+            // Router-wide pull/push plus every derived-index mirror is one
+            // cancellation-shielded mutation unit. A disconnected requester
+            // cannot leave one mapped repo's pull committed but unmirrored.
+            let unit_state = Arc::clone(&state);
+            let unit_branch = branch.clone();
+            let (sync_result, total_reindex, any_reindex) =
+                shielded_mutation_unit(&state.lexical, async move {
+                    let sync_result = unit_state
+                        .router
+                        .sync_all(&unit_state.auth, &unit_branch, pull_first)
+                        .await?;
+
+                    let mut total_reindex = ReindexStats::default();
+                    let mut any_reindex = false;
+                    let mut mirror_incomplete = false;
+                    for entry in &sync_result.results {
+                        if !entry.changes_complete {
+                            mirror_incomplete = true;
+                            unit_state.lexical.mark_rebuild_required(
+                                "post-pull change diff failed — pulled changes not mirrored",
+                            );
+                            spawn_lexical_repair_for_router(
+                                &unit_state.router,
+                                &unit_state.lexical,
+                            );
+                        }
+                        if let Some(ref changes) = entry.resolved_changes {
+                            mirror_incomplete |= changes.unresolved > 0;
+                            let repo = unit_state.router.repo(&entry.scope);
+                            let stats = incremental_reindex(
+                                repo,
+                                &unit_state.router,
+                                unit_state.embedding.as_ref(),
+                                unit_state.index.as_ref(),
+                                &unit_state.lexical,
+                                changes,
+                            )
+                            .instrument(tracing::info_span!(
+                                "server.incremental_reindex",
+                                repo = %entry.label,
+                            ))
+                            .await;
+                            info!(
+                                repo = %entry.label,
+                                added = stats.added,
+                                updated = stats.updated,
+                                removed = stats.removed,
+                                errors = stats.errors,
+                                "incremental reindex complete"
+                            );
+                            total_reindex.added += stats.added;
+                            total_reindex.updated += stats.updated;
+                            total_reindex.removed += stats.removed;
+                            total_reindex.errors += stats.errors;
+                            any_reindex = true;
+                        }
+                    }
+
+                    let reindex_failed_completely = any_reindex
+                        && total_reindex.added == 0
+                        && total_reindex.updated == 0
+                        && total_reindex.errors > 0;
+                    if !mirror_incomplete && !reindex_failed_completely {
+                        if let Some(sha) = unit_state.router.head_sha().await {
+                            unit_state.index.set_commit_sha(Some(&sha));
+                        }
+                    }
+
+                    Ok((sync_result, total_reindex, any_reindex))
+                })
                 .await
                 .map_err(ErrorData::from)?;
-
-            // Incremental reindex for any repos that had changes.
-            let mut total_reindex = ReindexStats::default();
-            let mut any_reindex = false;
-            for entry in &sync_result.results {
-                if let Some(ref changes) = entry.changes {
-                    let repo = state.router.repo(&entry.scope);
-                    let stats = incremental_reindex(
-                        repo,
-                        state.embedding.as_ref(),
-                        state.index.as_ref(),
-                        changes,
-                    )
-                    .instrument(tracing::info_span!(
-                        "server.incremental_reindex",
-                        repo = %entry.label,
-                    ))
-                    .await;
-                    info!(
-                        repo = %entry.label,
-                        added = stats.added,
-                        updated = stats.updated,
-                        removed = stats.removed,
-                        errors = stats.errors,
-                        "incremental reindex complete"
-                    );
-                    total_reindex.added += stats.added;
-                    total_reindex.updated += stats.updated;
-                    total_reindex.removed += stats.removed;
-                    total_reindex.errors += stats.errors;
-                    any_reindex = true;
-                }
-            }
-
-            // Advance the default repo's stored SHA.
-            let reindex_failed_completely = any_reindex
-                && total_reindex.added == 0
-                && total_reindex.updated == 0
-                && total_reindex.errors > 0;
-            if !reindex_failed_completely {
-                if let Some(sha) = state.router.head_sha().await {
-                    state.index.set_commit_sha(Some(&sha));
-                }
-            }
 
             // Build pull status summary.
             let pull_status = if !pull_first {
@@ -3048,7 +3094,7 @@ mod tests {
         use crate::index::InMemoryStore;
         use crate::repo::MemoryRepo;
         use crate::search::bm25::FailPoint;
-        use crate::search::rebuild_lexical_from_repo;
+        use crate::search::{rebuild_lexical_from_repo, spawn_lexical_repair};
         use async_trait::async_trait;
 
         struct MockEmbedding;
@@ -3274,6 +3320,7 @@ mod tests {
             state.lexical.fail_next(FailPoint::Commit);
             let stats = incremental_reindex(
                 &state.repo,
+                &state.router,
                 state.embedding.as_ref(),
                 state.index.as_ref(),
                 &state.lexical,

--- a/src/server.rs
+++ b/src/server.rs
@@ -625,8 +625,9 @@ async fn incremental_reindex(
 /// files could not all be resolved marks the lexical index rebuild-required,
 /// schedules router-wide repair, and refuses to advance the stored composite
 /// SHA — the next startup reindexes from git truth instead of trusting a
-/// partial mirror. The SHA is also held back when every reindex attempt
-/// failed, so the next startup retries.
+/// partial mirror. The SHA is also held back when the reindex recorded *any*
+/// item-level error (#293 review, round 3): a mirror that skipped even one
+/// memory is not verified, so partial success must not certify it.
 ///
 /// The refusal is sticky (#293 review, round 2): once a mirror gap opens,
 /// [`AppState::mark_index_mirror_incomplete`] blocks SHA advancement for the
@@ -680,11 +681,11 @@ async fn mirror_sync_results(
         }
     }
 
-    let reindex_failed_completely = any_reindex
-        && total_reindex.added == 0
-        && total_reindex.updated == 0
-        && total_reindex.errors > 0;
-    if mirror_incomplete || reindex_failed_completely {
+    // Any item-level error means the mirror skipped something (#293 review,
+    // round 3): certification requires errors == 0, not merely "some items
+    // succeeded".
+    let reindex_had_errors = total_reindex.errors > 0;
+    if mirror_incomplete || reindex_had_errors {
         // Sticky for the process lifetime: a later complete sync only
         // mirrors its own pulled range and cannot backfill this gap, so it
         // must not advance the SHA either — only a full reindex (next
@@ -813,7 +814,7 @@ async fn mirror_pulled_changes(
     }
 
     let mut reindex_stats = None;
-    let mut reindex_failed_completely = false;
+    let mut reindex_had_errors = false;
     if !changes.is_empty() {
         let stats = incremental_reindex(
             &state.repo,
@@ -832,7 +833,7 @@ async fn mirror_pulled_changes(
             errors = stats.errors,
             "incremental reindex complete"
         );
-        reindex_failed_completely = stats.added == 0 && stats.updated == 0 && stats.errors > 0;
+        reindex_had_errors = stats.errors > 0;
         reindex_stats = Some(stats);
     }
 
@@ -841,9 +842,10 @@ async fn mirror_pulled_changes(
     }
 
     // Advance the stored SHA so the next startup doesn't trigger a full
-    // reindex for changes already processed. Skip when every embed failed
-    // so the next startup retries.
-    if !reindex_failed_completely {
+    // reindex for changes already processed. Skip when any item-level error
+    // occurred or the change set was incomplete, so the next startup
+    // retries (#293 review, round 3).
+    if !reindex_had_errors && changes.unresolved == 0 {
         if let Some(sha) = state.repo.head_sha().await {
             state.index.set_commit_sha(Some(&sha));
         }
@@ -937,6 +939,53 @@ pub async fn full_reindex(
     }
 
     Ok(stats)
+}
+
+/// Run the startup full reindex and certify the result.
+///
+/// Stamps `head_sha` into the index only when the rebuild recorded zero
+/// item-level errors (#293 review, round 3): a rebuild that skipped even one
+/// memory is not a verified mirror, so the stamp is withheld — the next
+/// startup sees the SHA mismatch and rebuilds again — instead of certifying
+/// an incomplete index as intact.
+///
+/// Returns `true` when the reindex completed cleanly and was certified.
+pub async fn startup_reindex_and_certify(
+    router: &crate::repo_router::RepoRouter,
+    embedding: &dyn EmbeddingBackend,
+    index: &dyn VectorStore,
+    head_sha: Option<&str>,
+) -> bool {
+    match full_reindex(router, embedding, index).await {
+        Ok(stats) => {
+            info!(
+                added = stats.added,
+                errors = stats.errors,
+                "startup reindex complete"
+            );
+            if stats.errors == 0 {
+                if let Some(sha) = head_sha {
+                    index.set_commit_sha(Some(sha));
+                }
+                true
+            } else {
+                warn!(
+                    added = stats.added,
+                    errors = stats.errors,
+                    "startup reindex recorded item-level errors — SHA not stamped, \
+                     the next startup rebuilds instead of trusting a partial index"
+                );
+                false
+            }
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "startup reindex failed — SHA not stamped, will retry on next startup"
+            );
+            false
+        }
+    }
 }
 
 /// Persist the vector index at graceful shutdown.
@@ -4340,6 +4389,148 @@ mod tests {
                 fresh.index.commit_sha(),
                 expected,
                 "a complete mirror must advance the composite SHA"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Partial-rebuild certification (#293 review, round 3)
+        //
+        // A rebuild that recorded any item-level error is not a verified
+        // mirror — certification requires errors == 0. The startup stamp is
+        // withheld and incremental composite-SHA advancement is refused, so
+        // the next startup rebuilds from git truth instead of trusting a
+        // partially populated index that was stamped as intact.
+        // -------------------------------------------------------------------
+
+        /// Embedding backend that fails for content containing
+        /// "poisonword": the batch path errors and the per-item fallback
+        /// records a partial failure (other items embed fine).
+        struct PoisonEmbedding;
+
+        #[async_trait]
+        impl crate::embedding::EmbeddingBackend for PoisonEmbedding {
+            async fn embed(
+                &self,
+                texts: &[String],
+            ) -> Result<Vec<Vec<f32>>, crate::error::MemoryError> {
+                if texts.iter().any(|t| t.contains("poisonword")) {
+                    return Err(crate::error::MemoryError::Internal("poisoned embed".into()));
+                }
+                Ok(texts.iter().map(|_| vec![0.0, 0.0, 0.0, 1.0]).collect())
+            }
+
+            fn dimensions(&self) -> usize {
+                4
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn startup_reindex_with_item_errors_withholds_certification() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let repo = Arc::new(MemoryRepo::init_or_open(tmp.path(), None).expect("repo init"));
+            let router = RepoRouter::single(Arc::clone(&repo));
+
+            let memory = |name: &str, content: &str| {
+                Memory::from_validated(
+                    MemoryName::new(name.to_string()).unwrap(),
+                    content.to_string(),
+                    MemoryMetadata::new(Scope::Root, vec![], None),
+                )
+            };
+            repo.save_memory(&memory("good", "cleanword payload"))
+                .await
+                .expect("save good");
+            repo.save_memory(&memory("bad", "poisonword payload"))
+                .await
+                .expect("save bad");
+            let head = router.head_sha().await;
+            assert!(head.is_some(), "git truth must yield a head SHA");
+
+            // Partial rebuild: one item embeds, one errors. The rebuild
+            // "completes" but must NOT be certified.
+            let index = InMemoryStore::new(4);
+            let certified =
+                startup_reindex_and_certify(&router, &PoisonEmbedding, &index, head.as_deref())
+                    .await;
+            assert!(
+                !certified,
+                "a rebuild with item-level errors must not be certified"
+            );
+            assert_eq!(
+                index.commit_sha(),
+                None,
+                "the SHA stamp must be withheld — stamping would make the \
+                 next startup skip the rebuild that repairs the gap"
+            );
+
+            // Contrast: a clean rebuild of the same truth is certified and
+            // stamps the SHA, proving the withheld stamp above came from
+            // the item-level error, not a missing head.
+            let clean_index = InMemoryStore::new(4);
+            let certified =
+                startup_reindex_and_certify(&router, &MockEmbedding, &clean_index, head.as_deref())
+                    .await;
+            assert!(certified, "a clean rebuild must be certified");
+            assert_eq!(
+                clean_index.commit_sha(),
+                head,
+                "a clean rebuild must stamp the head SHA"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn partial_incremental_reindex_refuses_composite_sha_advancement() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            // Git truth: one readable memory, so head_sha() is Some and
+            // advancement is genuinely possible.
+            let good = Memory::from_validated(
+                MemoryName::new("good".to_string()).unwrap(),
+                "goodword payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&good).await.expect("save");
+
+            // A pulled change set naming the readable memory plus one that
+            // cannot be read back: the reindex partially succeeds and
+            // records one item-level error.
+            let mref = |name: &str| {
+                MemoryRef::new(Scope::Root, MemoryName::new(name.to_string()).unwrap())
+            };
+            let result = MultiSyncResult {
+                results: vec![SyncEntry {
+                    label: "default".to_string(),
+                    scope: Scope::Root,
+                    pull: None,
+                    pull_error: None,
+                    push_ok: true,
+                    push_error: None,
+                    changes: None,
+                    resolved_changes: Some(ResolvedChanges {
+                        upserted: vec![mref("good"), mref("ghost")],
+                        removed: vec![],
+                        unresolved: 0,
+                    }),
+                    changes_complete: true,
+                }],
+            };
+            let (stats, any_reindex) = mirror_sync_results(&state, &result).await;
+            assert!(any_reindex);
+            assert_eq!(stats.added, 1, "the readable memory must still be mirrored");
+            assert_eq!(
+                stats.errors, 1,
+                "the unreadable memory must be recorded as an item-level error"
+            );
+            assert!(
+                !state.index_mirror_is_intact(),
+                "an item-level error must open a sticky mirror gap"
+            );
+            assert_eq!(
+                state.index.commit_sha(),
+                None,
+                "a partially successful reindex must refuse composite-SHA \
+                 advancement — partial success is not certification"
             );
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -627,6 +627,12 @@ async fn incremental_reindex(
 /// SHA — the next startup reindexes from git truth instead of trusting a
 /// partial mirror. The SHA is also held back when every reindex attempt
 /// failed, so the next startup retries.
+///
+/// The refusal is sticky (#293 review, round 2): once a mirror gap opens,
+/// [`AppState::mark_index_mirror_incomplete`] blocks SHA advancement for the
+/// rest of the process — including later syncs whose own mirrors complete,
+/// since they cannot backfill an earlier sync's unmirrored range — and the
+/// shutdown persistence path honours the same flag.
 async fn mirror_sync_results(
     state: &Arc<AppState>,
     sync_result: &MultiSyncResult,
@@ -678,7 +684,14 @@ async fn mirror_sync_results(
         && total_reindex.added == 0
         && total_reindex.updated == 0
         && total_reindex.errors > 0;
-    if !mirror_incomplete && !reindex_failed_completely {
+    if mirror_incomplete || reindex_failed_completely {
+        // Sticky for the process lifetime: a later complete sync only
+        // mirrors its own pulled range and cannot backfill this gap, so it
+        // must not advance the SHA either — only a full reindex (next
+        // startup) closes the gap and re-earns advancement.
+        state.mark_index_mirror_incomplete();
+    }
+    if state.index_mirror_is_intact() {
         if let Some(sha) = state.router.head_sha().await {
             state.index.set_commit_sha(Some(&sha));
         }
@@ -924,6 +937,33 @@ pub async fn full_reindex(
     }
 
     Ok(stats)
+}
+
+/// Persist the vector index at graceful shutdown.
+///
+/// Advances the stored composite SHA to the router's current HEAD only when
+/// the in-process mirror is intact ([`AppState::index_mirror_is_intact`]).
+/// When a mirror gap was recorded — e.g. a sync's post-pull change discovery
+/// failed and the sync mirror refused SHA advancement — the index
+/// keeps the SHA it last legitimately verified, so the next startup sees the
+/// mismatch against git HEAD and rebuilds the vector index from git truth
+/// instead of trusting the incomplete mirror (#293 review, round 2).
+pub async fn persist_index_on_shutdown(
+    state: &AppState,
+    index_dir: &std::path::Path,
+) -> Result<(), MemoryError> {
+    std::fs::create_dir_all(index_dir)?;
+    if state.index_mirror_is_intact() {
+        if let Some(sha) = state.router.head_sha().await {
+            state.index.set_commit_sha(Some(&sha));
+        }
+    } else {
+        info!(
+            stored_sha = ?state.index.commit_sha(),
+            "index mirror incomplete — keeping last verified SHA so the next startup reindexes"
+        );
+    }
+    state.index.save(index_dir)
 }
 
 #[tool_router]
@@ -4269,19 +4309,149 @@ mod tests {
                 "incomplete change discovery must refuse composite-SHA advancement"
             );
 
-            // Contrast: a complete entry advances the SHA, proving the
-            // refusal above came from the incomplete flag, not a missing
-            // head.
+            // Sticky refusal (#293 round 2): a later complete mirror only
+            // covers its own pulled range and cannot backfill the gap left
+            // by the incomplete discovery, so it must not advance the SHA
+            // either — only the next startup's full reindex re-earns it.
             let complete = MultiSyncResult {
                 results: vec![entry(true)],
             };
             let _ = mirror_sync_results(&state, &complete).await;
+            assert_eq!(
+                state.index.commit_sha(),
+                None,
+                "a complete mirror after an earlier gap must keep refusing \
+                 composite-SHA advancement"
+            );
+
+            // Contrast on a gap-free state: a complete entry advances the
+            // SHA, proving the refusals above came from the incomplete
+            // discovery, not a missing head.
+            let fresh_tmp = tempfile::tempdir().expect("tempdir");
+            let fresh = test_state(&fresh_tmp);
+            fresh.repo.save_memory(&memory).await.expect("save");
+            let complete = MultiSyncResult {
+                results: vec![entry(true)],
+            };
+            let _ = mirror_sync_results(&fresh, &complete).await;
+            let expected = fresh.router.head_sha().await;
+            assert!(expected.is_some(), "git truth must yield a head SHA");
+            assert_eq!(
+                fresh.index.commit_sha(),
+                expected,
+                "a complete mirror must advance the composite SHA"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Shutdown persistence vs the incomplete-mirror SHA guard
+        // (#293 review, round 2)
+        //
+        // Graceful shutdown persists the vector index. It must never stamp
+        // the router's current HEAD over a SHA the mirror refused to
+        // advance: doing so would make the next startup see index SHA ==
+        // HEAD and skip the reindex that repairs the incomplete mirror.
+        // -------------------------------------------------------------------
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn shutdown_persistence_refuses_unverified_head_stamp() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            let entry = |changes_complete: bool| SyncEntry {
+                label: "default".to_string(),
+                scope: Scope::Root,
+                pull: None,
+                pull_error: None,
+                push_ok: true,
+                push_error: None,
+                changes: None,
+                resolved_changes: None,
+                changes_complete,
+            };
+
+            // Verified state at A: git truth exists and a complete mirror
+            // stamps the composite SHA.
+            let note_a = Memory::from_validated(
+                MemoryName::new("note-a".to_string()).unwrap(),
+                "payload a".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&note_a).await.expect("save a");
+            let complete = MultiSyncResult {
+                results: vec![entry(true)],
+            };
+            let _ = mirror_sync_results(&state, &complete).await;
+            let sha_a = state.index.commit_sha().expect("verified SHA at A");
+
+            // Git advances A → B, but post-pull change discovery for that
+            // range fails: the mirror refuses advancement, SHA stays at A.
+            let note_b = Memory::from_validated(
+                MemoryName::new("note-b".to_string()).unwrap(),
+                "payload b".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&note_b).await.expect("save b");
+            let incomplete = MultiSyncResult {
+                results: vec![entry(false)],
+            };
+            let _ = mirror_sync_results(&state, &incomplete).await;
+            assert_eq!(
+                state.index.commit_sha().as_deref(),
+                Some(sha_a.as_str()),
+                "precondition: the refused advancement must leave the SHA at A"
+            );
+            let head_b = state.router.head_sha().await.expect("git HEAD at B");
+            assert_ne!(head_b, sha_a, "git must have advanced past A");
+
+            // The graceful-shutdown persistence path must keep the verified
+            // SHA rather than stamping the current HEAD.
+            let index_dir = tempfile::tempdir().expect("index dir");
+            persist_index_on_shutdown(&state, index_dir.path())
+                .await
+                .expect("persist");
+            assert_eq!(
+                state.index.commit_sha().as_deref(),
+                Some(sha_a.as_str()),
+                "shutdown must persist only the last verified SHA — stamping \
+                 HEAD would make the next startup skip the repairing reindex"
+            );
+            assert_ne!(
+                state.index.commit_sha(),
+                state.router.head_sha().await,
+                "the persisted SHA must mismatch HEAD so the next startup's \
+                 freshness check triggers a full reindex"
+            );
+        }
+
+        /// The stamp still happens when no mirror gap was recorded: ordinary
+        /// writes advance HEAD while mirroring themselves, and shutdown
+        /// stamping is what lets the next startup skip a redundant reindex.
+        /// Regression guard for over-tightening the shutdown fix.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn shutdown_persistence_stamps_head_when_mirror_intact() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            let memory = Memory::from_validated(
+                MemoryName::new("note".to_string()).unwrap(),
+                "payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&memory).await.expect("save");
+            assert_eq!(state.index.commit_sha(), None);
+
+            let index_dir = tempfile::tempdir().expect("index dir");
+            persist_index_on_shutdown(&state, index_dir.path())
+                .await
+                .expect("persist");
             let expected = state.router.head_sha().await;
             assert!(expected.is_some(), "git truth must yield a head SHA");
             assert_eq!(
                 state.index.commit_sha(),
                 expected,
-                "a complete mirror must advance the composite SHA"
+                "an intact mirror must stamp HEAD at shutdown so the next \
+                 startup can skip the reindex"
             );
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -2305,17 +2305,11 @@ fn build_snippet(content: &str) -> (String, usize, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_log::capture_info_logs;
     use crate::{auth::AuthProvider, health::HealthRegistry, index::InMemoryStore};
     use async_trait::async_trait;
     use rmcp::model::Content;
-    use std::{
-        io::Write,
-        sync::{Arc, Mutex},
-    };
-    use tracing::subscriber::with_default;
-    use tracing_subscriber::{layer::SubscriberExt, Registry};
-
-    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+    use std::sync::Arc;
 
     struct ListTestEmbedding;
 
@@ -2328,32 +2322,6 @@ mod tests {
         fn dimensions(&self) -> usize {
             4
         }
-    }
-
-    impl Write for TestWriter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.lock().expect("log buffer").extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    fn capture_info_logs(f: impl FnOnce()) -> String {
-        let output = Arc::new(Mutex::new(Vec::new()));
-        let writer_output = Arc::clone(&output);
-        let subscriber = Registry::default()
-            .with(tracing_subscriber::EnvFilter::new("info"))
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .with_ansi(false)
-                    .with_writer(move || TestWriter(Arc::clone(&writer_output))),
-            );
-        with_default(subscriber, f);
-        let bytes = output.lock().expect("log buffer").clone();
-        String::from_utf8(bytes).expect("UTF-8 logs")
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1620,11 +1620,7 @@ impl MemoryServer {
             let mut any_reindex = false;
             for entry in &sync_result.results {
                 if let Some(ref changes) = entry.changes {
-                    let repo = state.router.repo(&if entry.label == "default" {
-                        Scope::Root
-                    } else {
-                        Scope::parse_or_default(Some(&entry.label)).unwrap_or(Scope::Root)
-                    });
+                    let repo = state.router.repo(&entry.scope);
                     let stats = incremental_reindex(
                         repo,
                         state.embedding.as_ref(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -702,20 +702,21 @@ async fn mirror_pulled_changes(
     Ok(reindex_stats)
 }
 
-/// Re-embed and re-index all memories in the repository.
+/// Re-embed and re-index all memories across all repos.
 ///
-/// This is a full rebuild: all memories are listed, their content is embedded,
-/// and the index is updated. Intended for startup freshness checks and
-/// recovery after a crash that discarded an in-progress index.
+/// This is a full rebuild: all memories are listed (via the router, which
+/// aggregates across scope-specific repos), their content is embedded, and the
+/// index is updated. Intended for startup freshness checks and recovery after
+/// a crash that discarded an in-progress index.
 ///
 /// Unlike delegating to `incremental_reindex`, this function uses the content
 /// already loaded by `list_memories` to avoid reading each file a second time.
 pub async fn full_reindex(
-    repo: &Arc<MemoryRepo>,
+    router: &crate::repo_router::RepoRouter,
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
 ) -> Result<ReindexStats, MemoryError> {
-    let memories = repo.list_memories(None).await?;
+    let memories = router.list_memories(None).await?;
     if memories.is_empty() {
         return Ok(ReindexStats::default());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -45,6 +45,7 @@ use crate::{
     index::VectorStore,
     recall_log::{BatchVerdict, RecallLog, RecallResult},
     repo::{traced_spawn_blocking, MemoryRepo},
+    repo_router::MultiSyncResult,
     search::{
         bm25::DegradeOnDrop, hybrid_search, spawn_lexical_repair_for_router, FusedHit, LexicalDoc,
         LexicalIndex, LexicalOp,
@@ -613,6 +614,136 @@ async fn incremental_reindex(
     }
 
     stats
+}
+
+/// Mirror `sync_all` results into the derived indexes and advance the
+/// composite index SHA when — and only when — the mirror is complete.
+///
+/// Runs inside sync's cancellation-shielded unit, after the pulls have moved
+/// git truth. Complete-or-degraded (#314): a repo whose post-pull change
+/// discovery did not complete (`changes_complete == false`) or whose pulled
+/// files could not all be resolved marks the lexical index rebuild-required,
+/// schedules router-wide repair, and refuses to advance the stored composite
+/// SHA — the next startup reindexes from git truth instead of trusting a
+/// partial mirror. The SHA is also held back when every reindex attempt
+/// failed, so the next startup retries.
+async fn mirror_sync_results(
+    state: &Arc<AppState>,
+    sync_result: &MultiSyncResult,
+) -> (ReindexStats, bool) {
+    let mut total_reindex = ReindexStats::default();
+    let mut any_reindex = false;
+    let mut mirror_incomplete = false;
+    for entry in &sync_result.results {
+        if !entry.changes_complete {
+            mirror_incomplete = true;
+            state.lexical.mark_rebuild_required(
+                "post-pull change diff failed — pulled changes not mirrored",
+            );
+            spawn_lexical_repair_for_router(&state.router, &state.lexical);
+        }
+        if let Some(ref changes) = entry.resolved_changes {
+            mirror_incomplete |= changes.unresolved > 0;
+            let repo = state.router.repo(&entry.scope);
+            let stats = incremental_reindex(
+                repo,
+                &state.router,
+                state.embedding.as_ref(),
+                state.index.as_ref(),
+                &state.lexical,
+                changes,
+            )
+            .instrument(tracing::info_span!(
+                "server.incremental_reindex",
+                repo = %entry.label,
+            ))
+            .await;
+            info!(
+                repo = %entry.label,
+                added = stats.added,
+                updated = stats.updated,
+                removed = stats.removed,
+                errors = stats.errors,
+                "incremental reindex complete"
+            );
+            total_reindex.added += stats.added;
+            total_reindex.updated += stats.updated;
+            total_reindex.removed += stats.removed;
+            total_reindex.errors += stats.errors;
+            any_reindex = true;
+        }
+    }
+
+    let reindex_failed_completely = any_reindex
+        && total_reindex.added == 0
+        && total_reindex.updated == 0
+        && total_reindex.errors > 0;
+    if !mirror_incomplete && !reindex_failed_completely {
+        if let Some(sha) = state.router.head_sha().await {
+            state.index.set_commit_sha(Some(&sha));
+        }
+    }
+
+    (total_reindex, any_reindex)
+}
+
+/// Per-repo failure detail carried in the `sync` tool's error payload.
+#[derive(Debug, Serialize)]
+struct SyncRepoFailure {
+    /// Repo label (`"default"` or the scope prefix).
+    label: String,
+    /// Pull error message, when the pull failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pull_error: Option<String>,
+    /// Push error message, when the push failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    push_error: Option<String>,
+}
+
+/// Build the `sync` tool error for a sync where at least one repo's pull or
+/// push failed.
+///
+/// Matches the single-repo contract where pull/push failures surface as MCP
+/// tool errors: the message enumerates every failed repo with its error, and
+/// the structured `data` payload carries the failed entries plus the labels
+/// of repos that synced cleanly, so partial success stays visible.
+fn sync_failure_error(sync_result: &MultiSyncResult, branch: &str) -> ErrorData {
+    let failed: Vec<SyncRepoFailure> = sync_result
+        .results
+        .iter()
+        .filter(|e| !e.is_ok())
+        .map(|e| SyncRepoFailure {
+            label: e.label.clone(),
+            pull_error: e.pull_error.clone(),
+            push_error: e.push_error.clone(),
+        })
+        .collect();
+    let succeeded: Vec<&str> = sync_result
+        .results
+        .iter()
+        .filter(|e| e.is_ok())
+        .map(|e| e.label.as_str())
+        .collect();
+    let summary = sync_result
+        .results
+        .iter()
+        .filter_map(|e| e.failure_summary().map(|s| format!("{}: {s}", e.label)))
+        .collect::<Vec<_>>()
+        .join("; ");
+    ErrorData {
+        code: rmcp::model::ErrorCode::INTERNAL_ERROR,
+        message: Cow::Owned(format!(
+            "sync failed for {}/{} repos: {summary}",
+            failed.len(),
+            sync_result.results.len()
+        )),
+        data: Some(serde_json::json!({
+            "status": "sync failed",
+            "branch": branch,
+            "failed": failed,
+            "succeeded": succeeded,
+        })),
+    }
 }
 
 /// Mirror a pull's git changes into the vector and lexical indexes.
@@ -1644,67 +1775,23 @@ impl MemoryServer {
                         .router
                         .sync_all(&unit_state.auth, &unit_branch, pull_first)
                         .await?;
-
-                    let mut total_reindex = ReindexStats::default();
-                    let mut any_reindex = false;
-                    let mut mirror_incomplete = false;
-                    for entry in &sync_result.results {
-                        if !entry.changes_complete {
-                            mirror_incomplete = true;
-                            unit_state.lexical.mark_rebuild_required(
-                                "post-pull change diff failed — pulled changes not mirrored",
-                            );
-                            spawn_lexical_repair_for_router(
-                                &unit_state.router,
-                                &unit_state.lexical,
-                            );
-                        }
-                        if let Some(ref changes) = entry.resolved_changes {
-                            mirror_incomplete |= changes.unresolved > 0;
-                            let repo = unit_state.router.repo(&entry.scope);
-                            let stats = incremental_reindex(
-                                repo,
-                                &unit_state.router,
-                                unit_state.embedding.as_ref(),
-                                unit_state.index.as_ref(),
-                                &unit_state.lexical,
-                                changes,
-                            )
-                            .instrument(tracing::info_span!(
-                                "server.incremental_reindex",
-                                repo = %entry.label,
-                            ))
-                            .await;
-                            info!(
-                                repo = %entry.label,
-                                added = stats.added,
-                                updated = stats.updated,
-                                removed = stats.removed,
-                                errors = stats.errors,
-                                "incremental reindex complete"
-                            );
-                            total_reindex.added += stats.added;
-                            total_reindex.updated += stats.updated;
-                            total_reindex.removed += stats.removed;
-                            total_reindex.errors += stats.errors;
-                            any_reindex = true;
-                        }
-                    }
-
-                    let reindex_failed_completely = any_reindex
-                        && total_reindex.added == 0
-                        && total_reindex.updated == 0
-                        && total_reindex.errors > 0;
-                    if !mirror_incomplete && !reindex_failed_completely {
-                        if let Some(sha) = unit_state.router.head_sha().await {
-                            unit_state.index.set_commit_sha(Some(&sha));
-                        }
-                    }
-
+                    let (total_reindex, any_reindex) =
+                        mirror_sync_results(&unit_state, &sync_result).await;
                     Ok((sync_result, total_reindex, any_reindex))
                 })
                 .await
                 .map_err(ErrorData::from)?;
+
+            // A failed pull or push on any repo must fail the tool call —
+            // successful repos were still synced and mirrored above, but a
+            // clean "sync complete" here would silently drop the failures.
+            if !sync_result.all_ok() {
+                warn!(
+                    ms = start.elapsed().as_millis(),
+                    pull_first, "sync finished with per-repo failures"
+                );
+                return Err(sync_failure_error(&sync_result, &branch));
+            }
 
             // Build pull status summary.
             let pull_status = if !pull_first {
@@ -3090,9 +3177,11 @@ mod tests {
     mod lexical_failure_receipts {
         use super::*;
         use crate::auth::AuthProvider;
+        use crate::config::RemoteMapping;
         use crate::health::HealthRegistry;
         use crate::index::InMemoryStore;
         use crate::repo::MemoryRepo;
+        use crate::repo_router::{RepoRouter, SyncEntry};
         use crate::search::bm25::FailPoint;
         use crate::search::{rebuild_lexical_from_repo, spawn_lexical_repair};
         use async_trait::async_trait;
@@ -3698,10 +3787,17 @@ mod tests {
         }
 
         async fn run_sync(server: &MemoryServer) -> Result<String, ErrorData> {
+            run_sync_with(server, true).await
+        }
+
+        async fn run_sync_with(
+            server: &MemoryServer,
+            pull_first: bool,
+        ) -> Result<String, ErrorData> {
             server
                 .sync(
                     Parameters(SyncArgs {
-                        pull_first: Some(true),
+                        pull_first: Some(pull_first),
                     }),
                     Extension(parts()),
                 )
@@ -3895,6 +3991,298 @@ mod tests {
             .await;
             assert_lexical_converges(&fx.state, "goodword", &[qualified(&Scope::Root, "good")])
                 .await;
+        }
+
+        // -------------------------------------------------------------------
+        // Sync failure surfacing (#293 review, finding 1)
+        //
+        // A failed pull or push must fail the `sync` tool call — per-repo
+        // resilience (continue syncing the other repos) must not become an
+        // acked-but-lost sync where the caller reads "sync complete" while
+        // every push failed.
+        // -------------------------------------------------------------------
+
+        /// State whose repo has an origin that cannot be reached, so pull and
+        /// push fail at the transport level.
+        fn bad_remote_state(tmp: &tempfile::TempDir) -> Arc<AppState> {
+            let repo = MemoryRepo::init_or_open(
+                tmp.path(),
+                Some("file:///nonexistent/memory-mcp-test-remote.git"),
+            )
+            .expect("repo init");
+            Arc::new(AppState::new(
+                Arc::new(repo),
+                "main".to_string(),
+                Box::new(MockEmbedding),
+                Box::new(InMemoryStore::new(4)),
+                sync_auth(),
+                HealthRegistry::new(),
+                None,
+            ))
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn sync_push_failure_surfaces_as_tool_error() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = bad_remote_state(&tmp);
+            let server = MemoryServer::new(Arc::clone(&state));
+
+            // A real local commit, so the push is genuinely attempted.
+            let memory = Memory::from_validated(
+                MemoryName::new("note".to_string()).unwrap(),
+                "pushfail payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&memory).await.expect("save");
+
+            let err = run_sync_with(&server, false)
+                .await
+                .expect_err("a failed push must fail the sync tool call");
+            assert!(
+                err.message.contains("sync failed for 1/1 repos"),
+                "error must name the failed/total counts: {}",
+                err.message
+            );
+            assert!(
+                err.message.contains("default: push failed:"),
+                "error must enumerate the failing repo and operation: {}",
+                err.message
+            );
+            let data = err.data.expect("structured failure payload");
+            assert_eq!(data["failed"][0]["label"], "default");
+            assert!(
+                data["failed"][0]["push_error"].is_string(),
+                "push_error must carry the failure: {data}"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn sync_pull_failure_reported_failed_not_skipped() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = bad_remote_state(&tmp);
+            let server = MemoryServer::new(Arc::clone(&state));
+
+            let err = run_sync_with(&server, true)
+                .await
+                .expect_err("a failed pull must fail the sync tool call");
+            assert!(
+                err.message.contains("default: pull failed:"),
+                "a failed pull must be reported as failed: {}",
+                err.message
+            );
+            assert!(
+                !err.message.contains("skipped"),
+                "a failed pull must not be reported as skipped: {}",
+                err.message
+            );
+            let data = err.data.expect("structured failure payload");
+            assert!(
+                data["failed"][0]["pull_error"].is_string(),
+                "pull_error must carry the failure: {data}"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn sync_mixed_failure_enumerates_failed_and_succeeded() {
+            // Reachable bare origin for the default repo, seeded by a writer.
+            let remote_dir = tempfile::tempdir().expect("tempdir");
+            git2::Repository::init_bare(remote_dir.path()).expect("bare init");
+            let remote_url = format!("file://{}", remote_dir.path().display());
+            let writer_dir = tempfile::tempdir().expect("tempdir");
+            let writer = Arc::new(
+                MemoryRepo::init_or_open(writer_dir.path(), Some(&remote_url))
+                    .expect("writer repo"),
+            );
+            let seed = Memory::from_validated(
+                MemoryName::new("seed".to_string()).unwrap(),
+                "seedword payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            writer.save_memory(&seed).await.expect("writer save");
+            writer
+                .push(&sync_auth(), "main")
+                .await
+                .expect("writer push");
+
+            let default_dir = tempfile::tempdir().expect("tempdir");
+            let default_repo = Arc::new(
+                MemoryRepo::init_or_open(default_dir.path(), Some(&remote_url))
+                    .expect("default repo"),
+            );
+
+            // Mapped repo whose origin cannot be reached: its pull fails.
+            let work_dir = tempfile::tempdir().expect("tempdir");
+            let health = HealthRegistry::new();
+            let mapping = RemoteMapping {
+                scope: "work".to_string(),
+                url: "file:///nonexistent/memory-mcp-test-remote.git".to_string(),
+                path: Some(work_dir.path().display().to_string()),
+                branch: None,
+            };
+            let router = RepoRouter::from_config(
+                Arc::clone(&default_repo),
+                std::slice::from_ref(&mapping),
+                &health.git,
+                &health.sync,
+            )
+            .expect("router");
+            let state = Arc::new(AppState::with_router(
+                Arc::clone(&default_repo),
+                router,
+                "main".to_string(),
+                Box::new(MockEmbedding),
+                Box::new(InMemoryStore::new(4)),
+                sync_auth(),
+                health,
+                None,
+            ));
+            let server = MemoryServer::new(Arc::clone(&state));
+
+            let err = run_sync(&server)
+                .await
+                .expect_err("one failing repo must fail the sync tool call");
+            assert!(
+                err.message.contains("sync failed for 1/2 repos"),
+                "error must show partial failure counts: {}",
+                err.message
+            );
+            assert!(
+                err.message.contains("work: pull failed:"),
+                "error must name the failing repo: {}",
+                err.message
+            );
+            let data = err.data.expect("structured failure payload");
+            assert_eq!(
+                data["succeeded"],
+                serde_json::json!(["default"]),
+                "the repo that synced cleanly must stay visible: {data}"
+            );
+            assert_eq!(data["failed"][0]["label"], "work");
+
+            // Per-repo resilience held: the default repo pulled the seeded
+            // memory despite the mapped repo's failure.
+            state
+                .repo
+                .read_memory("seed", &Scope::Root)
+                .await
+                .expect("default repo must sync despite the mapped repo failing");
+        }
+
+        /// Wire-contract receipt for the sync failure payload: message and
+        /// structured `data` shapes MCP clients parse.
+        #[test]
+        fn sync_failure_error_wire_shape() {
+            let result = MultiSyncResult {
+                results: vec![
+                    SyncEntry {
+                        label: "default".to_string(),
+                        scope: Scope::Root,
+                        pull: Some(PullResult::UpToDate),
+                        pull_error: None,
+                        push_ok: true,
+                        push_error: None,
+                        changes: None,
+                        resolved_changes: None,
+                        changes_complete: true,
+                    },
+                    SyncEntry {
+                        label: "work".to_string(),
+                        scope: Scope::Root,
+                        pull: None,
+                        pull_error: Some("git error: boom".to_string()),
+                        push_ok: false,
+                        push_error: None,
+                        changes: None,
+                        resolved_changes: None,
+                        changes_complete: true,
+                    },
+                ],
+            };
+
+            let err = sync_failure_error(&result, "main");
+            assert_eq!(err.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+            assert_eq!(
+                err.message,
+                "sync failed for 1/2 repos: work: pull failed: git error: boom"
+            );
+            assert_eq!(
+                err.data.expect("data"),
+                serde_json::json!({
+                    "status": "sync failed",
+                    "branch": "main",
+                    "failed": [{"label": "work", "pull_error": "git error: boom"}],
+                    "succeeded": ["default"],
+                })
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Composite-SHA advancement refusal (#293 review, finding 2)
+        //
+        // The production mirror seam: an entry whose post-pull change
+        // discovery did not complete must degrade the lexical index and
+        // refuse to advance the stored composite SHA, so the next startup
+        // reindexes from git truth.
+        // -------------------------------------------------------------------
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn incomplete_change_discovery_refuses_composite_sha_advancement() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            // Git truth exists, so head_sha() is Some and advancement is
+            // genuinely possible — the refusal below is the differentiator.
+            let memory = Memory::from_validated(
+                MemoryName::new("note".to_string()).unwrap(),
+                "shaword payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&memory).await.expect("save");
+
+            // Hold the repair slot so the degraded window is observable.
+            assert!(state.lexical.try_claim_repair());
+
+            let entry = |changes_complete: bool| SyncEntry {
+                label: "default".to_string(),
+                scope: Scope::Root,
+                pull: None,
+                pull_error: None,
+                push_ok: true,
+                push_error: None,
+                changes: None,
+                resolved_changes: None,
+                changes_complete,
+            };
+
+            let incomplete = MultiSyncResult {
+                results: vec![entry(false)],
+            };
+            let (_stats, any_reindex) = mirror_sync_results(&state, &incomplete).await;
+            assert!(!any_reindex);
+            assert!(
+                state.lexical.is_degraded(),
+                "incomplete change discovery must mark the index rebuild-required"
+            );
+            assert_eq!(
+                state.index.commit_sha(),
+                None,
+                "incomplete change discovery must refuse composite-SHA advancement"
+            );
+
+            // Contrast: a complete entry advances the SHA, proving the
+            // refusal above came from the incomplete flag, not a missing
+            // head.
+            let complete = MultiSyncResult {
+                results: vec![entry(true)],
+            };
+            let _ = mirror_sync_results(&state, &complete).await;
+            let expected = state.router.head_sha().await;
+            assert!(expected.is_some(), "git truth must yield a head SHA");
+            assert_eq!(
+                state.index.commit_sha(),
+                expected,
+                "a complete mirror must advance the composite SHA"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -866,7 +866,7 @@ impl MemoryServer {
             let start = Instant::now();
             let unit_state = Arc::clone(&state);
             let memory = shielded_mutation_unit(&state.lexical, async move {
-                unit_state.repo.save_memory(&memory).await?;
+                unit_state.router.save_memory(&memory).await?;
                 info!(repo_ms = start.elapsed().as_millis(), "saved to repo");
 
                 // Mirror into the lexical index after git truth is durable,
@@ -1004,7 +1004,7 @@ impl MemoryServer {
                 };
 
                 // Read the memory; if it was deleted but still in the index, skip it.
-                let memory = match state.repo.read_memory(&mref.name, &mref.scope).await {
+                let memory = match state.router.read_memory(&mref.name, &mref.scope).await {
                     Ok(m) => m,
                     Err(e) => {
                         warn!(
@@ -1097,7 +1097,10 @@ impl MemoryServer {
             shielded_mutation_unit(&state.lexical, async move {
                 // Delete from repo first — if this fails, index is untouched,
                 // memory stays functional.
-                unit_state.repo.delete_memory(&unit_name, &scope).await?;
+                unit_state
+                    .router
+                    .delete_memory(&unit_name, &scope)
+                    .await?;
 
                 // Remove from index (best-effort — stale entries are skipped at recall time).
                 let qualified_name =
@@ -1188,7 +1191,7 @@ impl MemoryServer {
             // Read the existing memory.
             timing.stage = "read";
             let stage_start = Instant::now();
-            let read_result = state.repo.read_memory(&name, &scope).await;
+            let read_result = state.router.read_memory(&name, &scope).await;
             timing.read_ms = elapsed_ms(stage_start);
             let mut memory = read_result.map_err(ErrorData::from)?;
 
@@ -1228,7 +1231,7 @@ impl MemoryServer {
             let unit_state = Arc::clone(&state);
             let (memory, mut timing) = shielded_mutation_unit(&state.lexical, async move {
                 let stage_start = Instant::now();
-                let save_result = unit_state.repo.save_memory(&memory).await;
+                let save_result = unit_state.router.save_memory(&memory).await;
                 timing.repo_save_ms = elapsed_ms(stage_start);
                 save_result?;
 
@@ -1333,7 +1336,7 @@ impl MemoryServer {
             let start = Instant::now();
 
             // 1. Reject early if the destination already exists.
-            match state.repo.read_memory(&new_name, &to_scope).await {
+            match state.router.read_memory(&new_name, &to_scope).await {
                 Ok(_) => {
                     return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
                         reason: format!(
@@ -1367,7 +1370,7 @@ impl MemoryServer {
                 //    in one git commit. Must happen before index mutations so a
                 //    failure leaves the index consistent with the repo on disk.
                 let dest = unit_state
-                    .repo
+                    .router
                     .move_memory(&unit_name, &unit_from_scope, &unit_new_name, &unit_to_scope)
                     .await?;
 
@@ -1488,24 +1491,24 @@ impl MemoryServer {
             let start = Instant::now();
             let memories = match &scope_filter {
                 ScopeFilter::RootOnly => state
-                    .repo
+                    .router
                     .list_memories(Some(&Scope::Root))
                     .await
                     .map_err(ErrorData::from)?,
                 ScopeFilter::All => state
-                    .repo
+                    .router
                     .list_memories(None)
                     .await
                     .map_err(ErrorData::from)?,
                 ScopeFilter::Subtree(sp) => {
                     let path_scope = Scope::Path(sp.clone());
                     let mut root_memories = state
-                        .repo
+                        .router
                         .list_memories(Some(&Scope::Root))
                         .await
                         .map_err(ErrorData::from)?;
                     let path_memories = state
-                        .repo
+                        .router
                         .list_memories(Some(&path_scope))
                         .await
                         .map_err(ErrorData::from)?;
@@ -1551,7 +1554,7 @@ impl MemoryServer {
 
             let start = Instant::now();
             let memory = state
-                .repo
+                .router
                 .read_memory(&name, &scope)
                 .await
                 .map_err(ErrorData::from)?;
@@ -1606,76 +1609,78 @@ impl MemoryServer {
             let start = Instant::now();
             let branch = &state.branch;
 
-            // Track whether origin is configured at all so we can skip push
-            // for local-only deployments that have no remote.
-            let mut has_remote = true;
+            let sync_result = state
+                .router
+                .sync_all(&state.auth, branch, pull_first)
+                .await
+                .map_err(ErrorData::from)?;
 
-            let mut reindex_stats: Option<ReindexStats> = None;
-
-            let pull_status = if pull_first {
-                // Pull + incremental reindex run as one cancellation-shielded
-                // unit: cancelling this request can no longer land the pull's
-                // git commits while stranding the reindex that mirrors them
-                // into the vector and lexical indexes (#310, ADR-0039).
-                let unit_state = Arc::clone(&state);
-                let (status, unit_reindex_stats, unit_has_remote) =
-                    shielded_mutation_unit(&state.lexical, async move {
-                        let branch = &unit_state.branch;
-                        let mut has_remote = true;
-                        let mut reindex_stats: Option<ReindexStats> = None;
-
-                        let result = unit_state.repo.pull(&unit_state.auth, branch).await?;
-
-                        let mut oid_range: Option<([u8; 20], [u8; 20])> = None;
-                        let status = match result {
-                            PullResult::NoRemote => {
-                                has_remote = false;
-                                "no-remote".to_string()
-                            }
-                            PullResult::UpToDate => "up-to-date".to_string(),
-                            PullResult::FastForward { old_head, new_head } => {
-                                oid_range = Some((old_head, new_head));
-                                "fast-forward".to_string()
-                            }
-                            PullResult::Merged {
-                                conflicts_resolved,
-                                old_head,
-                                new_head,
-                            } => {
-                                oid_range = Some((old_head, new_head));
-                                format!("merged ({} conflicts resolved)", conflicts_resolved)
-                            }
-                        };
-
-                        if let Some((old_head, new_head)) = oid_range {
-                            // Complete-or-degraded: the pull has already
-                            // moved git truth, so `mirror_pulled_changes`
-                            // owns flagging the lexical index and scheduling
-                            // repair for every preparation failure before
-                            // propagating the error (#314).
-                            reindex_stats =
-                                mirror_pulled_changes(&unit_state, old_head, new_head).await?;
-                        }
-
-                        Ok((status, reindex_stats, has_remote))
-                    })
-                    .await
-                    .map_err(ErrorData::from)?;
-
-                reindex_stats = unit_reindex_stats;
-                has_remote = unit_has_remote;
-                status
-            } else {
-                "skipped".to_string()
-            };
-
-            if has_remote {
-                state
-                    .repo
-                    .push(&state.auth, branch)
-                    .await
-                    .map_err(ErrorData::from)?;
+            // Incremental reindex for any repos that had changes.
+            let mut total_reindex = ReindexStats::default();
+            let mut any_reindex = false;
+            for entry in &sync_result.results {
+                if let Some(ref changes) = entry.changes {
+                    let repo = state.router.repo(&if entry.label == "default" {
+                        Scope::Root
+                    } else {
+                        Scope::parse_or_default(Some(&entry.label)).unwrap_or(Scope::Root)
+                    });
+                    let stats = incremental_reindex(
+                        repo,
+                        state.embedding.as_ref(),
+                        state.index.as_ref(),
+                        changes,
+                    )
+                    .instrument(tracing::info_span!(
+                        "server.incremental_reindex",
+                        repo = %entry.label,
+                    ))
+                    .await;
+                    info!(
+                        repo = %entry.label,
+                        added = stats.added,
+                        updated = stats.updated,
+                        removed = stats.removed,
+                        errors = stats.errors,
+                        "incremental reindex complete"
+                    );
+                    total_reindex.added += stats.added;
+                    total_reindex.updated += stats.updated;
+                    total_reindex.removed += stats.removed;
+                    total_reindex.errors += stats.errors;
+                    any_reindex = true;
+                }
             }
+
+            // Advance the default repo's stored SHA.
+            let reindex_failed_completely = any_reindex
+                && total_reindex.added == 0
+                && total_reindex.updated == 0
+                && total_reindex.errors > 0;
+            if !reindex_failed_completely {
+                if let Some(sha) = state.router.head_sha().await {
+                    state.index.set_commit_sha(Some(&sha));
+                }
+            }
+
+            // Build pull status summary.
+            let pull_status = if !pull_first {
+                "skipped".to_string()
+            } else if sync_result.results.len() == 1 {
+                match &sync_result.results[0].pull {
+                    Some(PullResult::NoRemote) => "no-remote".to_string(),
+                    Some(PullResult::UpToDate) => "up-to-date".to_string(),
+                    Some(PullResult::FastForward { .. }) => "fast-forward".to_string(),
+                    Some(PullResult::Merged {
+                        conflicts_resolved, ..
+                    }) => {
+                        format!("merged ({} conflicts resolved)", conflicts_resolved)
+                    }
+                    None => "skipped".to_string(),
+                }
+            } else {
+                format!("{} repos synced", sync_result.results.len())
+            };
 
             info!(
                 ms = start.elapsed().as_millis(),
@@ -1690,12 +1695,12 @@ impl MemoryServer {
                 "branch": branch,
             });
 
-            if let Some(stats) = reindex_stats {
+            if any_reindex {
                 response["reindex"] = serde_json::json!({
-                    "added": stats.added,
-                    "updated": stats.updated,
-                    "removed": stats.removed,
-                    "errors": stats.errors,
+                    "added": total_reindex.added,
+                    "updated": total_reindex.updated,
+                    "removed": total_reindex.removed,
+                    "errors": total_reindex.errors,
                 });
             }
 

--- a/src/test_log.rs
+++ b/src/test_log.rs
@@ -1,0 +1,40 @@
+//! Test-only tracing capture helpers shared across unit-test modules.
+
+use std::{
+    io::Write,
+    sync::{Arc, Mutex},
+};
+
+use tracing::subscriber::with_default;
+use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+/// A `Write` sink that appends into a shared buffer.
+struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+impl Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("log buffer").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Run `f` with an INFO-level subscriber installed on the current thread and
+/// return everything it logged as a string.
+pub(crate) fn capture_info_logs(f: impl FnOnce()) -> String {
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let writer_output = Arc::clone(&output);
+    let subscriber = Registry::default()
+        .with(tracing_subscriber::EnvFilter::new("info"))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(move || TestWriter(Arc::clone(&writer_output))),
+        );
+    with_default(subscriber, f);
+    let bytes = output.lock().expect("log buffer").clone();
+    String::from_utf8(bytes).expect("UTF-8 logs")
+}

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 
 use crate::{
     auth::AuthProvider, embedding::EmbeddingBackend, health::HealthRegistry, index::VectorStore,
-    repo::MemoryRepo,
+    repo::MemoryRepo, repo_router::RepoRouter,
 };
 
 pub(crate) const LIST_MAX_LIMIT: usize = 100;
@@ -384,8 +384,10 @@ pub struct ReindexStats {
 /// wrapped in its own `Arc` so it can be cloned into `spawn_blocking` closures.
 #[non_exhaustive]
 pub struct AppState {
-    /// Git-backed memory repository.
+    /// Git-backed memory repository (default repo, for backward compat).
     pub repo: Arc<MemoryRepo>,
+    /// Routes memory operations to scope-specific repos when configured.
+    pub router: RepoRouter,
     /// Backend used to compute text embeddings.
     pub embedding: Box<dyn EmbeddingBackend>,
     /// In-memory vector index for semantic search (scope-partitioned).
@@ -413,8 +415,33 @@ impl AppState {
         health: HealthRegistry,
         recall_log: Option<Arc<crate::recall_log::RecallLog>>,
     ) -> Self {
+        let router = RepoRouter::single(Arc::clone(&repo));
         Self {
             repo,
+            router,
+            embedding,
+            index,
+            auth,
+            branch,
+            health,
+            recall_log,
+        }
+    }
+
+    /// Create a new application state with a pre-built repo router.
+    pub fn with_router(
+        repo: Arc<MemoryRepo>,
+        router: RepoRouter,
+        branch: String,
+        embedding: Box<dyn EmbeddingBackend>,
+        index: Box<dyn VectorStore>,
+        auth: AuthProvider,
+        health: HealthRegistry,
+        recall_log: Option<Arc<crate::recall_log::RecallLog>>,
+    ) -> Self {
+        Self {
+            repo,
+            router,
             embedding,
             index,
             // Constructed here rather than injected: creation is infallible

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -407,8 +407,9 @@ pub struct AppState {
     ///
     /// Cleared — sticky for the process lifetime — when a mirror gap opens
     /// that only a full reindex can close: post-pull change discovery fails,
-    /// pulled files cannot be resolved, an incremental reindex fails
-    /// completely, or the startup reindex did not complete cleanly. While
+    /// pulled files cannot be resolved, an incremental reindex records any
+    /// item-level error, or the startup reindex did not complete cleanly
+    /// (#293 review, round 3: partial success is not certification). While
     /// cleared, composite-SHA advancement is refused at both sync and
     /// shutdown, so the next startup detects the SHA mismatch and rebuilds
     /// the vector index from git truth.

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -402,6 +402,17 @@ pub struct AppState {
     pub health: HealthRegistry,
     /// Optional append-only recall event log for threshold calibration.
     pub recall_log: Option<Arc<crate::recall_log::RecallLog>>,
+    /// `true` while every git HEAD advance since the vector index's stored
+    /// commit SHA has been fully mirrored into the vector index.
+    ///
+    /// Cleared — sticky for the process lifetime — when a mirror gap opens
+    /// that only a full reindex can close: post-pull change discovery fails,
+    /// pulled files cannot be resolved, an incremental reindex fails
+    /// completely, or the startup reindex did not complete cleanly. While
+    /// cleared, composite-SHA advancement is refused at both sync and
+    /// shutdown, so the next startup detects the SHA mismatch and rebuilds
+    /// the vector index from git truth.
+    index_mirror_intact: std::sync::atomic::AtomicBool,
 }
 
 impl AppState {
@@ -426,6 +437,7 @@ impl AppState {
             branch,
             health,
             recall_log,
+            index_mirror_intact: std::sync::atomic::AtomicBool::new(true),
         }
     }
 
@@ -455,7 +467,23 @@ impl AppState {
             branch,
             health,
             recall_log,
+            index_mirror_intact: std::sync::atomic::AtomicBool::new(true),
         }
+    }
+
+    /// Record that the vector index has a mirror gap only a full reindex can
+    /// close, blocking composite-SHA advancement for the rest of the process
+    /// lifetime (see [`AppState::index_mirror_is_intact`]).
+    pub fn mark_index_mirror_incomplete(&self) {
+        self.index_mirror_intact
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    /// `true` when the vector index mirror has no known gap and composite-SHA
+    /// advancement is allowed.
+    pub fn index_mirror_is_intact(&self) -> bool {
+        self.index_mirror_intact
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 }
 

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -429,6 +429,7 @@ impl AppState {
     }
 
     /// Create a new application state with a pre-built repo router.
+    #[allow(clippy::too_many_arguments)]
     pub fn with_router(
         repo: Arc<MemoryRepo>,
         router: RepoRouter,

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -421,6 +421,7 @@ impl AppState {
             router,
             embedding,
             index,
+            lexical: Arc::new(crate::search::LexicalIndex::new()),
             auth,
             branch,
             health,

--- a/src/types/memory.rs
+++ b/src/types/memory.rs
@@ -224,6 +224,21 @@ impl Memory {
         }
     }
 
+    /// Create a memory preserving an existing ID (for cross-repo moves).
+    pub(crate) fn from_validated_with_id(
+        id: String,
+        name: MemoryName,
+        content: impl Into<String>,
+        metadata: MemoryMetadata,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            content: content.into(),
+            metadata,
+        }
+    }
+
     /// Render to the on-disk format: YAML frontmatter + markdown body.
     ///
     /// Format:

--- a/src/types/scope.rs
+++ b/src/types/scope.rs
@@ -344,17 +344,30 @@ impl Scope {
 
 /// Validate a git branch name to prevent ref injection.
 ///
-/// Rejects names that are empty, contain `..`, start or end with `/` or `.`,
-/// contain consecutive slashes, or include characters that git disallows.
+/// Aligned with `git check-ref-format` (#293 review, round 4): rejects names
+/// that are empty, contain `..` or `@{`, are the single character `@`, start
+/// or end with `/` or `.`, contain consecutive slashes, have a component that
+/// starts with `.` or ends with `.lock`, or include characters that git
+/// disallows.
 pub fn validate_branch_name(branch: &str) -> Result<(), MemoryError> {
     if branch.is_empty() {
         return Err(MemoryError::InvalidInput {
             reason: "branch name cannot be empty".into(),
         });
     }
+    if branch == "@" {
+        return Err(MemoryError::InvalidInput {
+            reason: "branch name cannot be the single character '@'".into(),
+        });
+    }
     if branch.contains("..") {
         return Err(MemoryError::InvalidInput {
             reason: "branch name cannot contain '..'".into(),
+        });
+    }
+    if branch.contains("@{") {
+        return Err(MemoryError::InvalidInput {
+            reason: "branch name cannot contain '@{'".into(),
         });
     }
     let invalid_chars = [' ', '~', '^', ':', '?', '*', '[', '\\'];
@@ -378,6 +391,18 @@ pub fn validate_branch_name(branch: &str) -> Result<(), MemoryError> {
         return Err(MemoryError::InvalidInput {
             reason: "branch name contains consecutive slashes".into(),
         });
+    }
+    for component in branch.split('/') {
+        if component.starts_with('.') {
+            return Err(MemoryError::InvalidInput {
+                reason: format!("branch name component '{component}' cannot start with '.'"),
+            });
+        }
+        if component.ends_with(".lock") {
+            return Err(MemoryError::InvalidInput {
+                reason: format!("branch name component '{component}' cannot end with '.lock'"),
+            });
+        }
     }
     Ok(())
 }

--- a/src/types/scope_tests.rs
+++ b/src/types/scope_tests.rs
@@ -352,3 +352,27 @@ fn validate_branch_name_rejects_invalid_start_end() {
 fn validate_branch_name_rejects_consecutive_slashes() {
     assert!(validate_branch_name("foo//bar").is_err());
 }
+
+/// Names that passed the validator but fail `git check-ref-format`
+/// (#293 review, round 4): an accepted-but-git-invalid ref surfaces as a
+/// confusing git error at the first push/pull instead of a clean config
+/// rejection.
+#[test]
+fn validate_branch_name_rejects_git_invalid_refs() {
+    // `@{` is reflog syntax.
+    assert!(validate_branch_name("foo@{bar").is_err());
+    // No component may end with `.lock`.
+    assert!(validate_branch_name("foo.lock").is_err());
+    assert!(validate_branch_name("foo/bar.lock").is_err());
+    assert!(validate_branch_name("foo.lock/bar").is_err());
+    // No component may start with `.`.
+    assert!(validate_branch_name("foo/.hidden").is_err());
+    // The single character `@` is reserved.
+    assert!(validate_branch_name("@").is_err());
+
+    // Near-misses stay valid, proving the checks match git's rules rather
+    // than banning the characters outright.
+    assert!(validate_branch_name("foo@bar").is_ok());
+    assert!(validate_branch_name("foo.lockx").is_ok());
+    assert!(validate_branch_name("foo.hidden/bar").is_ok());
+}

--- a/tests/repo_round_trip.rs
+++ b/tests/repo_round_trip.rs
@@ -357,3 +357,28 @@ async fn repo_move_memory_atomic_commit() {
         "move should produce exactly one git commit"
     );
 }
+
+/// ADR-0038 compatibility (#293 review, round 6): a repo path spelled with
+/// `..` over a not-yet-existing component — `existing/missing/../repo` —
+/// worked before startup canonicalization was introduced, so the startup
+/// pipeline (canonicalize, then init at the resolved path) must still accept
+/// it and land the repo at `existing/repo`.
+#[tokio::test]
+async fn init_accepts_dot_dot_over_missing_component_in_repo_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = tmp.path().canonicalize().unwrap();
+    let spelled = tmp.path().join("missing/../repo");
+
+    // Mirrors `run_serve`: canonicalize before opening.
+    let resolved = memory_mcp::fs_util::canonicalize_allow_missing(&spelled)
+        .expect("previously valid spelling must canonicalize");
+    assert_eq!(resolved, existing.join("repo"));
+
+    // Repo init at the resolved path succeeds and creates the directory.
+    let repo = MemoryRepo::init_or_open(&resolved, None).expect("repo init should succeed");
+    assert!(
+        existing.join("repo/.git").exists(),
+        "repo should be created"
+    );
+    drop(repo);
+}


### PR DESCRIPTION
## Summary
- Adds per-scope remote mapping so different scopes can sync to different git repositories
- Each mapped scope gets its own independent git repo with its own remote
- Unmapped scopes fall through to the default repo (existing behavior preserved)
- Read operations (list, recall) aggregate across all repos transparently

## Design
- **Config** (`~/.config/memory-mcp/config.toml`): `[[remotes]]` entries map scope prefixes to dedicated repos
- **RepoRouter**: routes writes to the owning repo, aggregates reads, handles cross-repo moves
- **Longest-prefix matching** with segment boundary enforcement (e.g. `work` matches `work/sub` but not `workflow`)

## Files changed
- `src/config.rs` (new) — TOML config parser, `~` expansion, 8 unit tests
- `src/repo_router.rs` (new) — scope-based routing, 5 unit tests
- `src/server.rs` — all MCP tools rewired through the router
- `src/types/args.rs` — AppState gains `router` field
- `src/main.rs` — `--config` CLI arg, config loading, router construction
- `docs/adr/0038-per-scope-remote-mapping.md` — design decision record

## Hardening
Subsequent review/fix rounds on this branch addressed: multi-repo startup reindex (`head_sha` tracks all repos), sync durability (per-repo pull/push failures surfaced as tool errors, aggregated multi-repo sync health), index certification (rebuilds certified only on zero errors, only verified SHAs persisted at shutdown), scope ownership enforcement in aggregate reads, path canonicalization (repo-path collision detection incl. symlink/`..` aliasing), mapped-URL redaction, and branch validation aligned with git.

## Attribution
Original feature designed and authored by Lain (@lain-construct). Hardening commits by Ariadne and Mnemosyne — see commit history for the exact split.

## What's left (follow-up PRs)
- Per-repo index directories for SHA tracking
- Integration tests for multi-repo scenarios
- `--require-remote-sync` initial pull across all repos

## Test plan
- [ ] Unit tests pass for config parsing, path resolution, tilde expansion
- [ ] Unit tests pass for repo routing, prefix matching, branch override
- [ ] Existing tests pass (1 pre-existing failure: `push_rejected_by_server_hook` needs `git-daemon`)
- [ ] Clippy clean
- [ ] CI validates full build

Closes #292
