### PR TITLE
feat: expose MCP tool processing timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+
+- Return server-side tool processing duration in MCP result metadata and log edit stage timings (#298)
+
 ## [0.15.0] - 2026-06-26
 
 ### Added
@@ -367,4 +373,3 @@ Agents using `scope: "project:my-api"` in tool calls must switch to `scope: "my-
 * @github-actions[bot] made their first contribution in [#18](https://github.com/butterflyskies/memory-mcp/pull/18)
 * @butterflysky-ai made their first contribution in [#17](https://github.com/butterflyskies/memory-mcp/pull/17)
 * @butterflysky made their first contribution in [#8](https://github.com/butterflyskies/memory-mcp/pull/8)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-## [Unreleased]
+## [0.16.0] - 2026-07-12
 
 ### Added
 
-- Return server-side tool processing duration in MCP result metadata and log edit stage timings (#298)
+- Return server-side tool processing duration in MCP result metadata and default-verbosity completion logs (#298)
+- Report edit-stage totals and separate embedding queue-wait and inference timings (#298)
+
+### Dependencies
+
+- Upgrade `anyhow` to 1.0.103 and `crossbeam-epoch` to 0.9.20 to resolve newly published security advisories
 
 ## [0.15.0] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ Then use the `sync` tool from your editor, or call `memory-mcp sync` directly.
 | **list** | Browse all memories, optionally filtered by scope. |
 | **sync** | Push/pull the memory repo with a git remote. Handles conflicts via recency-based resolution. |
 
+Successful tool results include `_meta["memory-mcp/serverProcessingDurationMs"]`, measured
+from the server tool-handler boundary through result conversion. This is server processing
+time, not client round-trip time; clients should measure `clientRoundTripDurationMs` around
+the MCP call when end-to-end latency is needed.
+
 ### Example: agent remembers a debugging insight
 
 ```

--- a/deny.toml
+++ b/deny.toml
@@ -10,7 +10,6 @@ all-features = true
 [advisories]
 ignore = [
     # Transitive deps we can't control — unmaintained, not vulnerable.
-    { id = "RUSTSEC-2025-0119", reason = "number_prefix: transitive via indicatif → hf-hub" },
     { id = "RUSTSEC-2024-0436", reason = "paste: transitive via thiserror/serde derive macros" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile: transitive via rustls-native-certs 0.7 → ureq 2 (native-certs feature)" },
 ]

--- a/src/embedding/candle.rs
+++ b/src/embedding/candle.rs
@@ -1,6 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::sync::mpsc;
+use std::time::Instant;
 
 use candle_core::{Device, Tensor};
 use candle_nn::VarBuilder;
@@ -21,10 +22,11 @@ pub const MODEL_ID: &str = "BAAI/bge-small-en-v1.5";
 // Worker thread
 // ---------------------------------------------------------------------------
 
-type EmbedRequest = (
-    Vec<String>,
-    oneshot::Sender<Result<Vec<Vec<f32>>, MemoryError>>,
-);
+struct EmbedRequest {
+    texts: Vec<String>,
+    enqueued_at: Instant,
+    reply_tx: oneshot::Sender<Result<Vec<Vec<f32>>, MemoryError>>,
+}
 
 /// Pure-Rust embedding engine using candle for BERT inference.
 ///
@@ -165,7 +167,11 @@ impl Drop for CandleEmbeddingEngine {
 /// out), the send fails silently and the loop continues — this is the
 /// self-healing path.
 fn worker_loop(mut inner: CandleInner, dim: usize, rx: mpsc::Receiver<EmbedRequest>) {
-    for (texts, reply_tx) in rx {
+    for request in rx {
+        let queue_wait_ms =
+            u64::try_from(request.enqueued_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let texts = request.texts;
+        let reply_tx = request.reply_tx;
         let span = tracing::debug_span!(
             "embedding.embed",
             batch_size = texts.len(),
@@ -175,6 +181,7 @@ fn worker_loop(mut inner: CandleInner, dim: usize, rx: mpsc::Receiver<EmbedReque
         let _enter = span.enter();
 
         let mut panicked = false;
+        let inference_start = Instant::now();
         let result = catch_unwind(AssertUnwindSafe(|| embed_batch(&inner, &texts))).unwrap_or_else(
             |panic_payload| {
                 panicked = true;
@@ -190,6 +197,13 @@ fn worker_loop(mut inner: CandleInner, dim: usize, rx: mpsc::Receiver<EmbedReque
                     "embedding engine panicked: {msg}"
                 )))
             },
+        );
+        let inference_ms = u64::try_from(inference_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+        tracing::info!(
+            queue_wait_ms,
+            inference_ms,
+            outcome = if result.is_ok() { "success" } else { "error" },
+            "embedding completed"
         );
 
         let _ = reply_tx.send(result);
@@ -217,15 +231,19 @@ impl EmbeddingBackend for CandleEmbeddingEngine {
             .as_ref()
             .ok_or_else(|| MemoryError::Embedding("embedding engine has been shut down".into()))?;
 
-        tx.try_send((texts.to_vec(), reply_tx))
-            .map_err(|e| match e {
-                mpsc::TrySendError::Full(_) => {
-                    MemoryError::Embedding("embedding worker is busy — try again".into())
-                }
-                mpsc::TrySendError::Disconnected(_) => {
-                    MemoryError::Embedding("embedding worker has exited — restart required".into())
-                }
-            })?;
+        tx.try_send(EmbedRequest {
+            texts: texts.to_vec(),
+            enqueued_at: Instant::now(),
+            reply_tx,
+        })
+        .map_err(|e| match e {
+            mpsc::TrySendError::Full(_) => {
+                MemoryError::Embedding("embedding worker is busy — try again".into())
+            }
+            mpsc::TrySendError::Disconnected(_) => {
+                MemoryError::Embedding("embedding worker has exited — restart required".into())
+            }
+        })?;
 
         let result = match timeout(self.embed_timeout, reply_rx).await {
             Ok(Ok(result)) => result,
@@ -444,8 +462,8 @@ mod tests {
     {
         let (tx, rx) = mpsc::sync_channel::<EmbedRequest>(1);
         std::thread::spawn(move || {
-            for (texts, reply_tx) in rx {
-                handler(texts, reply_tx);
+            for request in rx {
+                handler(request.texts, request.reply_tx);
             }
         });
         CandleEmbeddingEngine::with_worker(tx, 4, timeout)
@@ -540,7 +558,12 @@ mod tests {
 
         // Pre-fill the single channel slot by sending directly, bypassing embed().
         let (filler_tx, _filler_rx) = oneshot::channel::<Result<Vec<Vec<f32>>, MemoryError>>();
-        tx.send((vec!["fill".to_string()], filler_tx)).unwrap();
+        tx.send(EmbedRequest {
+            texts: vec!["fill".to_string()],
+            enqueued_at: Instant::now(),
+            reply_tx: filler_tx,
+        })
+        .unwrap();
 
         // Now embed() hits try_send on a full channel.
         let engine = CandleEmbeddingEngine::with_worker(tx, 4, Duration::from_secs(5));

--- a/src/server.rs
+++ b/src/server.rs
@@ -121,7 +121,7 @@ struct EditStageTiming {
     stage: &'static str,
     outcome: &'static str,
     read_ms: u64,
-    embed_wait_ms: u64,
+    embed_total_ms: u64,
     index_ms: u64,
     repo_save_ms: u64,
 }
@@ -133,7 +133,7 @@ impl EditStageTiming {
             stage: "validation",
             outcome: "error",
             read_ms: 0,
-            embed_wait_ms: 0,
+            embed_total_ms: 0,
             index_ms: 0,
             repo_save_ms: 0,
         }
@@ -150,9 +150,9 @@ impl Drop for EditStageTiming {
         info!(
             outcome = self.outcome,
             stage = self.stage,
-            server_processing_duration_ms = elapsed_ms(self.start),
+            edit_total_ms = elapsed_ms(self.start),
             read_ms = self.read_ms,
-            embed_wait_ms = self.embed_wait_ms,
+            embed_total_ms = self.embed_total_ms,
             index_ms = self.index_ms,
             repo_save_ms = self.repo_save_ms,
             "edit stage timing"
@@ -784,7 +784,7 @@ impl MemoryServer {
                 timing.stage = "embed";
                 let stage_start = Instant::now();
                 let embed_result = state.embedding.embed_one(&memory.content).await;
-                timing.embed_wait_ms = elapsed_ms(stage_start);
+                timing.embed_total_ms = elapsed_ms(stage_start);
                 let vector = embed_result.map_err(ErrorData::from)?;
 
                 timing.stage = "index";
@@ -1680,7 +1680,7 @@ mod tests {
         let logs = capture_info_logs(|| {
             let mut success = EditStageTiming::new();
             success.read_ms = 1;
-            success.embed_wait_ms = 2;
+            success.embed_total_ms = 2;
             success.index_ms = 3;
             success.repo_save_ms = 4;
             success.completed();
@@ -1689,7 +1689,7 @@ mod tests {
             let mut failure = EditStageTiming::new();
             failure.stage = "embed";
             failure.read_ms = 1;
-            failure.embed_wait_ms = 2;
+            failure.embed_total_ms = 2;
             drop(failure);
         });
 
@@ -1697,9 +1697,19 @@ mod tests {
         assert!(logs.contains("stage=\"embed\""), "logs: {logs}");
         assert!(logs.contains("outcome=\"success\""), "logs: {logs}");
         assert!(logs.contains("outcome=\"error\""), "logs: {logs}");
-        for field in ["read_ms=", "embed_wait_ms=", "index_ms=", "repo_save_ms="] {
+        for field in [
+            "edit_total_ms=",
+            "read_ms=",
+            "embed_total_ms=",
+            "index_ms=",
+            "repo_save_ms=",
+        ] {
             assert!(logs.contains(field), "missing {field}; logs: {logs}");
         }
+        assert!(
+            !logs.contains("server_processing_duration_ms="),
+            "edit-stage logs must not reuse the authoritative tool-boundary field; logs: {logs}"
+        );
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,9 +6,16 @@ const SNIPPET_MAX_CHARS: usize = 500;
 
 use chrono::Utc;
 use rmcp::{
-    handler::server::{router::tool::ToolRouter, tool::Extension, wrapper::Parameters},
-    model::{ErrorData, ServerCapabilities, ServerInfo},
-    tool, tool_handler, tool_router, ServerHandler,
+    handler::server::{
+        router::tool::ToolRouter,
+        tool::{Extension, ToolCallContext},
+        wrapper::Parameters,
+    },
+    model::{
+        CallToolRequestParams, CallToolResult, ErrorData, Meta, ServerCapabilities, ServerInfo,
+    },
+    service::RequestContext,
+    tool, tool_handler, tool_router, RoleServer, ServerHandler,
 };
 use tracing::{info, warn, Instrument};
 
@@ -68,6 +75,90 @@ pub struct MemoryServer {
 
 /// Maximum allowed content size in bytes (1 MiB).
 const MAX_CONTENT_SIZE: usize = 1_048_576;
+
+const SERVER_PROCESSING_DURATION_META_KEY: &str = "memory-mcp/serverProcessingDurationMs";
+
+fn elapsed_ms(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn finish_tool_call(
+    tool_name: &str,
+    start: Instant,
+    result: Result<CallToolResult, ErrorData>,
+) -> Result<CallToolResult, ErrorData> {
+    let server_processing_duration_ms = elapsed_ms(start);
+    match result {
+        Ok(mut result) => {
+            let mut meta = result.meta.take().unwrap_or_else(Meta::new);
+            meta.insert(
+                SERVER_PROCESSING_DURATION_META_KEY.to_string(),
+                server_processing_duration_ms.into(),
+            );
+            result.meta = Some(meta);
+            info!(
+                tool_name,
+                server_processing_duration_ms,
+                outcome = "success",
+                "tool call completed"
+            );
+            Ok(result)
+        }
+        Err(error) => {
+            info!(
+                tool_name,
+                server_processing_duration_ms,
+                outcome = "error",
+                "tool call completed"
+            );
+            Err(error)
+        }
+    }
+}
+
+struct EditStageTiming {
+    start: Instant,
+    stage: &'static str,
+    outcome: &'static str,
+    read_ms: u64,
+    embed_wait_ms: u64,
+    index_ms: u64,
+    repo_save_ms: u64,
+}
+
+impl EditStageTiming {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            stage: "validation",
+            outcome: "error",
+            read_ms: 0,
+            embed_wait_ms: 0,
+            index_ms: 0,
+            repo_save_ms: 0,
+        }
+    }
+
+    fn completed(&mut self) {
+        self.stage = "completed";
+        self.outcome = "success";
+    }
+}
+
+impl Drop for EditStageTiming {
+    fn drop(&mut self) {
+        info!(
+            outcome = self.outcome,
+            stage = self.stage,
+            server_processing_duration_ms = elapsed_ms(self.start),
+            read_ms = self.read_ms,
+            embed_wait_ms = self.embed_wait_ms,
+            index_ms = self.index_ms,
+            repo_save_ms = self.repo_save_ms,
+            "edit stage timing"
+        );
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Incremental reindex helper
@@ -634,6 +725,7 @@ impl MemoryServer {
         Parameters(args): Parameters<EditArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
+        let mut timing = EditStageTiming::new();
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.is_none() && args.tags.is_none() {
             return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
@@ -664,17 +756,15 @@ impl MemoryServer {
         async move {
             let scope = Scope::parse_or_default(args.scope.as_deref()).map_err(ErrorData::from)?;
 
-            let start = Instant::now();
-
             // Track whether content changed so we can skip re-embedding when only tags changed.
             let content_changed = args.content.is_some();
 
             // Read the existing memory.
-            let mut memory = state
-                .repo
-                .read_memory(&name, &scope)
-                .await
-                .map_err(ErrorData::from)?;
+            timing.stage = "read";
+            let stage_start = Instant::now();
+            let read_result = state.repo.read_memory(&name, &scope).await;
+            timing.read_ms = elapsed_ms(stage_start);
+            let mut memory = read_result.map_err(ErrorData::from)?;
 
             // Apply partial updates.
             if let Some(content) = args.content {
@@ -691,31 +781,34 @@ impl MemoryServer {
                 let qualified_name = memory.mem_ref().qualified_path();
 
                 // Re-embed updated content.
-                let vector = state
-                    .embedding
-                    .embed_one(&memory.content)
-                    .await
-                    .map_err(ErrorData::from)?;
+                timing.stage = "embed";
+                let stage_start = Instant::now();
+                let embed_result = state.embedding.embed_one(&memory.content).await;
+                timing.embed_wait_ms = elapsed_ms(stage_start);
+                let vector = embed_result.map_err(ErrorData::from)?;
 
-                state
-                    .index
-                    .add(&scope, &vector, qualified_name)
-                    .map_err(ErrorData::from)?;
+                timing.stage = "index";
+                let stage_start = Instant::now();
+                let index_result = state.index.add(&scope, &vector, qualified_name);
+                timing.index_ms = elapsed_ms(stage_start);
+                index_result.map_err(ErrorData::from)?;
             }
 
             // Persist to repo (last, so partial failures leave recoverable state).
-            state
-                .repo
-                .save_memory(&memory)
-                .await
-                .map_err(ErrorData::from)?;
+            timing.stage = "repo_save";
+            let stage_start = Instant::now();
+            let save_result = state.repo.save_memory(&memory).await;
+            timing.repo_save_ms = elapsed_ms(stage_start);
+            save_result.map_err(ErrorData::from)?;
 
             info!(
-                ms = start.elapsed().as_millis(),
+                ms = elapsed_ms(timing.start),
                 name = %name,
                 content_changed,
                 "memory edited"
             );
+
+            timing.completed();
 
             Ok(serde_json::json!({
                 "id": memory.id,
@@ -1428,6 +1521,17 @@ impl MemoryServer {
 
 #[tool_handler]
 impl ServerHandler for MemoryServer {
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let start = Instant::now();
+        let tool_name = request.name.to_string();
+        let context = ToolCallContext::new(self, request, context);
+        finish_tool_call(&tool_name, start, self.tool_router.call(context).await)
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
             "A semantic memory system for AI coding agents. Memories are stored as markdown files \
@@ -1470,6 +1574,133 @@ fn build_snippet(content: &str) -> (String, usize, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::model::Content;
+    use std::{
+        io::Write,
+        sync::{Arc, Mutex},
+    };
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::{layer::SubscriberExt, Registry};
+
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("log buffer").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn capture_info_logs(f: impl FnOnce()) -> String {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer_output = Arc::clone(&output);
+        let subscriber = Registry::default()
+            .with(tracing_subscriber::EnvFilter::new("info"))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(move || TestWriter(Arc::clone(&writer_output))),
+            );
+        with_default(subscriber, f);
+        let bytes = output.lock().expect("log buffer").clone();
+        String::from_utf8(bytes).expect("UTF-8 logs")
+    }
+
+    #[test]
+    fn tool_timing_preserves_content_and_adds_metadata() {
+        let original = CallToolResult::success(vec![Content::text("{\"ok\":true}")]);
+        let original_content = original.content.clone();
+
+        let result = finish_tool_call("read", Instant::now(), Ok(original)).expect("success");
+
+        assert_eq!(result.content, original_content);
+        assert_eq!(result.structured_content, None);
+        assert_eq!(result.is_error, Some(false));
+        let duration = result
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get(SERVER_PROCESSING_DURATION_META_KEY))
+            .and_then(serde_json::Value::as_u64);
+        assert!(duration.is_some());
+    }
+
+    #[test]
+    fn tool_timing_merges_existing_metadata() {
+        let mut meta = Meta::new();
+        meta.insert("existing".to_string(), serde_json::json!("kept"));
+        let original = CallToolResult::success(vec![Content::text("ok")]).with_meta(Some(meta));
+
+        let result = finish_tool_call("list", Instant::now(), Ok(original)).expect("success");
+        let meta = result.meta.expect("metadata");
+
+        assert_eq!(meta.get("existing"), Some(&serde_json::json!("kept")));
+        assert!(meta.contains_key(SERVER_PROCESSING_DURATION_META_KEY));
+    }
+
+    #[test]
+    fn tool_timing_preserves_error_data_semantics() {
+        let original =
+            ErrorData::invalid_params("bad input", Some(serde_json::json!({"field": "name"})));
+        let expected_code = original.code;
+        let expected_message = original.message.clone();
+        let expected_data = original.data.clone();
+
+        let error = finish_tool_call("edit", Instant::now(), Err(original)).expect_err("error");
+
+        assert_eq!(error.code, expected_code);
+        assert_eq!(error.message, expected_message);
+        assert_eq!(error.data, expected_data);
+    }
+
+    #[test]
+    fn tool_timing_logs_success_and_error_at_info() {
+        let logs = capture_info_logs(|| {
+            let success = CallToolResult::success(vec![Content::text("ok")]);
+            finish_tool_call("read", Instant::now(), Ok(success)).expect("success");
+            let error = ErrorData::invalid_params("bad input", None);
+            finish_tool_call("edit", Instant::now(), Err(error)).expect_err("error");
+        });
+
+        assert!(logs.contains("tool_name=\"read\""), "logs: {logs}");
+        assert!(logs.contains("tool_name=\"edit\""), "logs: {logs}");
+        assert!(logs.contains("outcome=\"success\""), "logs: {logs}");
+        assert!(logs.contains("outcome=\"error\""), "logs: {logs}");
+        assert!(
+            logs.contains("server_processing_duration_ms="),
+            "logs: {logs}"
+        );
+    }
+
+    #[test]
+    fn edit_stage_timing_logs_success_and_failure_at_info() {
+        let logs = capture_info_logs(|| {
+            let mut success = EditStageTiming::new();
+            success.read_ms = 1;
+            success.embed_wait_ms = 2;
+            success.index_ms = 3;
+            success.repo_save_ms = 4;
+            success.completed();
+            drop(success);
+
+            let mut failure = EditStageTiming::new();
+            failure.stage = "embed";
+            failure.read_ms = 1;
+            failure.embed_wait_ms = 2;
+            drop(failure);
+        });
+
+        assert!(logs.contains("stage=\"completed\""), "logs: {logs}");
+        assert!(logs.contains("stage=\"embed\""), "logs: {logs}");
+        assert!(logs.contains("outcome=\"success\""), "logs: {logs}");
+        assert!(logs.contains("outcome=\"error\""), "logs: {logs}");
+        for field in ["read_ms=", "embed_wait_ms=", "index_ms=", "repo_save_ms="] {
+            assert!(logs.contains(field), "missing {field}; logs: {logs}");
+        }
+    }
 
     #[test]
     fn snippet_short_content_not_truncated() {


### PR DESCRIPTION
Closes #298.

Adds end-to-end server-side timing for every MCP tool invocation, emits default-verbosity completion logs on success and protocol errors, and returns successful processing duration in additive `_meta` as `memory-mcp/serverProcessingDurationMs` without changing existing content or structured results.

The edit path reports read, embedding, index, and repository-save totals. Candle worker instrumentation separates queue wait from inference, so slow edits can be attributed rather than merely observed. README documents the server-processing boundary and distinguishes it from client-observed round-trip time.

Release preparation:
- bumps memory-mcp to `0.16.0`
- adds the dated 2026-07-12 changelog entry
- updates `anyhow` to 1.0.103 and `crossbeam-epoch` to 0.9.20 for newly published advisories
- removes a stale cargo-deny advisory ignore
- `main` contains no unreleased commits after the 0.15.0 release commit

Verification:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo deny check advisories`
- `cargo nextest run --workspace`: 268 passed, 2 skipped
- independent review and rereview: approved after two attribution findings were fixed