### PR TITLE
feat: paginate memory list results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 
 - Bound `list` responses with cursor pagination (50 summaries by default, 100 maximum), exact field projection, deterministic ordering, and a 24 KiB page ceiling (#281). Existing callers must follow `next_cursor` when `has_more` is true; omitting `fields` retains the prior six-field summary shape.
+- `list.count` now means the total matching memories, while `list.returned` is the number in the current page. Repository enumeration and metadata parsing still scan the selected scope once per page; pushing the seek into a persistent summary index is deferred to #304.
+- Retain the original public Rust `ListArgs { scope }` DTO for semver compatibility; paginated MCP-only request fields use an internal wire type.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [0.16.0] - 2026-07-12
 
+### Changed
+
+- Bound `list` responses with cursor pagination (50 summaries by default, 100 maximum), exact field projection, deterministic ordering, and a 24 KiB page ceiling (#281). Existing callers must follow `next_cursor` when `has_more` is true; omitting `fields` retains the prior six-field summary shape.
+
 ### Added
 
 - Return server-side tool processing duration in MCP result metadata and default-verbosity completion logs (#298)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "candle-core",
  "candle-nn",
  "candle-transformers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ git2 = { version = "0.21", features = ["https", "vendored-openssl"] }
 usearch = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+base64 = "0.22"
 # Maintained fork of deprecated serde_yaml (dtolnay archived the original).
 serde_yaml_ng = "0.10"
 # Disable default features to trim unused chrono subsystems; clock provides

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,9 +46,9 @@ use crate::{
     repo::{traced_spawn_blocking, MemoryRepo},
     types::{
         parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
-        ForgetArgs, ListArgs, ListField, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName,
+        ForgetArgs, ListField, ListToolArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName,
         MemoryRef, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
-        RememberArgs, Scope, ScopeFilter, SyncArgs,
+        RememberArgs, Scope, ScopeFilter, SyncArgs, LIST_MAX_LIMIT,
     },
 };
 
@@ -79,7 +79,6 @@ const MAX_CONTENT_SIZE: usize = 1_048_576;
 
 /// Default and hard maximum number of summaries returned by `list`.
 const LIST_DEFAULT_LIMIT: usize = 50;
-const LIST_MAX_LIMIT: usize = 100;
 /// Hard ceiling for the serialized JSON returned by one successful `list` page.
 const LIST_PAGE_MAX_BYTES: usize = 24 * 1024;
 /// Bounds work performed while decoding an untrusted opaque cursor.
@@ -104,13 +103,11 @@ impl ListSortKey {
 struct ListCursorPayload {
     version: u8,
     filter: String,
-    generation: u64,
     scope: String,
     name: String,
 }
 
 struct DecodedListCursor {
-    generation: u64,
     key: ListSortKey,
 }
 
@@ -138,15 +135,10 @@ fn list_filter_key(filter: &ScopeFilter) -> String {
     }
 }
 
-fn encode_list_cursor(
-    filter: &str,
-    generation: u64,
-    key: &ListSortKey,
-) -> Result<String, MemoryError> {
+fn encode_list_cursor(filter: &str, key: &ListSortKey) -> Result<String, MemoryError> {
     let payload = serde_json::to_vec(&ListCursorPayload {
         version: 1,
         filter: filter.to_string(),
-        generation,
         scope: key.scope.clone(),
         name: key.name.clone(),
     })
@@ -201,48 +193,11 @@ fn decode_list_cursor(
         ));
     }
     Ok(DecodedListCursor {
-        generation: payload.generation,
         key: ListSortKey {
             scope: payload.scope,
             name: payload.name,
         },
     })
-}
-
-fn extend_list_generation(hash: &mut u64, value: &[u8]) {
-    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
-    for byte in value
-        .len()
-        .to_le_bytes()
-        .into_iter()
-        .chain(value.iter().copied())
-    {
-        *hash ^= u64::from(byte);
-        *hash = hash.wrapping_mul(FNV_PRIME);
-    }
-}
-
-fn list_generation(memories: &[Memory]) -> u64 {
-    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
-    let mut hash = FNV_OFFSET_BASIS;
-    for memory in memories {
-        let key = ListSortKey::from_memory(memory);
-        let created_at = memory.metadata.created_at.to_rfc3339();
-        let updated_at = memory.metadata.updated_at.to_rfc3339();
-        for value in [
-            key.scope.as_str(),
-            key.name.as_str(),
-            memory.id.as_str(),
-            created_at.as_str(),
-            updated_at.as_str(),
-        ] {
-            extend_list_generation(&mut hash, value.as_bytes());
-        }
-        for tag in &memory.metadata.tags {
-            extend_list_generation(&mut hash, tag.as_bytes());
-        }
-    }
-    hash
 }
 
 fn list_summary(memory: &Memory, fields: &[ListField]) -> serde_json::Value {
@@ -297,52 +252,73 @@ fn list_page_value(
     })
 }
 
+fn list_page_serialized_len(
+    summaries_bytes: usize,
+    returned: usize,
+    count: usize,
+    limit: usize,
+    next_cursor: Option<&str>,
+) -> Result<usize, MemoryError> {
+    let empty_page = serde_json::json!({
+        "memories": [],
+        "count": count,
+        "returned": returned,
+        "limit": limit,
+        "has_more": next_cursor.is_some(),
+        "next_cursor": next_cursor,
+    });
+    let envelope_len = serde_json::to_vec(&empty_page)
+        .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?
+        .len();
+    let memories_len = if returned == 0 {
+        0
+    } else {
+        summaries_bytes + returned - 1
+    };
+    Ok(envelope_len + memories_len)
+}
+
 fn paginate_list(
-    mut memories: Vec<Memory>,
+    memories: Vec<Memory>,
     filter: &ScopeFilter,
     limit: usize,
-    cursor: Option<&str>,
+    after: Option<DecodedListCursor>,
     fields: &[ListField],
 ) -> Result<String, MemoryError> {
-    memories.sort_by_key(ListSortKey::from_memory);
+    let mut memories: Vec<_> = memories
+        .into_iter()
+        .map(|memory| (ListSortKey::from_memory(&memory), memory))
+        .collect();
+    memories.sort_by(|(left, _), (right, _)| left.cmp(right));
     let count = memories.len();
-    let generation = list_generation(&memories);
     let filter_key = list_filter_key(filter);
-    let after = cursor
-        .map(|value| decode_list_cursor(value, &filter_key))
-        .transpose()?;
-    if let Some(cursor) = &after {
-        if cursor.generation != generation {
-            return Err(invalid_list_input(
-                "list cursor is stale because the matching list data changed; restart pagination",
-            ));
-        }
-    }
     let start = after.as_ref().map_or(0, |cursor| {
-        memories.partition_point(|memory| ListSortKey::from_memory(memory) <= cursor.key)
+        memories.partition_point(|(key, _)| key <= &cursor.key)
     });
 
     let mut summaries = Vec::with_capacity(limit.min(count.saturating_sub(start)));
-    for memory in memories.iter().skip(start).take(limit) {
-        summaries.push(list_summary(memory, fields));
+    let mut summaries_bytes = 0;
+    for (key, memory) in memories.iter().skip(start).take(limit) {
+        let summary = list_summary(memory, fields);
+        let summary_len = serde_json::to_vec(&summary)
+            .map_err(|error| MemoryError::Internal(format!("serialize list summary: {error}")))?
+            .len();
+        summaries.push(summary);
+        summaries_bytes += summary_len;
         let next_index = start + summaries.len();
         let next_cursor = if next_index < count {
-            Some(encode_list_cursor(
-                &filter_key,
-                generation,
-                &ListSortKey::from_memory(memory),
-            )?)
+            Some(encode_list_cursor(&filter_key, key)?)
         } else {
             None
         };
-        let candidate = serde_json::to_string(&list_page_value(
-            &summaries,
+        let candidate_len = list_page_serialized_len(
+            summaries_bytes,
+            summaries.len(),
             count,
             limit,
             next_cursor.as_deref(),
-        ))
-        .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?;
-        if candidate.len() > LIST_PAGE_MAX_BYTES {
+        )?;
+        if candidate_len > LIST_PAGE_MAX_BYTES {
             summaries.pop();
             if summaries.is_empty() {
                 return Err(invalid_list_input(format!(
@@ -358,11 +334,7 @@ fn paginate_list(
         let last = memories
             .get(next_index.saturating_sub(1))
             .ok_or_else(|| MemoryError::Internal("list pagination made no progress".to_string()))?;
-        Some(encode_list_cursor(
-            &filter_key,
-            generation,
-            &ListSortKey::from_memory(last),
-        )?)
+        Some(encode_list_cursor(&filter_key, &last.0)?)
     } else {
         None
     };
@@ -1260,14 +1232,14 @@ impl MemoryServer {
         description = "List stored memories. Pass a bare path like '<basename-of-your-cwd>' for that scope + global memories, \
         'global' for global-only, or 'all' for everything. Omitting scope defaults to global-only. \
         Pages are sorted by (scope, name); limit defaults to 50 and cannot exceed 100. \
-        Continue with the opaque next_cursor returned by the previous page; restart if a cursor is \
-        reported stale after the matching memory set changes. Use fields to request an exact summary \
+        Continue with the opaque next_cursor returned by the previous page. Concurrent inserts and \
+        deletes follow standard keyset semantics. Use fields to request an exact summary \
         projection; omitting fields returns id, name, scope, tags, created_at, and updated_at. \
         Successful pages are capped at 24 KiB; request fewer fields if one summary is too large."
     )]
     async fn list(
         &self,
-        Parameters(args): Parameters<ListArgs>,
+        Parameters(args): Parameters<ListToolArgs>,
         Extension(parts): Extension<http::request::Parts>,
     ) -> Result<String, ErrorData> {
         let session_id = extract_session_id(&parts);
@@ -1283,9 +1255,12 @@ impl MemoryServer {
             let scope_filter =
                 ScopeFilter::parse_or_default(args.scope.as_deref()).map_err(ErrorData::from)?;
             let filter_key = list_filter_key(&scope_filter);
-            if let Some(cursor) = args.cursor.as_deref() {
-                decode_list_cursor(cursor, &filter_key).map_err(ErrorData::from)?;
-            }
+            let cursor = args
+                .cursor
+                .as_deref()
+                .map(|cursor| decode_list_cursor(cursor, &filter_key))
+                .transpose()
+                .map_err(ErrorData::from)?;
             let fields = args.fields.unwrap_or_else(|| ListField::ALL.to_vec());
 
             let start = Instant::now();
@@ -1319,14 +1294,7 @@ impl MemoryServer {
             let count = memories.len();
             tracing::Span::current().record("count", count);
             info!(ms = start.elapsed().as_millis(), count, "listed memories");
-            paginate_list(
-                memories,
-                &scope_filter,
-                limit,
-                args.cursor.as_deref(),
-                &fields,
-            )
-            .map_err(ErrorData::from)
+            paginate_list(memories, &scope_filter, limit, cursor, &fields).map_err(ErrorData::from)
         }
         .instrument(span)
         .await
@@ -2128,7 +2096,7 @@ mod tests {
 
         let invalid_limit = server
             .list(
-                Parameters(ListArgs {
+                Parameters(ListToolArgs {
                     scope: None,
                     limit: Some(0),
                     cursor: None,
@@ -2142,7 +2110,7 @@ mod tests {
 
         let invalid_cursor = server
             .list(
-                Parameters(ListArgs {
+                Parameters(ListToolArgs {
                     scope: None,
                     limit: None,
                     cursor: Some("garbage".to_string()),
@@ -2155,6 +2123,53 @@ mod tests {
         assert_eq!(invalid_cursor.code, rmcp::model::ErrorCode::INVALID_PARAMS);
     }
 
+    #[tokio::test]
+    async fn list_mcp_handler_walks_seeded_repo_across_separate_reads() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = Arc::new(MemoryRepo::init_or_open(temp.path(), None).expect("repo"));
+        for name in ["delta", "alpha", "charlie"] {
+            repo.save_memory(&list_test_memory(name, Scope::Root, vec![]))
+                .await
+                .expect("seed memory");
+        }
+        let server = list_test_server(Arc::clone(&repo));
+        let mut cursor = None;
+        let mut walked = Vec::new();
+
+        loop {
+            let page = server
+                .list(
+                    Parameters(ListToolArgs {
+                        scope: None,
+                        limit: Some(1),
+                        cursor,
+                        fields: Some(vec![ListField::Name]),
+                    }),
+                    Extension(list_test_parts()),
+                )
+                .await
+                .expect("list page");
+            let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+            walked.push(
+                page["memories"][0]["name"]
+                    .as_str()
+                    .expect("memory name")
+                    .to_string(),
+            );
+            cursor = page["next_cursor"].as_str().map(str::to_string);
+            if walked.len() == 1 {
+                repo.save_memory(&list_test_memory("bravo", Scope::Root, vec![]))
+                    .await
+                    .expect("concurrent insert");
+            }
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(walked, ["alpha", "bravo", "charlie", "delta"]);
+    }
+
     #[test]
     fn list_cursor_rejects_malformed_and_scope_mismatch() {
         let all = ScopeFilter::All;
@@ -2162,7 +2177,7 @@ mod tests {
             scope: "global".to_string(),
             name: "alpha".to_string(),
         };
-        let cursor = encode_list_cursor(&list_filter_key(&all), 42, &key).expect("cursor");
+        let cursor = encode_list_cursor(&list_filter_key(&all), &key).expect("cursor");
 
         assert!(matches!(
             decode_list_cursor("not-a-cursor", "all"),
@@ -2180,9 +2195,8 @@ mod tests {
             scope: "s".repeat(1_000),
             name: "n".repeat(1_000),
         };
-        let cursor = encode_list_cursor("all", 42, &round_trip_key).expect("bounded cursor");
+        let cursor = encode_list_cursor("all", &round_trip_key).expect("bounded cursor");
         let decoded = decode_list_cursor(&cursor, "all").expect("cursor round trip");
-        assert_eq!(decoded.generation, 42);
         assert_eq!(decoded.key, round_trip_key);
 
         let oversized_key = ListSortKey {
@@ -2190,13 +2204,13 @@ mod tests {
             name: "n".repeat(LIST_CURSOR_MAX_CHARS),
         };
         assert!(matches!(
-            encode_list_cursor("all", 42, &oversized_key),
+            encode_list_cursor("all", &oversized_key),
             Err(MemoryError::InvalidInput { .. })
         ));
     }
 
     #[test]
-    fn list_cursor_rejects_a_changed_matching_memory_set() {
+    fn list_cursor_tolerates_concurrent_changes_with_keyset_semantics() {
         let original = vec![
             list_test_memory("alpha", Scope::Root, vec![]),
             list_test_memory("charlie", Scope::Root, vec![]),
@@ -2215,35 +2229,29 @@ mod tests {
             .expect("next cursor")
             .to_string();
 
-        let changed = vec![
+        let mut changed = vec![
             original[0].clone(),
+            list_test_memory("aardvark", Scope::Root, vec![]),
             list_test_memory("bravo", Scope::Root, vec![]),
             original[1].clone(),
         ];
-        let error = paginate_list(
-            changed,
-            &ScopeFilter::RootOnly,
-            1,
-            Some(&cursor),
-            &[ListField::Name],
-        )
-        .expect_err("changed memory set must stale the cursor");
-        assert!(matches!(error, MemoryError::InvalidInput { .. }));
-
-        let mut metadata_changed = original;
-        metadata_changed[1]
+        changed[0]
             .metadata
             .tags
-            .push("new-tag".to_string());
-        let error = paginate_list(
-            metadata_changed,
+            .push("edited-after-return".to_string());
+        let page = paginate_list(
+            changed,
             &ScopeFilter::RootOnly,
-            1,
-            Some(&cursor),
+            10,
+            Some(decode_list_cursor(&cursor, "root").expect("cursor")),
             &[ListField::Name],
         )
-        .expect_err("changed summary metadata must stale the cursor");
-        assert!(matches!(error, MemoryError::InvalidInput { .. }));
+        .expect("concurrent changes must not stale the cursor");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(
+            page["memories"],
+            serde_json::json!([{"name": "bravo"}, {"name": "charlie"}])
+        );
     }
 
     #[test]
@@ -2260,14 +2268,11 @@ mod tests {
         let mut walked = Vec::new();
 
         loop {
-            let page = paginate_list(
-                memories.clone(),
-                &ScopeFilter::All,
-                2,
-                cursor.as_deref(),
-                &fields,
-            )
-            .expect("page");
+            let decoded = cursor
+                .as_deref()
+                .map(|cursor| decode_list_cursor(cursor, "all").expect("cursor"));
+            let page = paginate_list(memories.clone(), &ScopeFilter::All, 2, decoded, &fields)
+                .expect("page");
             let value: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
             assert_eq!(value["count"], 5);
             assert!(page.len() <= LIST_PAGE_MAX_BYTES);
@@ -2311,6 +2316,49 @@ mod tests {
     }
 
     #[test]
+    fn list_final_page_has_exact_wire_shape_and_present_null_cursor() {
+        let page = paginate_list(
+            vec![list_test_memory("alpha", Scope::Root, vec![])],
+            &ScopeFilter::RootOnly,
+            25,
+            None,
+            &[ListField::Name],
+        )
+        .expect("final page");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(
+            page,
+            serde_json::json!({
+                "memories": [{"name": "alpha"}],
+                "count": 1,
+                "returned": 1,
+                "limit": 25,
+                "has_more": false,
+                "next_cursor": null,
+            })
+        );
+    }
+
+    #[test]
+    fn list_page_size_estimate_matches_exact_serialization() {
+        let summaries = vec![
+            serde_json::json!({"name": "alpha"}),
+            serde_json::json!({"name": "quoted \"value\""}),
+        ];
+        let summaries_bytes = summaries
+            .iter()
+            .map(|summary| serde_json::to_vec(summary).expect("summary JSON").len())
+            .sum();
+        for cursor in [None, Some("lc1_deadbeef")] {
+            let page =
+                serde_json::to_vec(&list_page_value(&summaries, 10, 2, cursor)).expect("page JSON");
+            let estimated =
+                list_page_serialized_len(summaries_bytes, 2, 10, 2, cursor).expect("page size");
+            assert_eq!(estimated, page.len());
+        }
+    }
+
+    #[test]
     fn list_byte_ceiling_splits_pages_without_losing_memories() {
         let memories: Vec<Memory> = (0..30)
             .map(|index| {
@@ -2326,11 +2374,14 @@ mod tests {
         let mut pages = 0;
 
         loop {
+            let decoded = cursor
+                .as_deref()
+                .map(|cursor| decode_list_cursor(cursor, "root").expect("cursor"));
             let page = paginate_list(
                 memories.clone(),
                 &ScopeFilter::RootOnly,
                 LIST_MAX_LIMIT,
-                cursor.as_deref(),
+                decoded,
                 &ListField::ALL,
             )
             .expect("bounded page");

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,10 @@
-use std::{sync::Arc, time::Instant};
+use std::{borrow::Cow, sync::Arc, time::Instant};
 
 /// Maximum number of characters included in recall result snippets.
 /// Content longer than this is truncated and flagged with `truncated: true`.
 const SNIPPET_MAX_CHARS: usize = 500;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::Utc;
 use rmcp::{
     handler::server::{
@@ -107,6 +108,7 @@ struct ListCursorPayload {
     name: String,
 }
 
+#[derive(Debug)]
 struct DecodedListCursor {
     key: ListSortKey,
 }
@@ -127,11 +129,11 @@ fn validate_list_limit(limit: Option<usize>) -> Result<usize, MemoryError> {
     Ok(limit)
 }
 
-fn list_filter_key(filter: &ScopeFilter) -> String {
+fn list_filter_key(filter: &ScopeFilter) -> Cow<'static, str> {
     match filter {
-        ScopeFilter::RootOnly => "root".to_string(),
-        ScopeFilter::All => "all".to_string(),
-        ScopeFilter::Subtree(path) => format!("subtree:{}", path.as_str()),
+        ScopeFilter::RootOnly => Cow::Borrowed("root"),
+        ScopeFilter::All => Cow::Borrowed("all"),
+        ScopeFilter::Subtree(path) => Cow::Owned(format!("subtree:{}", path.as_str())),
     }
 }
 
@@ -143,16 +145,10 @@ fn encode_list_cursor(filter: &str, key: &ListSortKey) -> Result<String, MemoryE
         name: key.name.clone(),
     })
     .map_err(|error| MemoryError::Internal(format!("serialize list cursor: {error}")))?;
-    let mut encoded = String::with_capacity(4 + payload.len() * 2);
-    encoded.push_str("lc1_");
-    for byte in payload {
-        use std::fmt::Write as _;
-        write!(&mut encoded, "{byte:02x}")
-            .map_err(|error| MemoryError::Internal(format!("encode list cursor: {error}")))?;
-    }
+    let encoded = format!("lc1_{}", URL_SAFE_NO_PAD.encode(payload));
     if encoded.len() > LIST_CURSOR_MAX_CHARS {
         return Err(invalid_list_input(
-            "list cursor exceeds the supported size; use shorter scope and memory names",
+            "encoded list cursor exceeds the supported size",
         ));
     }
     Ok(encoded)
@@ -163,33 +159,31 @@ fn decode_list_cursor(
     expected_filter: &str,
 ) -> Result<DecodedListCursor, MemoryError> {
     if cursor.len() > LIST_CURSOR_MAX_CHARS {
-        return Err(invalid_list_input("list cursor is too large"));
+        return Err(invalid_list_input(
+            "list cursor is too large; omit cursor to start a new page",
+        ));
     }
-    let hex = cursor
-        .strip_prefix("lc1_")
-        .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
-    if hex.is_empty() || hex.len() % 2 != 0 {
-        return Err(invalid_list_input("invalid list cursor"));
+    let encoded = cursor.strip_prefix("lc1_").ok_or_else(|| {
+        invalid_list_input("invalid list cursor; omit cursor to start a new page")
+    })?;
+    if encoded.is_empty() {
+        return Err(invalid_list_input(
+            "invalid list cursor; omit cursor to start a new page",
+        ));
     }
-    let bytes = hex.as_bytes();
-    let mut decoded = Vec::with_capacity(bytes.len() / 2);
-    for pair in bytes.chunks_exact(2) {
-        let high = (pair[0] as char)
-            .to_digit(16)
-            .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
-        let low = (pair[1] as char)
-            .to_digit(16)
-            .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
-        decoded.push(((high << 4) | low) as u8);
-    }
-    let payload: ListCursorPayload =
-        serde_json::from_slice(&decoded).map_err(|_| invalid_list_input("invalid list cursor"))?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|_| invalid_list_input("invalid list cursor; omit cursor to start a new page"))?;
+    let payload: ListCursorPayload = serde_json::from_slice(&decoded)
+        .map_err(|_| invalid_list_input("invalid list cursor; omit cursor to start a new page"))?;
     if payload.version != 1 {
-        return Err(invalid_list_input("unsupported list cursor version"));
+        return Err(invalid_list_input(
+            "unsupported list cursor version; omit cursor to start a new page",
+        ));
     }
     if payload.filter != expected_filter {
         return Err(invalid_list_input(
-            "list cursor belongs to a different scope query",
+            "list cursor belongs to a different scope query; omit cursor to start a new page",
         ));
     }
     Ok(DecodedListCursor {
@@ -252,32 +246,6 @@ fn list_page_value(
     })
 }
 
-fn list_page_serialized_len(
-    summaries_bytes: usize,
-    returned: usize,
-    count: usize,
-    limit: usize,
-    next_cursor: Option<&str>,
-) -> Result<usize, MemoryError> {
-    let empty_page = serde_json::json!({
-        "memories": [],
-        "count": count,
-        "returned": returned,
-        "limit": limit,
-        "has_more": next_cursor.is_some(),
-        "next_cursor": next_cursor,
-    });
-    let envelope_len = serde_json::to_vec(&empty_page)
-        .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?
-        .len();
-    let memories_len = if returned == 0 {
-        0
-    } else {
-        summaries_bytes + returned - 1
-    };
-    Ok(envelope_len + memories_len)
-}
-
 fn paginate_list(
     memories: Vec<Memory>,
     filter: &ScopeFilter,
@@ -297,28 +265,30 @@ fn paginate_list(
     });
 
     let mut summaries = Vec::with_capacity(limit.min(count.saturating_sub(start)));
-    let mut summaries_bytes = 0;
+    let mut accepted_page = None;
     for (key, memory) in memories.iter().skip(start).take(limit) {
-        let summary = list_summary(memory, fields);
-        let summary_len = serde_json::to_vec(&summary)
-            .map_err(|error| MemoryError::Internal(format!("serialize list summary: {error}")))?
-            .len();
-        summaries.push(summary);
-        summaries_bytes += summary_len;
+        summaries.push(list_summary(memory, fields));
         let next_index = start + summaries.len();
         let next_cursor = if next_index < count {
-            Some(encode_list_cursor(&filter_key, key)?)
+            Some(
+                encode_list_cursor(filter_key.as_ref(), key).map_err(|error| {
+                    invalid_list_input(format!(
+                        "cannot continue list pagination after memory '{}' in scope '{}': {error}",
+                        key.name, key.scope
+                    ))
+                })?,
+            )
         } else {
             None
         };
-        let candidate_len = list_page_serialized_len(
-            summaries_bytes,
-            summaries.len(),
+        let candidate = serde_json::to_string(&list_page_value(
+            &summaries,
             count,
             limit,
             next_cursor.as_deref(),
-        )?;
-        if candidate_len > LIST_PAGE_MAX_BYTES {
+        ))
+        .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?;
+        if candidate.len() > LIST_PAGE_MAX_BYTES {
             summaries.pop();
             if summaries.is_empty() {
                 return Err(invalid_list_input(format!(
@@ -327,24 +297,14 @@ fn paginate_list(
             }
             break;
         }
+        accepted_page = Some(candidate);
     }
 
-    let next_index = start + summaries.len();
-    let next_cursor = if next_index < count {
-        let last = memories
-            .get(next_index.saturating_sub(1))
-            .ok_or_else(|| MemoryError::Internal("list pagination made no progress".to_string()))?;
-        Some(encode_list_cursor(&filter_key, &last.0)?)
-    } else {
-        None
+    let page = match accepted_page {
+        Some(page) => page,
+        None => serde_json::to_string(&list_page_value(&[], count, limit, None))
+            .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?,
     };
-    let page = serde_json::to_string(&list_page_value(
-        &summaries,
-        count,
-        limit,
-        next_cursor.as_deref(),
-    ))
-    .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?;
     if page.len() > LIST_PAGE_MAX_BYTES {
         return Err(MemoryError::Internal(
             "list page exceeded its serialized byte ceiling".to_string(),
@@ -795,6 +755,7 @@ impl MemoryServer {
         Each result includes `truncated` (bool) and `content_length` (total character count). \
         When `truncated` is true, the snippet is incomplete — use the `read` tool with the memory's name and scope \
         to retrieve the full content before acting on it.\n\n\
+        limit defaults to 5 and values above 100 are clamped to 100. \
         Scope: pass '<basename-of-your-cwd>' or 'org/team' to search that scope + global memories, \
         'global' for global-only, or 'all' to search everything. Omitting scope defaults to global-only."
     )]
@@ -1231,11 +1192,13 @@ impl MemoryServer {
         name = "list",
         description = "List stored memories. Pass a bare path like '<basename-of-your-cwd>' for that scope + global memories, \
         'global' for global-only, or 'all' for everything. Omitting scope defaults to global-only. \
-        Pages are sorted by (scope, name); limit defaults to 50 and cannot exceed 100. \
+        Pages are sorted by (scope, name); limit defaults to 50, and values outside 1..=100 are rejected. \
         Continue with the opaque next_cursor returned by the previous page. Concurrent inserts and \
         deletes follow standard keyset semantics. Use fields to request an exact summary \
         projection; omitting fields returns id, name, scope, tags, created_at, and updated_at. \
-        Successful pages are capped at 24 KiB; request fewer fields if one summary is too large."
+        The response envelope reports count as the total matching memories and returned as the number \
+        in this page, plus limit, has_more, and next_cursor. Successful pages are capped at 24 KiB; \
+        request fewer fields if one summary is too large."
     )]
     async fn list(
         &self,
@@ -2161,6 +2124,9 @@ mod tests {
                 repo.save_memory(&list_test_memory("bravo", Scope::Root, vec![]))
                     .await
                     .expect("concurrent insert");
+                repo.delete_memory("alpha", &Scope::Root)
+                    .await
+                    .expect("delete cursor anchor");
             }
             if cursor.is_none() {
                 break;
@@ -2168,6 +2134,39 @@ mod tests {
         }
 
         assert_eq!(walked, ["alpha", "bravo", "charlie", "delta"]);
+    }
+
+    #[tokio::test]
+    async fn list_mcp_handler_applies_default_limit_of_fifty() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = Arc::new(MemoryRepo::init_or_open(temp.path(), None).expect("repo"));
+        for index in 0..51 {
+            repo.save_memory(&list_test_memory(
+                &format!("memory-{index:02}"),
+                Scope::Root,
+                vec![],
+            ))
+            .await
+            .expect("seed memory");
+        }
+        let page = list_test_server(repo)
+            .list(
+                Parameters(ListToolArgs {
+                    scope: None,
+                    limit: None,
+                    cursor: None,
+                    fields: Some(vec![ListField::Name]),
+                }),
+                Extension(list_test_parts()),
+            )
+            .await
+            .expect("default-limit page");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(page["count"], 51);
+        assert_eq!(page["returned"], LIST_DEFAULT_LIMIT);
+        assert_eq!(page["limit"], LIST_DEFAULT_LIMIT);
+        assert_eq!(page["has_more"], true);
+        assert!(page["next_cursor"].is_string());
     }
 
     #[test]
@@ -2187,6 +2186,40 @@ mod tests {
             decode_list_cursor(&cursor, "root"),
             Err(MemoryError::InvalidInput { .. })
         ));
+    }
+
+    #[test]
+    fn list_cursor_rejects_untrusted_shapes_with_remediation() {
+        let unsupported_version = format!(
+            "lc1_{}",
+            URL_SAFE_NO_PAD.encode(
+                serde_json::to_vec(&serde_json::json!({
+                    "version": 2,
+                    "filter": "all",
+                    "scope": "global",
+                    "name": "alpha",
+                }))
+                .expect("cursor payload"),
+            )
+        );
+        let cases = [
+            "lc1_".to_string(),
+            "lc1_*".to_string(),
+            format!("lc1_{}", URL_SAFE_NO_PAD.encode(b"not JSON")),
+            unsupported_version,
+            "x".repeat(LIST_CURSOR_MAX_CHARS + 1),
+        ];
+
+        for cursor in cases {
+            let error = decode_list_cursor(&cursor, "all").expect_err("cursor must fail");
+            let MemoryError::InvalidInput { reason } = error else {
+                panic!("expected invalid input");
+            };
+            assert!(
+                reason.contains("omit cursor to start a new page"),
+                "missing remediation: {reason}"
+            );
+        }
     }
 
     #[test]
@@ -2210,6 +2243,74 @@ mod tests {
     }
 
     #[test]
+    fn list_cursor_round_trips_generated_keys() {
+        for length in 0..=128 {
+            let key = ListSortKey {
+                scope: format!("scope-{}", "é".repeat(length)),
+                name: format!("name-{}", "界".repeat(length)),
+            };
+            let cursor = encode_list_cursor("subtree:scope", &key).expect("encode cursor");
+            let decoded = decode_list_cursor(&cursor, "subtree:scope").expect("decode cursor");
+            assert_eq!(decoded.key, key);
+        }
+    }
+
+    #[test]
+    fn list_cursor_fits_maximum_filesystem_legal_scope_and_name() {
+        let component = "s".repeat(255);
+        let scope = std::iter::repeat_n(component.as_str(), 10)
+            .collect::<Vec<_>>()
+            .join("/");
+        let name = std::iter::repeat_n("n".repeat(255), 3)
+            .collect::<Vec<_>>()
+            .join("/");
+        let key = ListSortKey {
+            scope: scope.clone(),
+            name,
+        };
+        let filter = format!("subtree:{scope}");
+        let cursor = encode_list_cursor(&filter, &key).expect("legal key must fit cursor bound");
+        assert!(cursor.len() <= LIST_CURSOR_MAX_CHARS);
+        assert_eq!(
+            decode_list_cursor(&cursor, &filter).expect("decode").key,
+            key
+        );
+    }
+
+    #[test]
+    fn list_paginates_past_a_maximum_legal_interior_key() {
+        let component = "s".repeat(255);
+        let scope_path = std::iter::repeat_n(component.as_str(), 10)
+            .collect::<Vec<_>>()
+            .join("/");
+        let scope = list_test_path(&scope_path);
+        let long_name = std::iter::repeat_n("m".repeat(255), 3)
+            .collect::<Vec<_>>()
+            .join("/");
+        let memories = vec![
+            list_test_memory("alpha", scope.clone(), vec![]),
+            list_test_memory(&long_name, scope.clone(), vec![]),
+            list_test_memory("zulu", scope, vec![]),
+        ];
+        let filter = ScopeFilter::Subtree(
+            crate::types::ScopePath::new(scope_path).expect("valid scope path"),
+        );
+
+        let page = paginate_list(memories, &filter, 2, None, &[ListField::Name])
+            .expect("long interior key must remain pageable");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(page["returned"], 2);
+        let cursor = page["next_cursor"].as_str().expect("next cursor");
+        assert_eq!(
+            decode_list_cursor(cursor, list_filter_key(&filter).as_ref())
+                .expect("decode")
+                .key
+                .name,
+            long_name
+        );
+    }
+
+    #[test]
     fn list_cursor_tolerates_concurrent_changes_with_keyset_semantics() {
         let original = vec![
             list_test_memory("alpha", Scope::Root, vec![]),
@@ -2229,16 +2330,12 @@ mod tests {
             .expect("next cursor")
             .to_string();
 
-        let mut changed = vec![
+        let changed = vec![
             original[0].clone(),
             list_test_memory("aardvark", Scope::Root, vec![]),
             list_test_memory("bravo", Scope::Root, vec![]),
             original[1].clone(),
         ];
-        changed[0]
-            .metadata
-            .tags
-            .push("edited-after-return".to_string());
         let page = paginate_list(
             changed,
             &ScopeFilter::RootOnly,
@@ -2251,6 +2348,40 @@ mod tests {
         assert_eq!(
             page["memories"],
             serde_json::json!([{"name": "bravo"}, {"name": "charlie"}])
+        );
+    }
+
+    #[test]
+    fn list_cursor_tolerates_an_observable_edit_after_the_cursor() {
+        let original = vec![
+            list_test_memory("alpha", Scope::Root, vec![]),
+            list_test_memory("charlie", Scope::Root, vec![]),
+        ];
+        let first = paginate_list(
+            original.clone(),
+            &ScopeFilter::RootOnly,
+            1,
+            None,
+            &[ListField::Name],
+        )
+        .expect("first page");
+        let first: serde_json::Value = serde_json::from_str(&first).expect("JSON page");
+        let cursor = first["next_cursor"].as_str().expect("cursor");
+        let mut edited = original;
+        edited[1].metadata.tags.push("edited".to_string());
+
+        let page = paginate_list(
+            edited,
+            &ScopeFilter::RootOnly,
+            10,
+            Some(decode_list_cursor(cursor, "root").expect("cursor")),
+            &[ListField::Name, ListField::Tags],
+        )
+        .expect("edit must not stale cursor");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(
+            page["memories"],
+            serde_json::json!([{"name": "charlie", "tags": ["edited"]}])
         );
     }
 
@@ -2340,22 +2471,55 @@ mod tests {
     }
 
     #[test]
-    fn list_page_size_estimate_matches_exact_serialization() {
-        let summaries = vec![
-            serde_json::json!({"name": "alpha"}),
-            serde_json::json!({"name": "quoted \"value\""}),
-        ];
-        let summaries_bytes = summaries
-            .iter()
-            .map(|summary| serde_json::to_vec(summary).expect("summary JSON").len())
-            .sum();
-        for cursor in [None, Some("lc1_deadbeef")] {
-            let page =
-                serde_json::to_vec(&list_page_value(&summaries, 10, 2, cursor)).expect("page JSON");
-            let estimated =
-                list_page_serialized_len(summaries_bytes, 2, 10, 2, cursor).expect("page size");
-            assert_eq!(estimated, page.len());
-        }
+    fn list_nonfinal_page_has_exact_wire_shape() {
+        let page = paginate_list(
+            vec![
+                list_test_memory("alpha", Scope::Root, vec![]),
+                list_test_memory("bravo", Scope::Root, vec![]),
+            ],
+            &ScopeFilter::RootOnly,
+            1,
+            None,
+            &[ListField::Name],
+        )
+        .expect("nonfinal page");
+        let page: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        let cursor = page["next_cursor"].as_str().expect("next cursor");
+        assert!(decode_list_cursor(cursor, "root").is_ok());
+        assert_eq!(
+            page,
+            serde_json::json!({
+                "memories": [{"name": "alpha"}],
+                "count": 2,
+                "returned": 1,
+                "limit": 1,
+                "has_more": true,
+                "next_cursor": cursor,
+            })
+        );
+    }
+
+    #[test]
+    fn list_empty_scope_has_exact_wire_shape() {
+        let page = paginate_list(
+            vec![],
+            &ScopeFilter::RootOnly,
+            LIST_DEFAULT_LIMIT,
+            None,
+            &[ListField::Name],
+        )
+        .expect("empty page");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&page).expect("JSON page"),
+            serde_json::json!({
+                "memories": [],
+                "count": 0,
+                "returned": 0,
+                "limit": 50,
+                "has_more": false,
+                "next_cursor": null,
+            })
+        );
     }
 
     #[test]
@@ -2370,7 +2534,7 @@ mod tests {
             })
             .collect();
         let mut cursor = None;
-        let mut returned = 0;
+        let mut walked = Vec::new();
         let mut pages = 0;
 
         loop {
@@ -2387,7 +2551,10 @@ mod tests {
             .expect("bounded page");
             assert!(page.len() <= LIST_PAGE_MAX_BYTES, "{} bytes", page.len());
             let value: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
-            returned += value["returned"].as_u64().expect("returned") as usize;
+            assert_eq!(value["count"], memories.len());
+            for memory in value["memories"].as_array().expect("memories") {
+                walked.push(memory["name"].as_str().expect("memory name").to_string());
+            }
             pages += 1;
             cursor = value["next_cursor"].as_str().map(str::to_string);
             if cursor.is_none() {
@@ -2395,7 +2562,8 @@ mod tests {
             }
         }
 
-        assert_eq!(returned, memories.len());
+        let expected: Vec<_> = (0..30).map(|index| format!("memory-{index:02}")).collect();
+        assert_eq!(walked, expected);
         assert!(pages > 1);
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -50,10 +50,10 @@ use crate::{
         LexicalIndex, LexicalOp,
     },
     types::{
-        parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
-        ForgetArgs, ListArgs, ListField, ListToolArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName,
-        MemoryRef, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
-        RememberArgs, Scope, ScopeFilter, SyncArgs, LIST_MAX_LIMIT,
+        parse_qualified_name, AppState, BatchMarkAppliedArgs, EditArgs, ForgetArgs, ListField,
+        ListToolArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef, MoveArgs,
+        PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs,
+        ResolvedChanges, Scope, ScopeFilter, SyncArgs, LIST_MAX_LIMIT,
     },
 };
 
@@ -2491,6 +2491,10 @@ mod tests {
             assert!(
                 reason.contains("omit cursor to start a new page"),
                 "missing remediation: {reason}"
+            );
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Wire-contract tests — the recall result entry shape MCP clients see.
     // -----------------------------------------------------------------------
@@ -3008,6 +3012,9 @@ mod tests {
             value["memories"],
             serde_json::json!([{"name": "huge-tags"}])
         );
+    }
+
+    #[test]
     fn recall_entry_both_hit_keeps_semantic_distance() {
         let hit = FusedHit {
             qualified_name: "v1:scope=global;name=wire-test".to_string(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,6 +17,7 @@ use rmcp::{
     service::RequestContext,
     tool, tool_handler, tool_router, RoleServer, ServerHandler,
 };
+use serde::{Deserialize, Serialize};
 use tracing::{info, warn, Instrument};
 
 /// Extract the `Mcp-Session-Id` header from HTTP request parts.
@@ -45,9 +46,9 @@ use crate::{
     repo::{traced_spawn_blocking, MemoryRepo},
     types::{
         parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
-        ForgetArgs, ListArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef,
-        MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats, RememberArgs,
-        Scope, ScopeFilter, SyncArgs,
+        ForgetArgs, ListArgs, ListField, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName,
+        MemoryRef, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
+        RememberArgs, Scope, ScopeFilter, SyncArgs,
     },
 };
 
@@ -75,6 +76,310 @@ pub struct MemoryServer {
 
 /// Maximum allowed content size in bytes (1 MiB).
 const MAX_CONTENT_SIZE: usize = 1_048_576;
+
+/// Default and hard maximum number of summaries returned by `list`.
+const LIST_DEFAULT_LIMIT: usize = 50;
+const LIST_MAX_LIMIT: usize = 100;
+/// Hard ceiling for the serialized JSON returned by one successful `list` page.
+const LIST_PAGE_MAX_BYTES: usize = 24 * 1024;
+/// Bounds work performed while decoding an untrusted opaque cursor.
+const LIST_CURSOR_MAX_CHARS: usize = 8 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ListSortKey {
+    scope: String,
+    name: String,
+}
+
+impl ListSortKey {
+    fn from_memory(memory: &Memory) -> Self {
+        Self {
+            scope: memory.metadata.scope.to_string(),
+            name: memory.name.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ListCursorPayload {
+    version: u8,
+    filter: String,
+    generation: u64,
+    scope: String,
+    name: String,
+}
+
+struct DecodedListCursor {
+    generation: u64,
+    key: ListSortKey,
+}
+
+fn invalid_list_input(reason: impl Into<String>) -> MemoryError {
+    MemoryError::InvalidInput {
+        reason: reason.into(),
+    }
+}
+
+fn validate_list_limit(limit: Option<usize>) -> Result<usize, MemoryError> {
+    let limit = limit.unwrap_or(LIST_DEFAULT_LIMIT);
+    if !(1..=LIST_MAX_LIMIT).contains(&limit) {
+        return Err(invalid_list_input(format!(
+            "list limit must be between 1 and {LIST_MAX_LIMIT}"
+        )));
+    }
+    Ok(limit)
+}
+
+fn list_filter_key(filter: &ScopeFilter) -> String {
+    match filter {
+        ScopeFilter::RootOnly => "root".to_string(),
+        ScopeFilter::All => "all".to_string(),
+        ScopeFilter::Subtree(path) => format!("subtree:{}", path.as_str()),
+    }
+}
+
+fn encode_list_cursor(
+    filter: &str,
+    generation: u64,
+    key: &ListSortKey,
+) -> Result<String, MemoryError> {
+    let payload = serde_json::to_vec(&ListCursorPayload {
+        version: 1,
+        filter: filter.to_string(),
+        generation,
+        scope: key.scope.clone(),
+        name: key.name.clone(),
+    })
+    .map_err(|error| MemoryError::Internal(format!("serialize list cursor: {error}")))?;
+    let mut encoded = String::with_capacity(4 + payload.len() * 2);
+    encoded.push_str("lc1_");
+    for byte in payload {
+        use std::fmt::Write as _;
+        write!(&mut encoded, "{byte:02x}")
+            .map_err(|error| MemoryError::Internal(format!("encode list cursor: {error}")))?;
+    }
+    if encoded.len() > LIST_CURSOR_MAX_CHARS {
+        return Err(invalid_list_input(
+            "list cursor exceeds the supported size; use shorter scope and memory names",
+        ));
+    }
+    Ok(encoded)
+}
+
+fn decode_list_cursor(
+    cursor: &str,
+    expected_filter: &str,
+) -> Result<DecodedListCursor, MemoryError> {
+    if cursor.len() > LIST_CURSOR_MAX_CHARS {
+        return Err(invalid_list_input("list cursor is too large"));
+    }
+    let hex = cursor
+        .strip_prefix("lc1_")
+        .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
+    if hex.is_empty() || hex.len() % 2 != 0 {
+        return Err(invalid_list_input("invalid list cursor"));
+    }
+    let bytes = hex.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len() / 2);
+    for pair in bytes.chunks_exact(2) {
+        let high = (pair[0] as char)
+            .to_digit(16)
+            .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
+        let low = (pair[1] as char)
+            .to_digit(16)
+            .ok_or_else(|| invalid_list_input("invalid list cursor"))?;
+        decoded.push(((high << 4) | low) as u8);
+    }
+    let payload: ListCursorPayload =
+        serde_json::from_slice(&decoded).map_err(|_| invalid_list_input("invalid list cursor"))?;
+    if payload.version != 1 {
+        return Err(invalid_list_input("unsupported list cursor version"));
+    }
+    if payload.filter != expected_filter {
+        return Err(invalid_list_input(
+            "list cursor belongs to a different scope query",
+        ));
+    }
+    Ok(DecodedListCursor {
+        generation: payload.generation,
+        key: ListSortKey {
+            scope: payload.scope,
+            name: payload.name,
+        },
+    })
+}
+
+fn extend_list_generation(hash: &mut u64, value: &[u8]) {
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    for byte in value
+        .len()
+        .to_le_bytes()
+        .into_iter()
+        .chain(value.iter().copied())
+    {
+        *hash ^= u64::from(byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
+}
+
+fn list_generation(memories: &[Memory]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut hash = FNV_OFFSET_BASIS;
+    for memory in memories {
+        let key = ListSortKey::from_memory(memory);
+        let created_at = memory.metadata.created_at.to_rfc3339();
+        let updated_at = memory.metadata.updated_at.to_rfc3339();
+        for value in [
+            key.scope.as_str(),
+            key.name.as_str(),
+            memory.id.as_str(),
+            created_at.as_str(),
+            updated_at.as_str(),
+        ] {
+            extend_list_generation(&mut hash, value.as_bytes());
+        }
+        for tag in &memory.metadata.tags {
+            extend_list_generation(&mut hash, tag.as_bytes());
+        }
+    }
+    hash
+}
+
+fn list_summary(memory: &Memory, fields: &[ListField]) -> serde_json::Value {
+    let mut summary = serde_json::Map::new();
+    for field in fields {
+        match field {
+            ListField::Id => {
+                summary.insert("id".to_string(), serde_json::json!(memory.id));
+            }
+            ListField::Name => {
+                summary.insert("name".to_string(), serde_json::json!(memory.name));
+            }
+            ListField::Scope => {
+                summary.insert(
+                    "scope".to_string(),
+                    serde_json::json!(memory.metadata.scope.to_string()),
+                );
+            }
+            ListField::Tags => {
+                summary.insert("tags".to_string(), serde_json::json!(memory.metadata.tags));
+            }
+            ListField::CreatedAt => {
+                summary.insert(
+                    "created_at".to_string(),
+                    serde_json::json!(memory.metadata.created_at),
+                );
+            }
+            ListField::UpdatedAt => {
+                summary.insert(
+                    "updated_at".to_string(),
+                    serde_json::json!(memory.metadata.updated_at),
+                );
+            }
+        }
+    }
+    serde_json::Value::Object(summary)
+}
+
+fn list_page_value(
+    summaries: &[serde_json::Value],
+    count: usize,
+    limit: usize,
+    next_cursor: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "memories": summaries,
+        "count": count,
+        "returned": summaries.len(),
+        "limit": limit,
+        "has_more": next_cursor.is_some(),
+        "next_cursor": next_cursor,
+    })
+}
+
+fn paginate_list(
+    mut memories: Vec<Memory>,
+    filter: &ScopeFilter,
+    limit: usize,
+    cursor: Option<&str>,
+    fields: &[ListField],
+) -> Result<String, MemoryError> {
+    memories.sort_by_key(ListSortKey::from_memory);
+    let count = memories.len();
+    let generation = list_generation(&memories);
+    let filter_key = list_filter_key(filter);
+    let after = cursor
+        .map(|value| decode_list_cursor(value, &filter_key))
+        .transpose()?;
+    if let Some(cursor) = &after {
+        if cursor.generation != generation {
+            return Err(invalid_list_input(
+                "list cursor is stale because the matching list data changed; restart pagination",
+            ));
+        }
+    }
+    let start = after.as_ref().map_or(0, |cursor| {
+        memories.partition_point(|memory| ListSortKey::from_memory(memory) <= cursor.key)
+    });
+
+    let mut summaries = Vec::with_capacity(limit.min(count.saturating_sub(start)));
+    for memory in memories.iter().skip(start).take(limit) {
+        summaries.push(list_summary(memory, fields));
+        let next_index = start + summaries.len();
+        let next_cursor = if next_index < count {
+            Some(encode_list_cursor(
+                &filter_key,
+                generation,
+                &ListSortKey::from_memory(memory),
+            )?)
+        } else {
+            None
+        };
+        let candidate = serde_json::to_string(&list_page_value(
+            &summaries,
+            count,
+            limit,
+            next_cursor.as_deref(),
+        ))
+        .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?;
+        if candidate.len() > LIST_PAGE_MAX_BYTES {
+            summaries.pop();
+            if summaries.is_empty() {
+                return Err(invalid_list_input(format!(
+                    "one list summary exceeds the {LIST_PAGE_MAX_BYTES}-byte page ceiling; request fewer fields"
+                )));
+            }
+            break;
+        }
+    }
+
+    let next_index = start + summaries.len();
+    let next_cursor = if next_index < count {
+        let last = memories
+            .get(next_index.saturating_sub(1))
+            .ok_or_else(|| MemoryError::Internal("list pagination made no progress".to_string()))?;
+        Some(encode_list_cursor(
+            &filter_key,
+            generation,
+            &ListSortKey::from_memory(last),
+        )?)
+    } else {
+        None
+    };
+    let page = serde_json::to_string(&list_page_value(
+        &summaries,
+        count,
+        limit,
+        next_cursor.as_deref(),
+    ))
+    .map_err(|error| MemoryError::Internal(format!("serialize list page: {error}")))?;
+    if page.len() > LIST_PAGE_MAX_BYTES {
+        return Err(MemoryError::Internal(
+            "list page exceeded its serialized byte ceiling".to_string(),
+        ));
+    }
+    Ok(page)
+}
 
 const SERVER_PROCESSING_DURATION_META_KEY: &str = "memory-mcp/serverProcessingDurationMs";
 
@@ -948,13 +1253,17 @@ impl MemoryServer {
 
     /// List stored memories, optionally filtered by scope.
     ///
-    /// Returns a JSON array of memory summaries (id, name, scope, tags,
-    /// created_at, updated_at). Full content bodies are omitted for brevity.
+    /// Returns a bounded JSON page of memory summaries. Full content bodies
+    /// are omitted for brevity.
     #[tool(
         name = "list",
         description = "List stored memories. Pass a bare path like '<basename-of-your-cwd>' for that scope + global memories, \
         'global' for global-only, or 'all' for everything. Omitting scope defaults to global-only. \
-        Returns a JSON array of memory summaries without full content."
+        Pages are sorted by (scope, name); limit defaults to 50 and cannot exceed 100. \
+        Continue with the opaque next_cursor returned by the previous page; restart if a cursor is \
+        reported stale after the matching memory set changes. Use fields to request an exact summary \
+        projection; omitting fields returns id, name, scope, tags, created_at, and updated_at. \
+        Successful pages are capped at 24 KiB; request fewer fields if one summary is too large."
     )]
     async fn list(
         &self,
@@ -970,8 +1279,14 @@ impl MemoryServer {
         );
         let state = Arc::clone(&self.state);
         async move {
+            let limit = validate_list_limit(args.limit).map_err(ErrorData::from)?;
             let scope_filter =
                 ScopeFilter::parse_or_default(args.scope.as_deref()).map_err(ErrorData::from)?;
+            let filter_key = list_filter_key(&scope_filter);
+            if let Some(cursor) = args.cursor.as_deref() {
+                decode_list_cursor(cursor, &filter_key).map_err(ErrorData::from)?;
+            }
+            let fields = args.fields.unwrap_or_else(|| ListField::ALL.to_vec());
 
             let start = Instant::now();
             let memories = match &scope_filter {
@@ -1004,26 +1319,14 @@ impl MemoryServer {
             let count = memories.len();
             tracing::Span::current().record("count", count);
             info!(ms = start.elapsed().as_millis(), count, "listed memories");
-
-            let summaries: Vec<serde_json::Value> = memories
-                .into_iter()
-                .map(|m| {
-                    serde_json::json!({
-                        "id": m.id,
-                        "name": m.name,
-                        "scope": m.metadata.scope.to_string(),
-                        "tags": m.metadata.tags,
-                        "created_at": m.metadata.created_at,
-                        "updated_at": m.metadata.updated_at,
-                    })
-                })
-                .collect();
-
-            Ok(serde_json::json!({
-                "memories": summaries,
-                "count": count,
-            })
-            .to_string())
+            paginate_list(
+                memories,
+                &scope_filter,
+                limit,
+                args.cursor.as_deref(),
+                &fields,
+            )
+            .map_err(ErrorData::from)
         }
         .instrument(span)
         .await
@@ -1574,6 +1877,8 @@ fn build_snippet(content: &str) -> (String, usize, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{auth::AuthProvider, health::HealthRegistry, index::InMemoryStore};
+    use async_trait::async_trait;
     use rmcp::model::Content;
     use std::{
         io::Write,
@@ -1583,6 +1888,19 @@ mod tests {
     use tracing_subscriber::{layer::SubscriberExt, Registry};
 
     struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct ListTestEmbedding;
+
+    #[async_trait]
+    impl EmbeddingBackend for ListTestEmbedding {
+        async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+            Ok(vec![vec![0.0; 4]; texts.len()])
+        }
+
+        fn dimensions(&self) -> usize {
+            4
+        }
+    }
 
     impl Write for TestWriter {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
@@ -1755,5 +2073,311 @@ mod tests {
         assert_eq!(snippet, "");
         assert_eq!(content_length, 0);
         assert!(!truncated);
+    }
+
+    fn list_test_memory(name: &str, scope: Scope, tags: Vec<String>) -> Memory {
+        Memory::new(name, "body", MemoryMetadata::new(scope, tags, None)).expect("valid memory")
+    }
+
+    fn list_test_path(path: &str) -> Scope {
+        Scope::Path(crate::types::ScopePath::new(path).expect("valid scope"))
+    }
+
+    fn list_test_server(repo: Arc<MemoryRepo>) -> MemoryServer {
+        let state = Arc::new(AppState::new(
+            repo,
+            "main".to_string(),
+            Box::new(ListTestEmbedding),
+            Box::new(InMemoryStore::new(4)),
+            AuthProvider::new(),
+            HealthRegistry::new(),
+            None,
+        ));
+        MemoryServer::new(state)
+    }
+
+    fn list_test_parts() -> http::request::Parts {
+        http::Request::builder()
+            .body(())
+            .expect("request")
+            .into_parts()
+            .0
+    }
+
+    #[test]
+    fn list_limit_rejects_zero_and_values_above_maximum() {
+        assert!(matches!(
+            validate_list_limit(Some(0)),
+            Err(MemoryError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            validate_list_limit(Some(LIST_MAX_LIMIT + 1)),
+            Err(MemoryError::InvalidInput { .. })
+        ));
+        assert_eq!(
+            validate_list_limit(None).expect("default limit"),
+            LIST_DEFAULT_LIMIT
+        );
+    }
+
+    #[tokio::test]
+    async fn list_mcp_handler_rejects_invalid_limit_and_cursor() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = Arc::new(MemoryRepo::init_or_open(temp.path(), None).expect("repo"));
+        let server = list_test_server(repo);
+
+        let invalid_limit = server
+            .list(
+                Parameters(ListArgs {
+                    scope: None,
+                    limit: Some(0),
+                    cursor: None,
+                    fields: None,
+                }),
+                Extension(list_test_parts()),
+            )
+            .await
+            .expect_err("zero limit must fail");
+        assert_eq!(invalid_limit.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+
+        let invalid_cursor = server
+            .list(
+                Parameters(ListArgs {
+                    scope: None,
+                    limit: None,
+                    cursor: Some("garbage".to_string()),
+                    fields: None,
+                }),
+                Extension(list_test_parts()),
+            )
+            .await
+            .expect_err("malformed cursor must fail");
+        assert_eq!(invalid_cursor.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn list_cursor_rejects_malformed_and_scope_mismatch() {
+        let all = ScopeFilter::All;
+        let key = ListSortKey {
+            scope: "global".to_string(),
+            name: "alpha".to_string(),
+        };
+        let cursor = encode_list_cursor(&list_filter_key(&all), 42, &key).expect("cursor");
+
+        assert!(matches!(
+            decode_list_cursor("not-a-cursor", "all"),
+            Err(MemoryError::InvalidInput { .. })
+        ));
+        assert!(matches!(
+            decode_list_cursor(&cursor, "root"),
+            Err(MemoryError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
+    fn list_cursor_encoder_never_emits_a_cursor_the_decoder_rejects_for_size() {
+        let round_trip_key = ListSortKey {
+            scope: "s".repeat(1_000),
+            name: "n".repeat(1_000),
+        };
+        let cursor = encode_list_cursor("all", 42, &round_trip_key).expect("bounded cursor");
+        let decoded = decode_list_cursor(&cursor, "all").expect("cursor round trip");
+        assert_eq!(decoded.generation, 42);
+        assert_eq!(decoded.key, round_trip_key);
+
+        let oversized_key = ListSortKey {
+            scope: "s".repeat(LIST_CURSOR_MAX_CHARS),
+            name: "n".repeat(LIST_CURSOR_MAX_CHARS),
+        };
+        assert!(matches!(
+            encode_list_cursor("all", 42, &oversized_key),
+            Err(MemoryError::InvalidInput { .. })
+        ));
+    }
+
+    #[test]
+    fn list_cursor_rejects_a_changed_matching_memory_set() {
+        let original = vec![
+            list_test_memory("alpha", Scope::Root, vec![]),
+            list_test_memory("charlie", Scope::Root, vec![]),
+        ];
+        let first = paginate_list(
+            original.clone(),
+            &ScopeFilter::RootOnly,
+            1,
+            None,
+            &[ListField::Name],
+        )
+        .expect("first page");
+        let first: serde_json::Value = serde_json::from_str(&first).expect("JSON page");
+        let cursor = first["next_cursor"]
+            .as_str()
+            .expect("next cursor")
+            .to_string();
+
+        let changed = vec![
+            original[0].clone(),
+            list_test_memory("bravo", Scope::Root, vec![]),
+            original[1].clone(),
+        ];
+        let error = paginate_list(
+            changed,
+            &ScopeFilter::RootOnly,
+            1,
+            Some(&cursor),
+            &[ListField::Name],
+        )
+        .expect_err("changed memory set must stale the cursor");
+        assert!(matches!(error, MemoryError::InvalidInput { .. }));
+
+        let mut metadata_changed = original;
+        metadata_changed[1]
+            .metadata
+            .tags
+            .push("new-tag".to_string());
+        let error = paginate_list(
+            metadata_changed,
+            &ScopeFilter::RootOnly,
+            1,
+            Some(&cursor),
+            &[ListField::Name],
+        )
+        .expect_err("changed summary metadata must stale the cursor");
+        assert!(matches!(error, MemoryError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn list_pages_walk_stably_in_scope_name_order() {
+        let memories = vec![
+            list_test_memory("zulu", list_test_path("team/b"), vec![]),
+            list_test_memory("bravo", Scope::Root, vec![]),
+            list_test_memory("alpha", list_test_path("team/a"), vec![]),
+            list_test_memory("alpha", Scope::Root, vec![]),
+            list_test_memory("charlie", list_test_path("team/a"), vec![]),
+        ];
+        let fields = [ListField::Scope, ListField::Name];
+        let mut cursor = None;
+        let mut walked = Vec::new();
+
+        loop {
+            let page = paginate_list(
+                memories.clone(),
+                &ScopeFilter::All,
+                2,
+                cursor.as_deref(),
+                &fields,
+            )
+            .expect("page");
+            let value: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+            assert_eq!(value["count"], 5);
+            assert!(page.len() <= LIST_PAGE_MAX_BYTES);
+            for memory in value["memories"].as_array().expect("memories") {
+                walked.push(format!(
+                    "{}/{}",
+                    memory["scope"].as_str().expect("scope"),
+                    memory["name"].as_str().expect("name")
+                ));
+            }
+            cursor = value["next_cursor"].as_str().map(str::to_string);
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(
+            walked,
+            [
+                "global/alpha",
+                "global/bravo",
+                "team/a/alpha",
+                "team/a/charlie",
+                "team/b/zulu",
+            ]
+        );
+    }
+
+    #[test]
+    fn list_projection_is_exact_and_omission_preserves_legacy_fields() {
+        let memory = list_test_memory("alpha", Scope::Root, vec!["tag".to_string()]);
+        let projected = list_summary(&memory, &[ListField::Name]);
+        assert_eq!(projected, serde_json::json!({"name": "alpha"}));
+
+        let legacy = list_summary(&memory, &ListField::ALL);
+        let object = legacy.as_object().expect("summary object");
+        assert_eq!(object.len(), 6);
+        for field in ["id", "name", "scope", "tags", "created_at", "updated_at"] {
+            assert!(object.contains_key(field), "missing {field}");
+        }
+    }
+
+    #[test]
+    fn list_byte_ceiling_splits_pages_without_losing_memories() {
+        let memories: Vec<Memory> = (0..30)
+            .map(|index| {
+                list_test_memory(
+                    &format!("memory-{index:02}"),
+                    Scope::Root,
+                    vec!["x".repeat(2_000)],
+                )
+            })
+            .collect();
+        let mut cursor = None;
+        let mut returned = 0;
+        let mut pages = 0;
+
+        loop {
+            let page = paginate_list(
+                memories.clone(),
+                &ScopeFilter::RootOnly,
+                LIST_MAX_LIMIT,
+                cursor.as_deref(),
+                &ListField::ALL,
+            )
+            .expect("bounded page");
+            assert!(page.len() <= LIST_PAGE_MAX_BYTES, "{} bytes", page.len());
+            let value: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+            returned += value["returned"].as_u64().expect("returned") as usize;
+            pages += 1;
+            cursor = value["next_cursor"].as_str().map(str::to_string);
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(returned, memories.len());
+        assert!(pages > 1);
+    }
+
+    #[test]
+    fn list_pathological_tags_require_a_leaner_projection() {
+        let memories = vec![list_test_memory(
+            "huge-tags",
+            Scope::Root,
+            vec!["x".repeat(LIST_PAGE_MAX_BYTES)],
+        )];
+        let error = paginate_list(
+            memories.clone(),
+            &ScopeFilter::RootOnly,
+            1,
+            None,
+            &ListField::ALL,
+        )
+        .expect_err("legacy projection is too large");
+        assert!(matches!(error, MemoryError::InvalidInput { .. }));
+
+        let page = paginate_list(
+            memories,
+            &ScopeFilter::RootOnly,
+            1,
+            None,
+            &[ListField::Name],
+        )
+        .expect("lean projection fits");
+        assert!(page.len() <= LIST_PAGE_MAX_BYTES);
+        let value: serde_json::Value = serde_json::from_str(&page).expect("JSON page");
+        assert_eq!(
+            value["memories"],
+            serde_json::json!([{"name": "huge-tags"}])
+        );
     }
 }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -84,12 +84,54 @@ pub struct MoveArgs {
     pub new_name: Option<String>,
 }
 
+/// A summary field that can be returned by the `list` tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(inline)]
+#[non_exhaustive]
+pub enum ListField {
+    /// Stable memory UUID.
+    Id,
+    /// Human-readable memory name.
+    Name,
+    /// Fully-qualified memory scope.
+    Scope,
+    /// Free-form memory tags.
+    Tags,
+    /// Memory creation timestamp.
+    CreatedAt,
+    /// Most recent memory update timestamp.
+    UpdatedAt,
+}
+
+impl ListField {
+    /// The compatibility projection used when callers omit `fields`.
+    pub(crate) const ALL: [Self; 6] = [
+        Self::Id,
+        Self::Name,
+        Self::Scope,
+        Self::Tags,
+        Self::CreatedAt,
+        Self::UpdatedAt,
+    ];
+}
+
 /// Arguments for the `list` tool — browse stored memories.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListArgs {
     /// Scope: 'global', a bare namespace path like 'my-project' or 'org/team', 'all', or omit for global-only. Use 'all' to list everything.
     #[serde(default)]
     pub scope: Option<String>,
+    /// Maximum number of summaries to return. Defaults to 50; maximum 100.
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 100))]
+    pub limit: Option<usize>,
+    /// Opaque cursor returned by a previous list page. Cursors are bound to the queried scope.
+    #[serde(default)]
+    pub cursor: Option<String>,
+    /// Summary fields to return. Omit to preserve the full six-field legacy summary.
+    #[serde(default)]
+    pub fields: Option<Vec<ListField>>,
 }
 
 /// Arguments for the `read` tool — retrieve a specific memory by name.
@@ -437,5 +479,35 @@ mod tests {
         let json = r#"{ "recall_id": "r_1", "memory": "m1", "verdict": "bogus" }"#;
         let result: Result<VerdictEntry, _> = serde_json::from_str(json);
         assert!(result.is_err(), "invalid verdict variant should fail");
+    }
+
+    #[test]
+    fn list_schema_exposes_pagination_and_projection_inputs() {
+        let schema = schemars::schema_for!(ListArgs);
+        let root = serde_json::to_value(&schema).unwrap();
+        let props = root["properties"].as_object().unwrap();
+
+        for field in ["scope", "limit", "cursor", "fields"] {
+            assert!(
+                props.contains_key(field),
+                "list schema must expose '{field}'"
+            );
+        }
+
+        let limit_schema = serde_json::to_string(&props["limit"]).unwrap();
+        assert!(limit_schema.contains("\"minimum\":1"), "{limit_schema}");
+        assert!(limit_schema.contains("\"maximum\":100"), "{limit_schema}");
+
+        let serialized = serde_json::to_string(&props["fields"]).unwrap();
+        assert!(
+            !serialized.contains("$ref"),
+            "fields schema must be inline for MCP clients: {serialized}"
+        );
+        for field in ["id", "name", "scope", "tags", "created_at", "updated_at"] {
+            assert!(
+                serialized.contains(&format!("\"{field}\"")),
+                "fields schema must advertise '{field}': {serialized}"
+            );
+        }
     }
 }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -90,7 +90,6 @@ pub struct MoveArgs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[schemars(inline)]
-#[non_exhaustive]
 pub enum ListField {
     /// Stable memory UUID.
     Id,
@@ -118,7 +117,12 @@ impl ListField {
     ];
 }
 
-/// Arguments for the `list` tool — browse stored memories.
+/// Legacy public Rust DTO for the original, scope-only `list` request.
+///
+/// The MCP handler now uses a crate-private wire type so its additive JSON
+/// fields do not silently break downstream code that constructs this public
+/// struct. This type remains public for semver compatibility even though the
+/// handler itself is not part of the public Rust API.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListArgs {
     /// Scope: 'global', a bare namespace path like 'my-project' or 'org/team', 'all', or omit for global-only. Use 'all' to list everything.

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -8,6 +8,8 @@ use crate::{
     repo::MemoryRepo,
 };
 
+pub(crate) const LIST_MAX_LIMIT: usize = 100;
+
 // ---------------------------------------------------------------------------
 // Tool argument structs
 // ---------------------------------------------------------------------------
@@ -122,9 +124,20 @@ pub struct ListArgs {
     /// Scope: 'global', a bare namespace path like 'my-project' or 'org/team', 'all', or omit for global-only. Use 'all' to list everything.
     #[serde(default)]
     pub scope: Option<String>,
+}
+
+/// Wire arguments for the paginated `list` MCP tool.
+///
+/// Kept crate-private so extending the tool's JSON request does not break
+/// downstream Rust callers that construct the legacy public [`ListArgs`].
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub(crate) struct ListToolArgs {
+    /// Scope: 'global', a bare namespace path like 'my-project' or 'org/team', 'all', or omit for global-only. Use 'all' to list everything.
+    #[serde(default)]
+    pub scope: Option<String>,
     /// Maximum number of summaries to return. Defaults to 50; maximum 100.
     #[serde(default)]
-    #[schemars(range(min = 1, max = 100))]
+    #[schemars(range(min = 1, max = LIST_MAX_LIMIT))]
     pub limit: Option<usize>,
     /// Opaque cursor returned by a previous list page. Cursors are bound to the queried scope.
     #[serde(default)]
@@ -414,6 +427,34 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn list_tool_args_deserializes_minimal() {
+        let args: ListToolArgs = serde_json::from_str(r#"{"scope":"all"}"#).unwrap();
+        assert_eq!(args.scope.as_deref(), Some("all"));
+        assert_eq!(args.limit, None);
+        assert_eq!(args.cursor, None);
+        assert_eq!(args.fields, None);
+    }
+
+    #[test]
+    fn list_tool_args_deserializes_full() {
+        let args: ListToolArgs = serde_json::from_str(
+            r#"{"scope":"all","limit":25,"cursor":"lc1_abc","fields":["name","scope"]}"#,
+        )
+        .unwrap();
+        assert_eq!(args.scope.as_deref(), Some("all"));
+        assert_eq!(args.limit, Some(25));
+        assert_eq!(args.cursor.as_deref(), Some("lc1_abc"));
+        assert_eq!(args.fields, Some(vec![ListField::Name, ListField::Scope]));
+    }
+
+    #[test]
+    fn list_tool_args_rejects_unknown_field_variant() {
+        let error = serde_json::from_str::<ListToolArgs>(r#"{"fields":["content"]}"#)
+            .expect_err("unknown projection field must fail");
+        assert!(error.to_string().contains("unknown variant"));
+    }
+
+    #[test]
     fn batch_mark_applied_deserializes_minimal() {
         let json = r#"{
             "verdicts": [
@@ -483,7 +524,7 @@ mod tests {
 
     #[test]
     fn list_schema_exposes_pagination_and_projection_inputs() {
-        let schema = schemars::schema_for!(ListArgs);
+        let schema = schemars::schema_for!(ListToolArgs);
         let root = serde_json::to_value(&schema).unwrap();
         let props = root["properties"].as_object().unwrap();
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,6 +15,8 @@ pub use args::{
     RememberArgs, SyncArgs, Verdict, VerdictEntry,
 };
 
+pub(crate) use args::{ListToolArgs, LIST_MAX_LIMIT};
+
 pub use memory::{parse_qualified_name, Memory, MemoryMetadata, MemoryName, MemoryRef};
 
 pub use scope::{validate_branch_name, Scope, ScopeFilter, ScopePath};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod validated;
 // re-exported as `pub(crate)`.
 
 pub use args::{
-    AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs, ForgetArgs, ListArgs,
+    AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs, ForgetArgs, ListArgs, ListField,
     MarkAppliedArgs, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
     RememberArgs, SyncArgs, Verdict, VerdictEntry,
 };


### PR DESCRIPTION
## What changed

- bound `list` to 50 summaries by default (100 maximum)
- added deterministic `(scope, name)` keyset pagination with opaque, scope-bound cursors
- reject stale cursors when matching list data changes during a walk
- added exact summary-field projection while preserving the legacy six-field shape when omitted
- added `returned`, `limit`, `has_more`, and `next_cursor` response metadata while retaining total `count`
- capped successful serialized pages at 24 KiB
- documented the compatibility impact and cursor-walk requirement

## Why

`list(scope="shared")` grew to 217 summaries / 60,268 serialized bytes and exceeded the tool-result token cap. The old tool had no limit, projection, stable ordering, or continuation mechanism.

## Compatibility

Existing callers still receive the same six fields when `fields` is omitted, but an omitted `limit` now returns at most 50 summaries. Callers must follow `next_cursor` while `has_more` is true.

## Verification

- focused list tests: 10 passed
- full nextest: 278 passed, 2 skipped
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --check`
- `cargo check --features k8s`
- two independent review passes: no blocking or Medium findings remain

Residual follow-up: router-level MCP wire snapshots (#274) and broader cursor properties (#277) remain separate Low-severity coverage work.

Closes #281
