### PR TITLE
fix: composite head_sha for multi-repo startup reindex

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
             }),
     );
 
-    let head_sha = repo.head_sha().await;
+    let head_sha = router.head_sha().await;
     let needs_reindex = head_sha != index.commit_sha();
     // Track whether the reindex (if it ran) completed without errors.
     // Used below to gate startup report_ok for embedding and vector_index.
@@ -555,7 +555,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         );
 
         reindex_ok =
-            match memory_mcp::server::full_reindex(&repo, embedding.as_ref(), index.as_ref())
+            match memory_mcp::server::full_reindex(&router, embedding.as_ref(), index.as_ref())
                 .instrument(tracing::info_span!("startup.full_reindex"))
                 .await
             {
@@ -732,7 +732,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Persist the scoped vector index so the next startup can skip a full reindex.
     std::fs::create_dir_all(&index_dir)
         .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
-    if let Some(sha) = state_for_shutdown.repo.head_sha().await {
+    if let Some(sha) = state_for_shutdown.router.head_sha().await {
         state_for_shutdown.index.set_commit_sha(Some(&sha));
     }
     if let Err(e) = state_for_shutdown.index.save(&index_dir) {

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -394,9 +394,42 @@ impl RepoRouter {
         Ok(result)
     }
 
-    /// Get the HEAD SHA for the default repo (used for index persistence).
+    /// Get a composite HEAD SHA covering all repos.
+    ///
+    /// When no scope-specific routes are configured, returns the default repo's
+    /// SHA directly (backward compatible). When routes exist, returns a
+    /// deterministic string built from all repos' HEADs so that a change in
+    /// *any* repo invalidates the stored index SHA and triggers a reindex.
     pub async fn head_sha(&self) -> Option<String> {
-        self.default_repo.head_sha().await
+        if self.routes.is_empty() {
+            return self.default_repo.head_sha().await;
+        }
+
+        // Collect (label, sha) from all repos. Labels are already unique
+        // ("default" + each route prefix) and we sort for determinism.
+        let mut parts: Vec<(String, String)> = Vec::with_capacity(1 + self.routes.len());
+
+        if let Some(sha) = self.default_repo.head_sha().await {
+            parts.push(("default".to_string(), sha));
+        }
+        for route in &self.routes {
+            if let Some(sha) = route.repo.head_sha().await {
+                parts.push((route.prefix.clone(), sha));
+            }
+        }
+
+        if parts.is_empty() {
+            return None;
+        }
+
+        parts.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let composite = parts
+            .iter()
+            .map(|(label, sha)| format!("{label}={sha}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        Some(composite)
     }
 
     /// Return a reference to the repo for a given scope (for direct access when needed).

--- a/src/server.rs
+++ b/src/server.rs
@@ -237,20 +237,21 @@ async fn incremental_reindex(
     stats
 }
 
-/// Re-embed and re-index all memories in the repository.
+/// Re-embed and re-index all memories across all repos.
 ///
-/// This is a full rebuild: all memories are listed, their content is embedded,
-/// and the index is updated. Intended for startup freshness checks and
-/// recovery after a crash that discarded an in-progress index.
+/// This is a full rebuild: all memories are listed (via the router, which
+/// aggregates across scope-specific repos), their content is embedded, and the
+/// index is updated. Intended for startup freshness checks and recovery after
+/// a crash that discarded an in-progress index.
 ///
 /// Unlike delegating to `incremental_reindex`, this function uses the content
 /// already loaded by `list_memories` to avoid reading each file a second time.
 pub async fn full_reindex(
-    repo: &Arc<MemoryRepo>,
+    router: &crate::repo_router::RepoRouter,
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
 ) -> Result<ReindexStats, MemoryError> {
-    let memories = repo.list_memories(None).await?;
+    let memories = router.list_memories(None).await?;
     if memories.is_empty() {
         return Ok(ReindexStats::default());
     }


### PR DESCRIPTION
## Summary

- **Problem:** Startup reindex only checked the default repo's HEAD SHA to decide whether the vector index was stale. When scope-specific repos (introduced in `feat/per-scope-remotes`) had new commits but the default repo hadn't changed, the startup freshness check passed and those memories were never re-embedded — leaving the index silently incomplete.
- **Fix:** `RepoRouter::head_sha()` now returns a composite SHA string (`default=abc;scope1=def;...`) built from all configured repos, sorted deterministically by label. A change in *any* repo invalidates the stored index SHA and triggers a full reindex.
- **`full_reindex` takes the router:** `server::full_reindex()` now accepts a `&RepoRouter` instead of `&Arc<MemoryRepo>`, so it lists memories across all scope-specific repos during the rebuild — not just the default repo.
- Shutdown persistence and the startup comparison both use the new composite SHA, so the round-trip is consistent.

Closes review finding from #293 (startup reindex only checked default repo SHA).

## Test plan

- [x] `cargo fmt -- --check` passes
- [ ] `cargo test` passes (CI will run this)
- [ ] Manual verification: configure a scope-specific route, commit to the scope repo only, restart — confirm reindex fires
- [ ] Verify single-repo (no routes) still works identically (fast path returns default SHA directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)