### PR TITLE
feat: hybrid recall — BM25 lexical search fused with semantic ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,12 +220,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -345,6 +379,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
@@ -548,6 +588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +784,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -868,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1033,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -1035,6 +1114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1416,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1993,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,10 +2107,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2044,6 +2169,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2097,6 +2231,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tantivy",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers 0.23.1",
@@ -2165,6 +2300,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nom"
@@ -2241,6 +2382,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "onig"
@@ -2411,6 +2558,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3092,6 +3257,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3341,7 +3516,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.1",
  "serde",
 ]
 
@@ -3490,6 +3665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,6 +3810,154 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "datasketches",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "typetag",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
+dependencies = [
+ "fnv",
+ "nom",
+ "ordered-float 5.3.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
+dependencies = [
+ "futures-util",
+ "itertools",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4076,10 +4408,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -4218,6 +4580,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,6 +4611,7 @@ checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4529,6 +4898,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4914,3 +5292,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 git2 = { version = "0.21", features = ["https", "vendored-openssl"] }
 usearch = "2"
+# BM25 keyword search for hybrid retrieval (pure Rust, Lucene-inspired).
+tantivy = "0.26"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # Maintained fork of deprecated serde_yaml (dtolnay archived the original).

--- a/docs/adr/0038-bm25-hybrid-retrieval.md
+++ b/docs/adr/0038-bm25-hybrid-retrieval.md
@@ -35,7 +35,11 @@ Key choices:
   (remember, edit, forget, move, incremental reindex) mirror the write
   into the lexical index. Lexical writes are best-effort: a failure
   logs a warning and degrades that memory to semantic-only until the
-  next startup rebuild.
+  next startup rebuild. Mutations are batched (`LexicalOp` lists): each
+  logical operation performs exactly one Tantivy commit and one reader
+  reload — incremental reindex applies the whole changed set in one
+  batch — and the commit runs on the Tokio blocking pool
+  (`apply_async`), never on an async worker thread.
 - **Exact-phrase precedence.** BM25 length normalisation lets a short
   document containing one query term outrank a long document containing
   the exact phrase — the very failure hybrid retrieval exists to fix.
@@ -43,8 +47,9 @@ Key choices:
   strictly above term-only matches. Fusion consumes ranks, not scores.
 - **RRF over score interpolation.** Cosine distances and BM25 scores
   live on incomparable scales; rank fusion needs no normalisation, no
-  tuned weights, and is fully deterministic (ties break on qualified
-  name).
+  tuned weights, and is fully deterministic (score ties break
+  lexical-first — a hit with a lexical contribution outranks a tied hit
+  without one — then on qualified name).
 - **Error asymmetry.** A semantic failure is fatal (preserves recall's
   pre-hybrid error surface); a lexical failure degrades to
   semantic-only with a warning. `LexicalIndex::new()` is infallible —
@@ -57,12 +62,17 @@ Key choices:
 
 ## Consequences
 - Literal phrases buried in long memories are retrievable: the top
-  lexical hit mathematically outranks every semantic-only candidate in
-  the fused list (1/(k+1) beats 1/(k+r) for r > 1).
+  lexical hit outranks every semantic-only candidate in the fused list
+  — 1/(k+1) beats 1/(k+r) for r > 1, and the remaining rank-0 tie
+  (lexical rank 0 vs semantic rank 0, both 1/(k+1)) resolves in the
+  lexical hit's favour via the deterministic lexical-first tie-break.
+  Only candidates found by *both* strategies can rank above it.
 - Recall results gain a `match_type` field (`semantic` / `lexical` /
-  `both`); `distance` is `null` for lexical-only hits. Recall-log
-  entries for lexical-only hits use a `-1.0` distance sentinel, which
-  distance-bucketed stats already exclude (`distance >= 0.0`).
+  `both`). `distance` stays a required numeric field for wire
+  compatibility with pre-hybrid clients: lexical-only hits, which have
+  no embedding distance, carry the `-1.0` sentinel (impossible as a
+  real cosine distance). Recall-log entries use the same sentinel,
+  which distance-bucketed stats already exclude (`distance >= 0.0`).
 - Startup reads all memories once even when the vector index is fresh.
 - The binary grows by the Tantivy dependency tree (pure Rust, no new
   C/C++ FFI beyond the existing zstd already vendored elsewhere).

--- a/docs/adr/0038-bm25-hybrid-retrieval.md
+++ b/docs/adr/0038-bm25-hybrid-retrieval.md
@@ -1,0 +1,70 @@
+# ADR-0038: Hybrid retrieval — BM25 lexical search fused with semantic recall
+
+## Status
+Accepted
+
+## Context
+Whole-memory embeddings dilute short exact phrases inside long
+multi-topic memories: a one-line fact in a ~3 KB memory contributes
+almost nothing to the document vector, so literal-phrase queries rank
+it below short memories that are topically adjacent but wrong. A
+concrete field failure is documented on issue #55: the query "happy
+birthday" failed to surface the memory containing that verbatim
+phrase, while every top-10 result was noise.
+
+Alternatives considered:
+- **Substring grep fallback** when semantic top-k distances are poor —
+  cheap, but no ranking, no tokenisation, and a threshold to tune.
+- **Chunk-level embeddings** (#140) — helps long memories generally
+  but does not guarantee literal-phrase retrieval; complementary, not
+  a substitute.
+- **BM25 lexical search fused with semantic ranking** — standard
+  hybrid retrieval; the two strategies fail independently.
+
+## Decision
+Add a BM25 keyword index (Tantivy, pure Rust — Lucene-inspired, no FFI)
+alongside the vector index, and merge the two ranked lists with
+reciprocal rank fusion (RRF, k = 60).
+
+Key choices:
+- **In-RAM index, rebuilt on startup.** Indexing text is cheap (unlike
+  embedding it), so the Tantivy index is never persisted. This removes
+  the entire index-versioning/migration surface; startup cost is one
+  `list_memories` pass.
+- **Same write path.** The handlers that update the vector index
+  (remember, edit, forget, move, incremental reindex) mirror the write
+  into the lexical index. Lexical writes are best-effort: a failure
+  logs a warning and degrades that memory to semantic-only until the
+  next startup rebuild.
+- **Exact-phrase precedence.** BM25 length normalisation lets a short
+  document containing one query term outrank a long document containing
+  the exact phrase — the very failure hybrid retrieval exists to fix.
+  Lexical search therefore runs two passes: exact-phrase matches rank
+  strictly above term-only matches. Fusion consumes ranks, not scores.
+- **RRF over score interpolation.** Cosine distances and BM25 scores
+  live on incomparable scales; rank fusion needs no normalisation, no
+  tuned weights, and is fully deterministic (ties break on qualified
+  name).
+- **Error asymmetry.** A semantic failure is fatal (preserves recall's
+  pre-hybrid error surface); a lexical failure degrades to
+  semantic-only with a warning. `LexicalIndex::new()` is infallible —
+  an initialisation failure yields a disabled instance whose operations
+  all error, which callers already treat as degradation. This keeps
+  `AppState::new` and startup unchanged.
+- **Scope filtering** reuses `ScopeFilter::matches` on scopes parsed
+  from the canonical index key, post-search, bounded at 10 000
+  candidates — identical semantics to recall's existing filtering.
+
+## Consequences
+- Literal phrases buried in long memories are retrievable: the top
+  lexical hit mathematically outranks every semantic-only candidate in
+  the fused list (1/(k+1) beats 1/(k+r) for r > 1).
+- Recall results gain a `match_type` field (`semantic` / `lexical` /
+  `both`); `distance` is `null` for lexical-only hits. Recall-log
+  entries for lexical-only hits use a `-1.0` distance sentinel, which
+  distance-bucketed stats already exclude (`distance >= 0.0`).
+- Startup reads all memories once even when the vector index is fresh.
+- The binary grows by the Tantivy dependency tree (pure Rust, no new
+  C/C++ FFI beyond the existing zstd already vendored elsewhere).
+- Memory cost: one in-RAM copy of all memory text plus posting lists —
+  negligible next to the embedding model.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod index;
 pub mod recall_log;
 /// Git-backed memory repository — read, write, sync, and diff operations.
 pub mod repo;
+/// Hybrid retrieval — semantic + BM25 lexical search merged via rank fusion.
+pub mod search;
 /// MCP server implementation — tool handlers for the memory protocol.
 pub mod server;
 /// Domain types: memories, scopes, metadata, validation, and application state.

--- a/src/main.rs
+++ b/src/main.rs
@@ -616,6 +616,21 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         recall_log,
     ));
 
+    // Populate the lexical (BM25) index. It lives in RAM only — indexing
+    // text is cheap, unlike embedding it — so it is rebuilt from the repo on
+    // every startup and never persisted or migrated. Failure degrades recall
+    // to semantic-only; it never blocks startup.
+    match memory_mcp::search::rebuild_lexical_from_repo(&state.repo, &state.lexical)
+        .instrument(tracing::info_span!("startup.lexical_rebuild"))
+        .await
+    {
+        Ok(count) => info!(count, "lexical index built"),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "lexical index rebuild failed — keyword search degraded until next restart"
+        ),
+    }
+
     // Keep a reference for post-shutdown index persistence.
     let state_for_shutdown = Arc::clone(&state);
 

--- a/src/recall_log.rs
+++ b/src/recall_log.rs
@@ -323,6 +323,10 @@ pub struct RecallResult {
     /// Zero-based rank in the result set (lower is more relevant).
     pub rank: usize,
     /// Cosine distance from the query vector (lower is more similar).
+    ///
+    /// Hits surfaced only by the lexical (BM25) strategy have no embedding
+    /// distance and use the sentinel `-1.0`, which keeps them out of
+    /// distance-bucketed stats (those filter on `distance >= 0.0`).
     pub distance: f64,
 }
 

--- a/src/search/bm25.rs
+++ b/src/search/bm25.rs
@@ -1,0 +1,639 @@
+//! BM25 keyword search over memory names and content, backed by Tantivy.
+//!
+//! The lexical index is held entirely in RAM and rebuilt from the git repo
+//! on startup (indexing text is cheap, unlike embedding it), so there is no
+//! on-disk index to version or migrate. Writes go through the same handlers
+//! that update the vector index, keeping the two views consistent.
+
+use std::sync::Mutex;
+
+use tantivy::{
+    collector::TopDocs,
+    query::{BooleanQuery, Occur, PhraseQuery, Query, QueryParser},
+    schema::{Field, Schema, Value, STORED, STRING, TEXT},
+    Index, IndexReader, IndexWriter, ReloadPolicy, Searcher, TantivyDocument, Term,
+};
+use tracing::{debug, warn};
+
+use crate::{
+    error::MemoryError,
+    types::{parse_qualified_name, ScopeFilter},
+};
+
+/// Heap budget for the single Tantivy writer thread. Tantivy requires at
+/// least 15 MB; the corpus (markdown memories) is far smaller than this.
+const WRITER_HEAP_BYTES: usize = 32 * 1024 * 1024;
+
+/// Upper bound on candidates collected per query before scope filtering.
+/// Scope filtering happens post-search, so a filtered query must be able to
+/// look past out-of-scope matches; this caps the worst case.
+const MAX_CANDIDATES: u64 = 10_000;
+
+/// One memory's searchable text, as fed to [`LexicalIndex::rebuild`].
+#[derive(Debug, Clone)]
+pub struct LexicalDoc {
+    /// Canonical index key (`v1:scope=<scope>;name=<name>`).
+    pub qualified_name: String,
+    /// Bare memory name (searchable).
+    pub name: String,
+    /// Full memory content (searchable).
+    pub content: String,
+}
+
+/// In-RAM BM25 index over memory names and content.
+///
+/// Thread-safe: reads go through a Tantivy [`IndexReader`], writes are
+/// serialised by an internal mutex. Every write commits and reloads the
+/// reader so results are immediately visible — acceptable because writes
+/// happen at memory-mutation frequency, not query frequency.
+///
+/// Construction is infallible: if the underlying Tantivy index cannot be
+/// initialised (practically impossible for a RAM directory), the instance
+/// is *disabled* — every operation returns an error, which callers already
+/// treat as best-effort degradation to semantic-only retrieval.
+pub struct LexicalIndex {
+    inner: Option<Inner>,
+}
+
+struct Inner {
+    index: Index,
+    writer: Mutex<IndexWriter>,
+    reader: IndexReader,
+    field_qualified_name: Field,
+    field_name: Field,
+    field_content: Field,
+}
+
+impl Inner {
+    fn build() -> Result<Self, MemoryError> {
+        let mut schema_builder = Schema::builder();
+        // Raw (untokenised) unique key — used for deletes and result lookup.
+        let field_qualified_name = schema_builder.add_text_field("qualified_name", STRING | STORED);
+        // Tokenised searchable fields (default tokenizer: simple + lowercase).
+        let field_name = schema_builder.add_text_field("name", TEXT);
+        let field_content = schema_builder.add_text_field("content", TEXT);
+        let schema = schema_builder.build();
+
+        let index = Index::create_in_ram(schema);
+        let writer = index
+            .writer_with_num_threads(1, WRITER_HEAP_BYTES)
+            .map_err(lexical_error)?;
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()
+            .map_err(lexical_error)?;
+
+        Ok(Self {
+            index,
+            writer: Mutex::new(writer),
+            reader,
+            field_qualified_name,
+            field_name,
+            field_content,
+        })
+    }
+
+    fn lock_writer(&self) -> Result<std::sync::MutexGuard<'_, IndexWriter>, MemoryError> {
+        self.writer
+            .lock()
+            .map_err(|_| MemoryError::Index("lexical index writer lock poisoned".to_string()))
+    }
+}
+
+impl Default for LexicalIndex {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LexicalIndex {
+    /// Create an empty in-RAM lexical index.
+    ///
+    /// Infallible by design: an initialisation failure produces a disabled
+    /// instance whose operations all error, degrading recall to
+    /// semantic-only rather than preventing startup.
+    pub fn new() -> Self {
+        let inner = match Inner::build() {
+            Ok(inner) => Some(inner),
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    "lexical index initialisation failed — keyword search disabled"
+                );
+                None
+            }
+        };
+        Self { inner }
+    }
+
+    #[cfg(test)]
+    fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    fn inner(&self) -> Result<&Inner, MemoryError> {
+        self.inner.as_ref().ok_or_else(|| {
+            MemoryError::Index("lexical index unavailable (initialisation failed)".to_string())
+        })
+    }
+
+    /// Insert or replace the document for `qualified_name`.
+    pub fn upsert(
+        &self,
+        qualified_name: &str,
+        name: &str,
+        content: &str,
+    ) -> Result<(), MemoryError> {
+        let span = tracing::debug_span!("lexical.upsert", qualified_name = %qualified_name);
+        let _guard = span.enter();
+
+        let inner = self.inner()?;
+        let mut writer = inner.lock_writer()?;
+        writer.delete_term(Term::from_field_text(
+            inner.field_qualified_name,
+            qualified_name,
+        ));
+        let mut doc = TantivyDocument::default();
+        doc.add_text(inner.field_qualified_name, qualified_name);
+        doc.add_text(inner.field_name, name);
+        doc.add_text(inner.field_content, content);
+        writer.add_document(doc).map_err(lexical_error)?;
+        writer.commit().map_err(lexical_error)?;
+        drop(writer);
+        inner.reader.reload().map_err(lexical_error)
+    }
+
+    /// Remove the document for `qualified_name`. No-op if absent.
+    pub fn remove(&self, qualified_name: &str) -> Result<(), MemoryError> {
+        let span = tracing::debug_span!("lexical.remove", qualified_name = %qualified_name);
+        let _guard = span.enter();
+
+        let inner = self.inner()?;
+        let mut writer = inner.lock_writer()?;
+        writer.delete_term(Term::from_field_text(
+            inner.field_qualified_name,
+            qualified_name,
+        ));
+        writer.commit().map_err(lexical_error)?;
+        drop(writer);
+        inner.reader.reload().map_err(lexical_error)
+    }
+
+    /// Replace the entire index contents with `docs` in a single commit.
+    pub fn rebuild<I>(&self, docs: I) -> Result<usize, MemoryError>
+    where
+        I: IntoIterator<Item = LexicalDoc>,
+    {
+        let span = tracing::debug_span!("lexical.rebuild", count = tracing::field::Empty);
+        let _guard = span.enter();
+
+        let inner = self.inner()?;
+        let mut writer = inner.lock_writer()?;
+        writer.delete_all_documents().map_err(lexical_error)?;
+        let mut count = 0usize;
+        for item in docs {
+            let mut doc = TantivyDocument::default();
+            doc.add_text(inner.field_qualified_name, &item.qualified_name);
+            doc.add_text(inner.field_name, &item.name);
+            doc.add_text(inner.field_content, &item.content);
+            writer.add_document(doc).map_err(lexical_error)?;
+            count += 1;
+        }
+        writer.commit().map_err(lexical_error)?;
+        drop(writer);
+        inner.reader.reload().map_err(lexical_error)?;
+        tracing::Span::current().record("count", count);
+        debug!(count, "lexical index rebuilt");
+        Ok(count)
+    }
+
+    /// Run a BM25 keyword query, returning up to `limit`
+    /// `(qualified_name, score)` pairs.
+    ///
+    /// Ranking is two-pass: documents matching the query as an *exact
+    /// phrase* rank strictly above term-only matches. Plain BM25 term
+    /// scoring lets a short document containing one query term outrank a
+    /// long document containing the exact phrase (length normalisation
+    /// dilutes the long document's term scores) — the failure mode behind
+    /// #55. Within each pass, results are ordered by descending BM25 score
+    /// with ties broken by ascending name, so the ranking is fully
+    /// deterministic. Returned scores are only comparable within a pass;
+    /// downstream fusion consumes ranks, not scores.
+    ///
+    /// Scope filtering matches recall semantics exactly: candidate scopes
+    /// are parsed from the canonical key and checked with
+    /// [`ScopeFilter::matches`].
+    pub fn search(
+        &self,
+        filter: &ScopeFilter,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>, MemoryError> {
+        let span = tracing::debug_span!("lexical.search", ?filter, limit);
+        let _guard = span.enter();
+
+        let inner = self.inner()?;
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let searcher = inner.reader.searcher();
+        if searcher.num_docs() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut results: Vec<(String, f32)> = Vec::new();
+
+        // Pass 1: exact-phrase matches (only meaningful for multi-term queries).
+        if let Some(phrase_query) = inner.phrase_query(query) {
+            let phrase_hits = inner.execute(&searcher, &phrase_query, filter, limit)?;
+            results.extend(phrase_hits);
+        }
+
+        // Pass 2: regular term matching, skipping documents pass 1 found.
+        let parser =
+            QueryParser::for_index(&inner.index, vec![inner.field_name, inner.field_content]);
+        // Lenient parsing: user queries are natural language, not query
+        // syntax — unbalanced quotes/parens degrade instead of erroring.
+        let (parsed, parse_errors) = parser.parse_query_lenient(query);
+        if !parse_errors.is_empty() {
+            debug!(errors = ?parse_errors, "lexical query parsed leniently");
+        }
+        let term_hits = inner.execute(&searcher, &parsed, filter, limit)?;
+        for hit in term_hits {
+            if !results.iter().any(|(name, _)| name == &hit.0) {
+                results.push(hit);
+            }
+        }
+
+        results.truncate(limit);
+        Ok(results)
+    }
+}
+
+impl Inner {
+    /// Build a phrase query matching the whole `query` as an exact phrase
+    /// in either the name or content field. Returns `None` when the query
+    /// tokenises to fewer than two terms (a phrase needs at least two).
+    fn phrase_query(&self, query: &str) -> Option<Box<dyn Query>> {
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+        for field in [self.field_name, self.field_content] {
+            let Ok(mut analyzer) = self.index.tokenizer_for_field(field) else {
+                // Unreachable for TEXT fields with the default tokenizer;
+                // skip this field's clause rather than the whole phrase pass.
+                continue;
+            };
+            let mut terms: Vec<Term> = Vec::new();
+            let mut stream = analyzer.token_stream(query);
+            while let Some(token) = stream.next() {
+                terms.push(Term::from_field_text(field, &token.text));
+            }
+            if terms.len() >= 2 {
+                clauses.push((Occur::Should, Box::new(PhraseQuery::new(terms))));
+            }
+        }
+        if clauses.is_empty() {
+            None
+        } else {
+            Some(Box::new(BooleanQuery::new(clauses)))
+        }
+    }
+
+    /// Execute `query`, post-filter by scope, and return up to `limit`
+    /// `(qualified_name, score)` pairs ordered by descending score with
+    /// ties broken by ascending name.
+    fn execute(
+        &self,
+        searcher: &Searcher,
+        query: &dyn Query,
+        filter: &ScopeFilter,
+        limit: usize,
+    ) -> Result<Vec<(String, f32)>, MemoryError> {
+        // Scope filtering happens after search, so collect enough candidates
+        // to look past out-of-scope matches (bounded by MAX_CANDIDATES).
+        let fetch = usize::try_from(searcher.num_docs().min(MAX_CANDIDATES))
+            .unwrap_or(usize::MAX)
+            .max(limit);
+        let top_docs = searcher
+            .search(query, &TopDocs::with_limit(fetch).order_by_score())
+            .map_err(lexical_error)?;
+
+        let mut results: Vec<(String, f32)> = Vec::new();
+        for (score, address) in top_docs {
+            let doc: TantivyDocument = searcher.doc(address).map_err(lexical_error)?;
+            let Some(qualified_name) = doc
+                .get_first(self.field_qualified_name)
+                .and_then(|v| v.as_str())
+            else {
+                warn!("lexical index document is missing its qualified_name; skipping");
+                continue;
+            };
+            let mref = match parse_qualified_name(qualified_name) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(
+                        qualified_name = %qualified_name,
+                        error = %e,
+                        "could not parse qualified name from lexical index; skipping"
+                    );
+                    continue;
+                }
+            };
+            if filter.matches(&mref.scope) {
+                results.push((qualified_name.to_string(), score));
+            }
+        }
+
+        results.sort_by(|a, b| b.1.total_cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        results.truncate(limit);
+        Ok(results)
+    }
+}
+
+fn lexical_error(e: tantivy::TantivyError) -> MemoryError {
+    MemoryError::Index(format!("lexical index: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{MemoryName, MemoryRef, Scope, ScopePath};
+
+    fn key(scope: &Scope, name: &str) -> String {
+        MemoryRef::new(scope.clone(), MemoryName::new(name.to_string()).unwrap()).qualified_path()
+    }
+
+    fn scoped(path: &str) -> Scope {
+        Scope::Path(ScopePath::new(path).unwrap())
+    }
+
+    fn subtree(path: &str) -> ScopeFilter {
+        ScopeFilter::Subtree(ScopePath::new(path).unwrap())
+    }
+
+    fn index_with(docs: &[(&Scope, &str, &str)]) -> LexicalIndex {
+        let index = LexicalIndex::new();
+        for (scope, name, content) in docs {
+            index
+                .upsert(&key(scope, name), name, content)
+                .expect("upsert");
+        }
+        index
+    }
+
+    #[test]
+    fn keyword_match_is_found_and_scored() {
+        let index = index_with(&[
+            (
+                &Scope::Root,
+                "greeting",
+                "happy birthday is a morning ritual",
+            ),
+            (&Scope::Root, "other", "kubernetes deployment configuration"),
+        ]);
+
+        let results = index
+            .search(&ScopeFilter::All, "happy birthday", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, key(&Scope::Root, "greeting"));
+        assert!(results[0].1 > 0.0, "BM25 score should be positive");
+    }
+
+    #[test]
+    fn memory_name_is_searchable() {
+        let index = index_with(&[(&Scope::Root, "birthday-protocol", "unrelated body text")]);
+
+        let results = index
+            .search(&ScopeFilter::All, "birthday", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn upsert_replaces_previous_document() {
+        let scope = Scope::Root;
+        let index = index_with(&[(&scope, "note", "contains magicword here")]);
+
+        index
+            .upsert(&key(&scope, "note"), "note", "completely different now")
+            .expect("upsert");
+
+        let old = index
+            .search(&ScopeFilter::All, "magicword", 10)
+            .expect("search");
+        assert!(old.is_empty(), "old content should no longer match");
+
+        let new = index
+            .search(&ScopeFilter::All, "different", 10)
+            .expect("search");
+        assert_eq!(new.len(), 1, "new content should match exactly once");
+    }
+
+    #[test]
+    fn remove_makes_document_unreachable() {
+        let scope = Scope::Root;
+        let index = index_with(&[(&scope, "doomed", "contains magicword here")]);
+
+        index.remove(&key(&scope, "doomed")).expect("remove");
+
+        let results = index
+            .search(&ScopeFilter::All, "magicword", 10)
+            .expect("search");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn scope_filter_root_only_excludes_scoped_memories() {
+        let proj = scoped("proj");
+        let index = index_with(&[
+            (&Scope::Root, "root-note", "magicword in global"),
+            (&proj, "proj-note", "magicword in project"),
+        ]);
+
+        let results = index
+            .search(&ScopeFilter::RootOnly, "magicword", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, key(&Scope::Root, "root-note"));
+    }
+
+    #[test]
+    fn scope_filter_subtree_includes_root_and_descendants_only() {
+        let team = scoped("org/team");
+        let nested = scoped("org/team/project");
+        let other = scoped("org/other");
+        let index = index_with(&[
+            (&Scope::Root, "root-note", "magicword in global"),
+            (&team, "team-note", "magicword in team"),
+            (&nested, "nested-note", "magicword in nested"),
+            (&other, "other-note", "magicword in other"),
+        ]);
+
+        let results = index
+            .search(&subtree("org/team"), "magicword", 10)
+            .expect("search");
+
+        let names: Vec<&str> = results.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(results.len(), 3);
+        assert!(names.contains(&key(&Scope::Root, "root-note").as_str()));
+        assert!(names.contains(&key(&team, "team-note").as_str()));
+        assert!(names.contains(&key(&nested, "nested-note").as_str()));
+    }
+
+    #[test]
+    fn scope_filter_all_includes_everything() {
+        let proj = scoped("proj");
+        let index = index_with(&[
+            (&Scope::Root, "root-note", "magicword in global"),
+            (&proj, "proj-note", "magicword in project"),
+        ]);
+
+        let results = index
+            .search(&ScopeFilter::All, "magicword", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        let index = index_with(&[(&Scope::Root, "note", "Happy Birthday To You")]);
+
+        let results = index
+            .search(&ScopeFilter::All, "happy birthday", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn query_syntax_errors_degrade_instead_of_failing() {
+        let index = index_with(&[(&Scope::Root, "note", "unbalanced quote content")]);
+
+        // Unbalanced quotes and parens must not produce an error.
+        let result = index.search(&ScopeFilter::All, "\"unbalanced (quote", 10);
+        assert!(result.is_ok(), "lenient parsing should never error");
+    }
+
+    #[test]
+    fn empty_index_and_zero_limit_return_empty() {
+        let index = LexicalIndex::new();
+        assert!(index
+            .search(&ScopeFilter::All, "anything", 10)
+            .expect("search")
+            .is_empty());
+
+        index
+            .upsert(&key(&Scope::Root, "note"), "note", "content")
+            .expect("upsert");
+        assert!(index
+            .search(&ScopeFilter::All, "content", 0)
+            .expect("search")
+            .is_empty());
+    }
+
+    #[test]
+    fn rebuild_replaces_all_contents() {
+        let scope = Scope::Root;
+        let index = index_with(&[(&scope, "stale", "oldword content")]);
+
+        let count = index
+            .rebuild(vec![
+                LexicalDoc {
+                    qualified_name: key(&scope, "fresh-a"),
+                    name: "fresh-a".to_string(),
+                    content: "newword alpha".to_string(),
+                },
+                LexicalDoc {
+                    qualified_name: key(&scope, "fresh-b"),
+                    name: "fresh-b".to_string(),
+                    content: "newword beta".to_string(),
+                },
+            ])
+            .expect("rebuild");
+        assert_eq!(count, 2);
+
+        assert!(index
+            .search(&ScopeFilter::All, "oldword", 10)
+            .expect("search")
+            .is_empty());
+        assert_eq!(
+            index
+                .search(&ScopeFilter::All, "newword", 10)
+                .expect("search")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn exact_phrase_in_long_document_outranks_short_term_only_matches() {
+        let scope = Scope::Root;
+        // Long document: the exact phrase is buried in unrelated prose, so
+        // BM25 length normalisation dilutes its per-term scores.
+        let mut long_content = String::new();
+        for i in 0..80 {
+            long_content.push_str(&format!(
+                "Filler sentence number {i} about infrastructure, deployments, and rust. "
+            ));
+        }
+        long_content.push_str("the magic phrase appears exactly once here. ");
+        for i in 0..80 {
+            long_content.push_str(&format!("More filler prose {i} about unrelated topics. "));
+        }
+
+        let index = index_with(&[
+            (&scope, "long-doc", long_content.as_str()),
+            (&scope, "decoy-a", "magic tricks for beginners"),
+            (&scope, "decoy-b", "phrase books for travellers"),
+            (
+                &scope,
+                "decoy-c",
+                "magic and phrase collections, magic themed",
+            ),
+        ]);
+
+        let results = index
+            .search(&ScopeFilter::All, "magic phrase", 10)
+            .expect("search");
+
+        assert_eq!(
+            results[0].0,
+            key(&scope, "long-doc"),
+            "exact-phrase match must rank above term-only matches: {results:?}"
+        );
+    }
+
+    #[test]
+    fn disabled_instance_errors_on_every_operation() {
+        let index = LexicalIndex::disabled();
+
+        assert!(index.upsert("key", "name", "content").is_err());
+        assert!(index.remove("key").is_err());
+        assert!(index.rebuild(Vec::new()).is_err());
+        assert!(index.search(&ScopeFilter::All, "query", 10).is_err());
+    }
+
+    #[test]
+    fn results_are_deterministically_ordered() {
+        let scope = Scope::Root;
+        // Two documents with identical content produce identical BM25
+        // scores — ordering must fall back to the qualified name.
+        let index = index_with(&[
+            (&scope, "zeta", "identical magicword content"),
+            (&scope, "alpha", "identical magicword content"),
+        ]);
+
+        let results = index
+            .search(&ScopeFilter::All, "magicword", 10)
+            .expect("search");
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, key(&scope, "alpha"));
+        assert_eq!(results[1].0, key(&scope, "zeta"));
+    }
+}

--- a/src/search/bm25.rs
+++ b/src/search/bm25.rs
@@ -4,8 +4,14 @@
 //! on startup (indexing text is cheap, unlike embedding it), so there is no
 //! on-disk index to version or migrate. Writes go through the same handlers
 //! that update the vector index, keeping the two views consistent.
+//!
+//! Mutations are batched: [`LexicalIndex::apply`] takes a list of
+//! [`LexicalOp`]s and performs exactly one Tantivy commit and one reader
+//! reload for the whole batch, and [`LexicalIndex::apply_async`] runs that
+//! blocking work on the Tokio blocking pool so async workers are never
+//! stalled behind a commit.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use tantivy::{
     collector::TopDocs,
@@ -17,6 +23,7 @@ use tracing::{debug, warn};
 
 use crate::{
     error::MemoryError,
+    repo::traced_spawn_blocking,
     types::{parse_qualified_name, ScopeFilter},
 };
 
@@ -40,12 +47,27 @@ pub struct LexicalDoc {
     pub content: String,
 }
 
+/// A single mutation applied by [`LexicalIndex::apply`].
+///
+/// Ops within one batch are applied in order (Tantivy serialises them by
+/// opstamp), so a `Remove` followed by an `Upsert` of the same key yields
+/// a fresh document, not a ghost.
+#[derive(Debug, Clone)]
+pub enum LexicalOp {
+    /// Insert or replace the document for the contained key.
+    Upsert(LexicalDoc),
+    /// Delete the document with this qualified name. No-op if absent.
+    Remove(String),
+}
+
 /// In-RAM BM25 index over memory names and content.
 ///
 /// Thread-safe: reads go through a Tantivy [`IndexReader`], writes are
-/// serialised by an internal mutex. Every write commits and reloads the
-/// reader so results are immediately visible — acceptable because writes
-/// happen at memory-mutation frequency, not query frequency.
+/// serialised by an internal mutex. Each *batch* of writes commits and
+/// reloads the reader once so results are immediately visible — acceptable
+/// because writes happen at memory-mutation frequency, not query frequency.
+/// Callers on the async runtime must use [`LexicalIndex::apply_async`],
+/// which moves the commit onto the blocking pool.
 ///
 /// Construction is infallible: if the underlying Tantivy index cannot be
 /// initialised (practically impossible for a RAM directory), the instance
@@ -138,46 +160,81 @@ impl LexicalIndex {
         })
     }
 
+    /// Apply a batch of mutations with exactly one commit and one reader
+    /// reload, regardless of batch size.
+    ///
+    /// Blocking: takes the writer mutex and performs a Tantivy commit.
+    /// Callers on the async runtime must use [`Self::apply_async`] instead.
+    pub fn apply(&self, ops: Vec<LexicalOp>) -> Result<(), MemoryError> {
+        let span = tracing::debug_span!("lexical.apply", ops = ops.len());
+        let _guard = span.enter();
+
+        if ops.is_empty() {
+            return Ok(());
+        }
+        let inner = self.inner()?;
+        let mut writer = inner.lock_writer()?;
+        for op in &ops {
+            match op {
+                LexicalOp::Upsert(item) => {
+                    writer.delete_term(Term::from_field_text(
+                        inner.field_qualified_name,
+                        &item.qualified_name,
+                    ));
+                    let mut doc = TantivyDocument::default();
+                    doc.add_text(inner.field_qualified_name, &item.qualified_name);
+                    doc.add_text(inner.field_name, &item.name);
+                    doc.add_text(inner.field_content, &item.content);
+                    writer.add_document(doc).map_err(lexical_error)?;
+                }
+                LexicalOp::Remove(qualified_name) => {
+                    writer.delete_term(Term::from_field_text(
+                        inner.field_qualified_name,
+                        qualified_name,
+                    ));
+                }
+            }
+        }
+        writer.commit().map_err(lexical_error)?;
+        drop(writer);
+        inner.reader.reload().map_err(lexical_error)
+    }
+
+    /// Run [`Self::apply`] on the Tokio blocking pool.
+    ///
+    /// This is the mutation entry point for async handlers: the writer
+    /// lock, the Tantivy commit, and the reader reload never run on an
+    /// async worker thread.
+    pub async fn apply_async(self: &Arc<Self>, ops: Vec<LexicalOp>) -> Result<(), MemoryError> {
+        let index = Arc::clone(self);
+        traced_spawn_blocking(move || index.apply(ops))
+            .await
+            .map_err(|e| MemoryError::Join(e.to_string()))?
+    }
+
     /// Insert or replace the document for `qualified_name`.
+    ///
+    /// Blocking convenience wrapper over [`Self::apply`] — one commit per
+    /// call. Async callers batch through [`Self::apply_async`].
     pub fn upsert(
         &self,
         qualified_name: &str,
         name: &str,
         content: &str,
     ) -> Result<(), MemoryError> {
-        let span = tracing::debug_span!("lexical.upsert", qualified_name = %qualified_name);
-        let _guard = span.enter();
-
-        let inner = self.inner()?;
-        let mut writer = inner.lock_writer()?;
-        writer.delete_term(Term::from_field_text(
-            inner.field_qualified_name,
-            qualified_name,
-        ));
-        let mut doc = TantivyDocument::default();
-        doc.add_text(inner.field_qualified_name, qualified_name);
-        doc.add_text(inner.field_name, name);
-        doc.add_text(inner.field_content, content);
-        writer.add_document(doc).map_err(lexical_error)?;
-        writer.commit().map_err(lexical_error)?;
-        drop(writer);
-        inner.reader.reload().map_err(lexical_error)
+        self.apply(vec![LexicalOp::Upsert(LexicalDoc {
+            qualified_name: qualified_name.to_string(),
+            name: name.to_string(),
+            content: content.to_string(),
+        })])
     }
 
     /// Remove the document for `qualified_name`. No-op if absent.
+    ///
+    /// Blocking convenience wrapper over [`Self::apply`] — one commit per
+    /// call. Async callers batch through [`Self::apply_async`].
     pub fn remove(&self, qualified_name: &str) -> Result<(), MemoryError> {
-        let span = tracing::debug_span!("lexical.remove", qualified_name = %qualified_name);
-        let _guard = span.enter();
-
-        let inner = self.inner()?;
-        let mut writer = inner.lock_writer()?;
-        writer.delete_term(Term::from_field_text(
-            inner.field_qualified_name,
-            qualified_name,
-        ));
-        writer.commit().map_err(lexical_error)?;
-        drop(writer);
-        inner.reader.reload().map_err(lexical_error)
+        self.apply(vec![LexicalOp::Remove(qualified_name.to_string())])
     }
 
     /// Replace the entire index contents with `docs` in a single commit.
@@ -609,11 +666,83 @@ mod tests {
     }
 
     #[test]
+    fn apply_batches_mixed_ops_in_order_with_one_commit() {
+        let scope = Scope::Root;
+        let index = index_with(&[(&scope, "doomed", "contains magicword here")]);
+
+        // Remove-then-upsert of the same key inside one batch must yield a
+        // fresh document, plus an unrelated upsert — all in a single apply.
+        index
+            .apply(vec![
+                LexicalOp::Remove(key(&scope, "doomed")),
+                LexicalOp::Upsert(LexicalDoc {
+                    qualified_name: key(&scope, "doomed"),
+                    name: "doomed".to_string(),
+                    content: "reborn freshword".to_string(),
+                }),
+                LexicalOp::Upsert(LexicalDoc {
+                    qualified_name: key(&scope, "extra"),
+                    name: "extra".to_string(),
+                    content: "another freshword".to_string(),
+                }),
+            ])
+            .expect("apply");
+
+        assert!(
+            index
+                .search(&ScopeFilter::All, "magicword", 10)
+                .expect("search")
+                .is_empty(),
+            "old content must be gone after the batch"
+        );
+        assert_eq!(
+            index
+                .search(&ScopeFilter::All, "freshword", 10)
+                .expect("search")
+                .len(),
+            2,
+            "both batch upserts must be visible"
+        );
+    }
+
+    #[test]
+    fn apply_empty_batch_is_a_no_op() {
+        let index = LexicalIndex::new();
+        index.apply(Vec::new()).expect("empty batch is fine");
+    }
+
+    #[tokio::test]
+    async fn apply_async_mutations_are_visible_after_await() {
+        let scope = Scope::Root;
+        let index = std::sync::Arc::new(LexicalIndex::new());
+
+        index
+            .apply_async(vec![LexicalOp::Upsert(LexicalDoc {
+                qualified_name: key(&scope, "note"),
+                name: "note".to_string(),
+                content: "asyncword content".to_string(),
+            })])
+            .await
+            .expect("apply_async");
+
+        assert_eq!(
+            index
+                .search(&ScopeFilter::All, "asyncword", 10)
+                .expect("search")
+                .len(),
+            1
+        );
+    }
+
+    #[test]
     fn disabled_instance_errors_on_every_operation() {
         let index = LexicalIndex::disabled();
 
         assert!(index.upsert("key", "name", "content").is_err());
         assert!(index.remove("key").is_err());
+        assert!(index
+            .apply(vec![LexicalOp::Remove("key".to_string())])
+            .is_err());
         assert!(index.rebuild(Vec::new()).is_err());
         assert!(index.search(&ScopeFilter::All, "query", 10).is_err());
     }

--- a/src/search/fusion.rs
+++ b/src/search/fusion.rs
@@ -1,0 +1,199 @@
+//! Reciprocal rank fusion (RRF) for merging semantic and lexical results.
+//!
+//! RRF combines ranked lists without needing the underlying scores to be
+//! comparable: each list contributes `1 / (K + rank)` per document, so a
+//! top-ranked lexical hit can surface even when its embedding distance is
+//! poor (and vice versa). The constant `K = 60` is the standard value from
+//! Cormack et al. (2009) — it damps the influence of lower ranks without
+//! letting any single list dominate.
+
+use std::collections::HashMap;
+
+/// Standard RRF damping constant.
+const RRF_K: f64 = 60.0;
+
+/// A single result produced by [`reciprocal_rank_fusion`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedHit {
+    /// Canonical index key (`v1:scope=<scope>;name=<name>`).
+    pub qualified_name: String,
+    /// Cosine distance from the semantic strategy, if it returned this hit.
+    pub semantic_distance: Option<f32>,
+    /// BM25 score from the lexical strategy, if it returned this hit.
+    pub lexical_score: Option<f32>,
+    /// Combined RRF score (higher is better).
+    pub score: f64,
+}
+
+impl FusedHit {
+    /// Which strategies contributed this hit: `"both"`, `"semantic"`, or
+    /// `"lexical"`.
+    pub fn match_type(&self) -> &'static str {
+        match (self.semantic_distance, self.lexical_score) {
+            (Some(_), Some(_)) => "both",
+            (Some(_), None) => "semantic",
+            (None, _) => "lexical",
+        }
+    }
+}
+
+/// Merge a semantic result list (ascending distance) and a lexical result
+/// list (descending BM25 score) into a single ranking via reciprocal rank
+/// fusion.
+///
+/// Both inputs must already be sorted best-first; ranks are taken from list
+/// positions. Duplicate names within one list keep their best (first) rank.
+/// The output is sorted by descending fused score, with ties broken by
+/// ascending qualified name so the ordering is fully deterministic. At most
+/// `limit` hits are returned.
+pub fn reciprocal_rank_fusion(
+    semantic: &[(String, f32)],
+    lexical: &[(String, f32)],
+    limit: usize,
+) -> Vec<FusedHit> {
+    let mut merged: HashMap<&str, FusedHit> = HashMap::new();
+
+    for (rank, (qualified_name, distance)) in semantic.iter().enumerate() {
+        merged
+            .entry(qualified_name.as_str())
+            .or_insert_with(|| FusedHit {
+                qualified_name: qualified_name.clone(),
+                semantic_distance: Some(*distance),
+                lexical_score: None,
+                score: rrf_contribution(rank),
+            });
+    }
+
+    for (rank, (qualified_name, bm25)) in lexical.iter().enumerate() {
+        merged
+            .entry(qualified_name.as_str())
+            .and_modify(|hit| {
+                if hit.lexical_score.is_none() {
+                    hit.lexical_score = Some(*bm25);
+                    hit.score += rrf_contribution(rank);
+                }
+            })
+            .or_insert_with(|| FusedHit {
+                qualified_name: qualified_name.clone(),
+                semantic_distance: None,
+                lexical_score: Some(*bm25),
+                score: rrf_contribution(rank),
+            });
+    }
+
+    let mut hits: Vec<FusedHit> = merged.into_values().collect();
+    hits.sort_by(|a, b| {
+        b.score
+            .total_cmp(&a.score)
+            .then_with(|| a.qualified_name.cmp(&b.qualified_name))
+    });
+    hits.truncate(limit);
+    hits
+}
+
+/// RRF contribution of a zero-based rank: `1 / (K + rank + 1)`.
+fn rrf_contribution(rank: usize) -> f64 {
+    // Precision loss is irrelevant here: ranks are small (≤ recall limit).
+    #[allow(clippy::cast_precision_loss)]
+    let rank = rank as f64;
+    1.0 / (RRF_K + rank + 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(hits: &[FusedHit]) -> Vec<&str> {
+        hits.iter().map(|h| h.qualified_name.as_str()).collect()
+    }
+
+    fn sem(entries: &[(&str, f32)]) -> Vec<(String, f32)> {
+        entries.iter().map(|(n, s)| (n.to_string(), *s)).collect()
+    }
+
+    #[test]
+    fn agreement_between_lists_ranks_first() {
+        let semantic = sem(&[("a", 0.1), ("b", 0.2), ("c", 0.3)]);
+        let lexical = sem(&[("b", 9.0), ("d", 5.0)]);
+
+        let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
+
+        // "b" appears in both lists, so it outranks the single-list hits.
+        assert_eq!(names(&hits)[0], "b");
+        assert_eq!(hits[0].match_type(), "both");
+        assert_eq!(hits[0].semantic_distance, Some(0.2));
+        assert_eq!(hits[0].lexical_score, Some(9.0));
+    }
+
+    #[test]
+    fn top_lexical_hit_surfaces_without_semantic_support() {
+        // "needle" is absent from the semantic list entirely (the
+        // "happy birthday" failure mode) but is the top lexical hit.
+        let semantic = sem(&[("decoy1", 0.3), ("decoy2", 0.35), ("decoy3", 0.4)]);
+        let lexical = sem(&[("needle", 12.0)]);
+
+        let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
+
+        // Lexical rank 0 ties semantic rank 0 and beats every lower
+        // semantic rank, so "needle" lands in the top two.
+        let pos = names(&hits)
+            .iter()
+            .position(|n| *n == "needle")
+            .expect("needle must be present");
+        assert!(pos <= 1, "needle should be in the top 2, got rank {pos}");
+        assert_eq!(hits[pos].match_type(), "lexical");
+        assert_eq!(hits[pos].semantic_distance, None);
+    }
+
+    #[test]
+    fn equal_score_ties_break_by_name() {
+        // Semantic rank 0 and lexical rank 0 contribute identical RRF
+        // scores; ordering must fall back to the qualified name.
+        let semantic = sem(&[("zzz", 0.1)]);
+        let lexical = sem(&[("aaa", 3.0)]);
+
+        let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
+
+        assert_eq!(names(&hits), vec!["aaa", "zzz"]);
+    }
+
+    #[test]
+    fn output_is_truncated_to_limit() {
+        let semantic = sem(&[("a", 0.1), ("b", 0.2), ("c", 0.3)]);
+        let lexical = sem(&[("d", 3.0), ("e", 2.0)]);
+
+        let hits = reciprocal_rank_fusion(&semantic, &lexical, 2);
+
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_names_within_a_list_keep_best_rank() {
+        let semantic = sem(&[("a", 0.1), ("a", 0.9)]);
+        let lexical = sem(&[("a", 5.0), ("a", 1.0)]);
+
+        let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].semantic_distance, Some(0.1));
+        assert_eq!(hits[0].lexical_score, Some(5.0));
+        let expected = 2.0 / (RRF_K + 1.0);
+        assert!((hits[0].score - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn empty_inputs_produce_empty_output() {
+        assert!(reciprocal_rank_fusion(&[], &[], 10).is_empty());
+    }
+
+    #[test]
+    fn fusion_is_deterministic() {
+        let semantic = sem(&[("a", 0.1), ("b", 0.2), ("c", 0.3)]);
+        let lexical = sem(&[("c", 4.0), ("d", 3.0), ("a", 2.0)]);
+
+        let first = reciprocal_rank_fusion(&semantic, &lexical, 10);
+        for _ in 0..10 {
+            assert_eq!(first, reciprocal_rank_fusion(&semantic, &lexical, 10));
+        }
+    }
+}

--- a/src/search/fusion.rs
+++ b/src/search/fusion.rs
@@ -43,9 +43,11 @@ impl FusedHit {
 ///
 /// Both inputs must already be sorted best-first; ranks are taken from list
 /// positions. Duplicate names within one list keep their best (first) rank.
-/// The output is sorted by descending fused score, with ties broken by
-/// ascending qualified name so the ordering is fully deterministic. At most
-/// `limit` hits are returned.
+/// The output is sorted by descending fused score. Score ties break
+/// lexical-first (a hit with a lexical contribution outranks a tied hit
+/// without one — so the top lexical hit is never displaced by a tied
+/// semantic-only hit), then by ascending qualified name, so the ordering is
+/// fully deterministic. At most `limit` hits are returned.
 pub fn reciprocal_rank_fusion(
     semantic: &[(String, f32)],
     lexical: &[(String, f32)],
@@ -85,6 +87,10 @@ pub fn reciprocal_rank_fusion(
     hits.sort_by(|a, b| {
         b.score
             .total_cmp(&a.score)
+            // Lexical wins score ties: the only structural tie is lexical
+            // rank r vs semantic rank r (both contribute 1/(K+r+1)), and an
+            // exact keyword match must not be displaced by it (#55).
+            .then_with(|| b.lexical_score.is_some().cmp(&a.lexical_score.is_some()))
             .then_with(|| a.qualified_name.cmp(&b.qualified_name))
     });
     hits.truncate(limit);
@@ -134,27 +140,30 @@ mod tests {
 
         let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
 
-        // Lexical rank 0 ties semantic rank 0 and beats every lower
-        // semantic rank, so "needle" lands in the top two.
-        let pos = names(&hits)
-            .iter()
-            .position(|n| *n == "needle")
-            .expect("needle must be present");
-        assert!(pos <= 1, "needle should be in the top 2, got rank {pos}");
-        assert_eq!(hits[pos].match_type(), "lexical");
-        assert_eq!(hits[pos].semantic_distance, None);
+        // Lexical rank 0 ties semantic rank 0 on RRF score, and the
+        // lexical-first tie-break resolves it: "needle" must rank first,
+        // ahead of every semantic-only candidate.
+        assert_eq!(
+            names(&hits)[0],
+            "needle",
+            "top lexical hit must outrank all semantic-only hits"
+        );
+        assert_eq!(hits[0].match_type(), "lexical");
+        assert_eq!(hits[0].semantic_distance, None);
     }
 
     #[test]
-    fn equal_score_ties_break_by_name() {
+    fn equal_score_ties_prefer_lexical_regardless_of_name() {
         // Semantic rank 0 and lexical rank 0 contribute identical RRF
-        // scores; ordering must fall back to the qualified name.
-        let semantic = sem(&[("zzz", 0.1)]);
-        let lexical = sem(&[("aaa", 3.0)]);
+        // scores; the lexical hit must win the tie even when its name
+        // sorts after the semantic hit's.
+        let semantic = sem(&[("aaa", 0.1)]);
+        let lexical = sem(&[("zzz", 3.0)]);
 
         let hits = reciprocal_rank_fusion(&semantic, &lexical, 10);
 
-        assert_eq!(names(&hits), vec!["aaa", "zzz"]);
+        assert_eq!(names(&hits), vec!["zzz", "aaa"]);
+        assert_eq!(hits[0].match_type(), "lexical");
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,0 +1,124 @@
+//! Hybrid retrieval — semantic (embedding) and lexical (BM25) strategies
+//! run in parallel and merged via reciprocal rank fusion.
+//!
+//! Whole-memory embeddings dilute short exact phrases inside long
+//! multi-topic memories: a one-line fact in a 3 KB memory contributes almost
+//! nothing to the document vector, so literal-phrase queries rank it below
+//! short memories that are topically adjacent but wrong. The lexical
+//! strategy catches exactly those queries; fusion lets either strategy
+//! surface a hit the other missed.
+
+use std::sync::Arc;
+
+use tracing::{info, warn, Instrument};
+
+use crate::{
+    embedding::EmbeddingBackend,
+    error::MemoryError,
+    index::VectorStore,
+    repo::{traced_spawn_blocking, MemoryRepo},
+    types::ScopeFilter,
+};
+
+/// BM25 keyword index (Tantivy, in-RAM).
+pub mod bm25;
+/// Reciprocal rank fusion for merging result lists.
+pub mod fusion;
+
+pub use bm25::{LexicalDoc, LexicalIndex};
+pub use fusion::{reciprocal_rank_fusion, FusedHit};
+
+/// Run semantic and lexical retrieval in parallel and merge the ranked
+/// lists with reciprocal rank fusion.
+///
+/// Each strategy contributes up to `limit` candidates; the fused list is
+/// truncated back to `limit`. A semantic failure (embedding or vector index)
+/// is fatal — it preserves recall's pre-hybrid error surface. A lexical
+/// failure only degrades: the error is logged and semantic results are
+/// returned alone, so the new subsystem can never break recall.
+pub async fn hybrid_search(
+    embedding: &dyn EmbeddingBackend,
+    index: &dyn VectorStore,
+    lexical: &Arc<LexicalIndex>,
+    filter: &ScopeFilter,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<FusedHit>, MemoryError> {
+    let span = tracing::info_span!(
+        "search.hybrid",
+        ?filter,
+        limit,
+        semantic_candidates = tracing::field::Empty,
+        lexical_candidates = tracing::field::Empty,
+    );
+    async move {
+        let semantic_fut = async {
+            let start = std::time::Instant::now();
+            let query_vector = embedding.embed_one(query).await?;
+            info!(embed_ms = start.elapsed().as_millis(), "query embedded");
+
+            let start = std::time::Instant::now();
+            let results = index.search(filter, &query_vector, limit)?;
+            info!(
+                search_ms = start.elapsed().as_millis(),
+                candidates = results.len(),
+                "semantic index searched"
+            );
+            Ok::<_, MemoryError>(results)
+        };
+
+        let lexical_index = Arc::clone(lexical);
+        let lexical_filter = filter.clone();
+        let lexical_query = query.to_string();
+        let lexical_fut = traced_spawn_blocking(move || {
+            lexical_index.search(&lexical_filter, &lexical_query, limit)
+        });
+
+        let (semantic_result, lexical_result) = tokio::join!(semantic_fut, lexical_fut);
+
+        let semantic: Vec<(String, f32)> = semantic_result?
+            .into_iter()
+            .map(|(_key, qualified_name, distance)| (qualified_name, distance))
+            .collect();
+
+        let lexical: Vec<(String, f32)> = match lexical_result {
+            Ok(Ok(hits)) => hits,
+            Ok(Err(e)) => {
+                warn!(error = %e, "lexical search failed — returning semantic results only");
+                Vec::new()
+            }
+            Err(e) => {
+                warn!(error = %e, "lexical search task failed — returning semantic results only");
+                Vec::new()
+            }
+        };
+
+        tracing::Span::current().record("semantic_candidates", semantic.len());
+        tracing::Span::current().record("lexical_candidates", lexical.len());
+
+        Ok(reciprocal_rank_fusion(&semantic, &lexical, limit))
+    }
+    .instrument(span)
+    .await
+}
+
+/// Rebuild the lexical index from every memory in the repository.
+///
+/// The lexical index lives in RAM only, so this runs on every startup —
+/// unlike the vector index, which is persisted because embedding is
+/// expensive. Returns the number of indexed memories.
+pub async fn rebuild_lexical_from_repo(
+    repo: &Arc<MemoryRepo>,
+    lexical: &LexicalIndex,
+) -> Result<usize, MemoryError> {
+    let memories = repo.list_memories(None).await?;
+    let docs: Vec<LexicalDoc> = memories
+        .into_iter()
+        .map(|m| LexicalDoc {
+            qualified_name: m.mem_ref().qualified_path(),
+            name: m.name.to_string(),
+            content: m.content,
+        })
+        .collect();
+    lexical.rebuild(docs)
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -25,7 +25,7 @@ pub mod bm25;
 /// Reciprocal rank fusion for merging result lists.
 pub mod fusion;
 
-pub use bm25::{LexicalDoc, LexicalIndex};
+pub use bm25::{LexicalDoc, LexicalIndex, LexicalOp};
 pub use fusion::{reciprocal_rank_fusion, FusedHit};
 
 /// Run semantic and lexical retrieval in parallel and merge the ranked
@@ -106,10 +106,11 @@ pub async fn hybrid_search(
 ///
 /// The lexical index lives in RAM only, so this runs on every startup —
 /// unlike the vector index, which is persisted because embedding is
-/// expensive. Returns the number of indexed memories.
+/// expensive. The rebuild is a single Tantivy commit and runs on the
+/// blocking pool. Returns the number of indexed memories.
 pub async fn rebuild_lexical_from_repo(
     repo: &Arc<MemoryRepo>,
-    lexical: &LexicalIndex,
+    lexical: &Arc<LexicalIndex>,
 ) -> Result<usize, MemoryError> {
     let memories = repo.list_memories(None).await?;
     let docs: Vec<LexicalDoc> = memories
@@ -120,5 +121,8 @@ pub async fn rebuild_lexical_from_repo(
             content: m.content,
         })
         .collect();
-    lexical.rebuild(docs)
+    let lexical = Arc::clone(lexical);
+    traced_spawn_blocking(move || lexical.rebuild(docs))
+        .await
+        .map_err(|e| MemoryError::Join(e.to_string()))?
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,7 @@ use crate::{
     index::VectorStore,
     recall_log::{BatchVerdict, RecallLog, RecallResult},
     repo::{traced_spawn_blocking, MemoryRepo},
-    search::{hybrid_search, FusedHit, LexicalIndex},
+    search::{hybrid_search, FusedHit, LexicalDoc, LexicalIndex, LexicalOp},
     types::{
         parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
         ForgetArgs, ListArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef,
@@ -168,29 +168,25 @@ impl Drop for EditStageTiming {
 /// Re-embed and re-index all memories that changed between two commits.
 ///
 /// Removals are processed first so a name that was deleted and re-added in
-/// the same pull gets a fresh entry rather than a ghost.
+/// the same pull gets a fresh entry rather than a ghost. Lexical mutations
+/// are accumulated and applied as one batch (a single Tantivy commit and
+/// reader reload on the blocking pool), not one commit per memory.
 async fn incremental_reindex(
     repo: &Arc<MemoryRepo>,
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
-    lexical: &LexicalIndex,
+    lexical: &Arc<LexicalIndex>,
     changes: &ChangedMemories,
 ) -> ReindexStats {
     let mut stats = ReindexStats::default();
+    let mut lexical_ops: Vec<LexicalOp> = Vec::new();
 
     // ---- 1. Removals --------------------------------------------------------
     for name in &changes.removed {
         match parse_qualified_name(name) {
             Ok(mref) => {
                 let canonical = mref.qualified_path();
-                if let Err(e) = lexical.remove(&canonical) {
-                    warn!(
-                        qualified_name = %canonical,
-                        error = %e,
-                        "incremental_reindex: lexical removal failed; stale entry \
-                         will be skipped at recall"
-                    );
-                }
+                lexical_ops.push(LexicalOp::Remove(canonical.clone()));
                 match index.remove(&mref.scope, &canonical) {
                     Ok(()) => {
                         stats.removed += 1;
@@ -273,15 +269,24 @@ async fn incremental_reindex(
                 continue;
             }
         };
-        if let Err(e) = lexical.upsert(&qualified, memory.name.as_str(), &memory.content) {
-            warn!(
-                qualified_name = %qualified,
-                error = %e,
-                "incremental_reindex: lexical upsert failed; memory will not be \
-                 keyword-searchable until restart"
-            );
-        }
+        lexical_ops.push(LexicalOp::Upsert(LexicalDoc {
+            qualified_name: qualified,
+            name: memory.name.as_str().to_string(),
+            content: memory.content.clone(),
+        }));
         to_embed.push((mref.clone(), memory.content));
+    }
+
+    // ---- 3b. Mirror all changes into the lexical index ----------------------
+    // One batch: a single commit and reader reload for the whole changed
+    // set, on the blocking pool. Best-effort — a failure degrades the
+    // changed memories to semantic-only until the next startup rebuild.
+    if let Err(e) = lexical.apply_async(lexical_ops).await {
+        warn!(
+            error = %e,
+            "incremental_reindex: lexical batch update failed; changed memories \
+             will not be keyword-searchable until restart"
+        );
     }
 
     if to_embed.is_empty() {
@@ -506,10 +511,15 @@ impl MemoryServer {
 
             // Lexical index is best-effort: a failure here leaves the memory
             // semantically searchable, and the next startup rebuild heals it.
-            if let Err(e) =
-                state
-                    .lexical
-                    .upsert(&qualified_name, memory.name.as_str(), &memory.content)
+            // The commit runs on the blocking pool, not this async worker.
+            if let Err(e) = state
+                .lexical
+                .apply_async(vec![LexicalOp::Upsert(LexicalDoc {
+                    qualified_name: qualified_name.clone(),
+                    name: memory.name.as_str().to_string(),
+                    content: memory.content.clone(),
+                })])
+                .await
             {
                 warn!(
                     name = %memory.name,
@@ -553,7 +563,8 @@ impl MemoryServer {
         When `truncated` is true, the snippet is incomplete — use the `read` tool with the memory's name and scope \
         to retrieve the full content before acting on it.\n\n\
         Each result also includes `match_type` ('semantic', 'lexical', or 'both') and `distance` \
-        (cosine distance, lower is more similar; null for lexical-only hits, which have no embedding distance).\n\n\
+        (cosine distance, lower is more similar; always numeric — lexical-only hits, which have no \
+        embedding distance, carry the sentinel -1.0).\n\n\
         Scope: pass '<basename-of-your-cwd>' or 'org/team' to search that scope + global memories, \
         'global' for global-only, or 'all' to search everything. Omitting scope defaults to global-only."
     )]
@@ -648,7 +659,9 @@ impl MemoryServer {
                     // Lexical-only hits have no embedding distance; the -1.0
                     // sentinel keeps them out of distance-bucketed recall
                     // stats (which filter on distance >= 0.0).
-                    distance: hit.semantic_distance.map_or(-1.0, f64::from),
+                    distance: hit
+                        .semantic_distance
+                        .map_or(LEXICAL_ONLY_DISTANCE_SENTINEL, f64::from),
                 });
 
                 results_vec.push(recall_entry_json(&memory, &hit));
@@ -721,7 +734,11 @@ impl MemoryServer {
             if let Err(e) = state.index.remove(&scope, &qualified_name) {
                 warn!(name = %name, error = %e, "vector removal failed during forget; stale entry will be skipped at recall");
             }
-            if let Err(e) = state.lexical.remove(&qualified_name) {
+            if let Err(e) = state
+                .lexical
+                .apply_async(vec![LexicalOp::Remove(qualified_name.clone())])
+                .await
+            {
                 warn!(name = %name, error = %e, "lexical removal failed during forget; stale entry will be skipped at recall");
             }
 
@@ -827,10 +844,15 @@ impl MemoryServer {
                 index_result.map_err(ErrorData::from)?;
 
                 // Lexical index is best-effort: the next startup rebuild heals it.
-                if let Err(e) =
-                    state
-                        .lexical
-                        .upsert(&qualified_name, memory.name.as_str(), &memory.content)
+                // The commit runs on the blocking pool, not this async worker.
+                if let Err(e) = state
+                    .lexical
+                    .apply_async(vec![LexicalOp::Upsert(LexicalDoc {
+                        qualified_name: qualified_name.clone(),
+                        name: memory.name.as_str().to_string(),
+                        content: memory.content.clone(),
+                    })])
+                    .await
                 {
                     warn!(
                         name = %memory.name,
@@ -973,24 +995,28 @@ impl MemoryServer {
                 );
             }
 
-            // 6. Mirror the move in the lexical index (best-effort).
-            if let Err(e) =
-                state
-                    .lexical
-                    .upsert(&dest_qualified, dest.name.as_str(), &dest.content)
+            // 6. Mirror the move in the lexical index (best-effort). One
+            //    batch: destination upsert + source removal share a single
+            //    commit and reader reload on the blocking pool.
+            if let Err(e) = state
+                .lexical
+                .apply_async(vec![
+                    LexicalOp::Upsert(LexicalDoc {
+                        qualified_name: dest_qualified.clone(),
+                        name: dest.name.as_str().to_string(),
+                        content: dest.content.clone(),
+                    }),
+                    LexicalOp::Remove(source_qualified.clone()),
+                ])
+                .await
             {
                 warn!(
-                    name = %new_name,
+                    name = %name,
+                    new_name = %new_name,
                     error = %e,
                     "lexical index update failed during move; destination will not be \
-                     keyword-searchable until restart"
-                );
-            }
-            if let Err(e) = state.lexical.remove(&source_qualified) {
-                warn!(
-                    name = %name,
-                    error = %e,
-                    "lexical removal failed during move; stale source entry will be skipped at recall"
+                     keyword-searchable and the stale source entry will be skipped \
+                     at recall, until restart"
                 );
             }
 
@@ -1632,10 +1658,20 @@ impl ServerHandler for MemoryServer {
     }
 }
 
+/// Sentinel `distance` for hits that only the lexical strategy returned.
+///
+/// Lexical-only hits have no embedding distance, but the `distance` field
+/// predates hybrid retrieval and was always numeric on the wire — strict
+/// clients deserialize it as a required float, so it must stay numeric
+/// (never `null` or absent). `-1.0` is impossible as a real cosine distance
+/// and matches the recall log's lexical-only sentinel.
+const LEXICAL_ONLY_DISTANCE_SENTINEL: f64 = -1.0;
+
 /// Build one recall result entry as seen on the wire.
 ///
-/// `distance` is the semantic (cosine) distance and is `null` for hits that
-/// only the lexical strategy returned. `match_type` says which strategies
+/// `distance` is the semantic (cosine) distance, or the numeric sentinel
+/// [`LEXICAL_ONLY_DISTANCE_SENTINEL`] (`-1.0`) for hits that only the
+/// lexical strategy returned. `match_type` says which strategies
 /// contributed: `"semantic"`, `"lexical"`, or `"both"`.
 fn recall_entry_json(memory: &Memory, hit: &FusedHit) -> serde_json::Value {
     let (snippet, content_length, truncated) = build_snippet(&memory.content);
@@ -1647,7 +1683,9 @@ fn recall_entry_json(memory: &Memory, hit: &FusedHit) -> serde_json::Value {
         "content": snippet,
         "content_length": content_length,
         "truncated": truncated,
-        "distance": hit.semantic_distance,
+        "distance": hit
+            .semantic_distance
+            .map_or(LEXICAL_ONLY_DISTANCE_SENTINEL, f64::from),
         "match_type": hit.match_type(),
     })
 }
@@ -1910,7 +1948,7 @@ mod tests {
     }
 
     #[test]
-    fn recall_entry_lexical_only_hit_has_null_distance() {
+    fn recall_entry_lexical_only_hit_has_numeric_sentinel_distance() {
         let hit = FusedHit {
             qualified_name: "v1:scope=global;name=wire-test".to_string(),
             semantic_distance: None,
@@ -1920,11 +1958,71 @@ mod tests {
 
         let entry = recall_entry_json(&wire_test_memory(), &hit);
 
-        assert!(
-            entry["distance"].is_null(),
-            "lexical-only hits have no embedding distance"
-        );
+        // The pre-hybrid wire contract has `distance` as a required numeric
+        // field; lexical-only hits must keep it numeric (never null/absent)
+        // so strict older clients still deserialize the entry.
+        let distance = entry["distance"]
+            .as_f64()
+            .expect("distance must stay numeric for lexical-only hits");
+        assert!((distance - LEXICAL_ONLY_DISTANCE_SENTINEL).abs() < 1e-12);
         assert_eq!(entry["match_type"], "lexical");
+    }
+
+    #[test]
+    fn recall_entry_lexical_only_hit_keeps_the_full_contract_shape() {
+        // Both hit shapes — with a real distance and with the sentinel —
+        // must expose exactly the same field set.
+        let hit = FusedHit {
+            qualified_name: "v1:scope=global;name=wire-test".to_string(),
+            semantic_distance: None,
+            lexical_score: Some(7.5),
+            score: 0.016,
+        };
+
+        let entry = recall_entry_json(&wire_test_memory(), &hit);
+
+        assert_eq!(
+            entry_keys(&entry),
+            vec![
+                "content",
+                "content_length",
+                "distance",
+                "id",
+                "match_type",
+                "name",
+                "scope",
+                "tags",
+                "truncated",
+            ]
+        );
+    }
+
+    #[test]
+    fn recall_entry_deserializes_for_a_strict_numeric_distance_client() {
+        // Simulates a pre-hybrid client that models `distance` as a
+        // required f32 — both hit shapes must satisfy it.
+        #[derive(serde::Deserialize)]
+        struct StrictClientEntry {
+            #[allow(dead_code)]
+            name: String,
+            distance: f32,
+        }
+
+        for semantic_distance in [Some(0.25_f32), None] {
+            let hit = FusedHit {
+                qualified_name: "v1:scope=global;name=wire-test".to_string(),
+                semantic_distance,
+                lexical_score: Some(7.5),
+                score: 0.016,
+            };
+            let entry = recall_entry_json(&wire_test_memory(), &hit);
+            let parsed: StrictClientEntry = serde_json::from_value(entry)
+                .expect("strict numeric-distance clients must keep working");
+            assert!(
+                parsed.distance >= -1.0,
+                "sentinel is the only negative value"
+            );
+        }
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,6 +43,7 @@ use crate::{
     index::VectorStore,
     recall_log::{BatchVerdict, RecallLog, RecallResult},
     repo::{traced_spawn_blocking, MemoryRepo},
+    search::{hybrid_search, FusedHit, LexicalIndex},
     types::{
         parse_qualified_name, AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs,
         ForgetArgs, ListArgs, MarkAppliedArgs, Memory, MemoryMetadata, MemoryName, MemoryRef,
@@ -172,6 +173,7 @@ async fn incremental_reindex(
     repo: &Arc<MemoryRepo>,
     embedding: &dyn EmbeddingBackend,
     index: &dyn VectorStore,
+    lexical: &LexicalIndex,
     changes: &ChangedMemories,
 ) -> ReindexStats {
     let mut stats = ReindexStats::default();
@@ -181,6 +183,14 @@ async fn incremental_reindex(
         match parse_qualified_name(name) {
             Ok(mref) => {
                 let canonical = mref.qualified_path();
+                if let Err(e) = lexical.remove(&canonical) {
+                    warn!(
+                        qualified_name = %canonical,
+                        error = %e,
+                        "incremental_reindex: lexical removal failed; stale entry \
+                         will be skipped at recall"
+                    );
+                }
                 match index.remove(&mref.scope, &canonical) {
                     Ok(()) => {
                         stats.removed += 1;
@@ -263,6 +273,14 @@ async fn incremental_reindex(
                 continue;
             }
         };
+        if let Err(e) = lexical.upsert(&qualified, memory.name.as_str(), &memory.content) {
+            warn!(
+                qualified_name = %qualified,
+                error = %e,
+                "incremental_reindex: lexical upsert failed; memory will not be \
+                 keyword-searchable until restart"
+            );
+        }
         to_embed.push((mref.clone(), memory.content));
     }
 
@@ -483,8 +501,23 @@ impl MemoryServer {
 
             state
                 .index
-                .add(&scope, &vector, qualified_name)
+                .add(&scope, &vector, qualified_name.clone())
                 .map_err(ErrorData::from)?;
+
+            // Lexical index is best-effort: a failure here leaves the memory
+            // semantically searchable, and the next startup rebuild heals it.
+            if let Err(e) =
+                state
+                    .lexical
+                    .upsert(&qualified_name, memory.name.as_str(), &memory.content)
+            {
+                warn!(
+                    name = %memory.name,
+                    error = %e,
+                    "lexical index update failed during remember; memory will not be \
+                     keyword-searchable until restart"
+                );
+            }
 
             let start = Instant::now();
             state
@@ -513,11 +546,14 @@ impl MemoryServer {
     /// Returns a JSON array of matching memories sorted by relevance.
     #[tool(
         name = "recall",
-        description = "Search memories by semantic similarity. Embeds the query and returns the top matching memories as a JSON array \
-        with name, scope, tags, and a content snippet (max 500 chars).\n\n\
+        description = "Search memories with hybrid retrieval: semantic similarity (embeddings) and keyword/BM25 \
+        search run in parallel and are rank-fused, so exact phrases buried in long memories still surface. \
+        Returns the top matching memories as a JSON array with name, scope, tags, and a content snippet (max 500 chars).\n\n\
         Each result includes `truncated` (bool) and `content_length` (total character count). \
         When `truncated` is true, the snippet is incomplete — use the `read` tool with the memory's name and scope \
         to retrieve the full content before acting on it.\n\n\
+        Each result also includes `match_type` ('semantic', 'lexical', or 'both') and `distance` \
+        (cosine distance, lower is more similar; null for lexical-only hits, which have no embedding distance).\n\n\
         Scope: pass '<basename-of-your-cwd>' or 'org/team' to search that scope + global memories, \
         'global' for global-only, or 'all' to search everything. Omitting scope defaults to global-only."
     )]
@@ -545,41 +581,42 @@ impl MemoryServer {
 
             let limit = args.limit.unwrap_or(5).min(100);
 
+            // Semantic and lexical retrieval run in parallel; ranked lists
+            // are merged with reciprocal rank fusion so an exact keyword hit
+            // can surface even when its embedding distance is poor.
             let start = Instant::now();
-            let query_vector = state
-                .embedding
-                .embed_one(&args.query)
-                .await
-                .map_err(ErrorData::from)?;
-            info!(embed_ms = start.elapsed().as_millis(), "query embedded");
-
-            let start = Instant::now();
-            let results = state
-                .index
-                .search(&scope_filter, &query_vector, limit)
-                .map_err(ErrorData::from)?;
+            let fused = hybrid_search(
+                state.embedding.as_ref(),
+                state.index.as_ref(),
+                &state.lexical,
+                &scope_filter,
+                &args.query,
+                limit,
+            )
+            .await
+            .map_err(ErrorData::from)?;
             info!(
                 search_ms = start.elapsed().as_millis(),
-                candidates = results.len(),
-                "index searched"
+                candidates = fused.len(),
+                "hybrid search complete"
             );
 
-            let pre_filter_count = results.len();
+            let pre_filter_count = fused.len();
             let mut results_vec = Vec::new();
             let mut log_entries: Vec<RecallResult> = Vec::new();
             let mut skipped_errors: usize = 0;
 
-            for (_key, qualified_name, distance) in results {
-                // The index returns at most `limit` candidates; this guard is a safety
+            for hit in fused {
+                // Fusion returns at most `limit` candidates; this guard is a safety
                 // net that only activates if more candidates arrive than expected.
                 if results_vec.len() >= limit {
                     break;
                 }
-                let mref = match parse_qualified_name(&qualified_name) {
+                let mref = match parse_qualified_name(&hit.qualified_name) {
                     Ok(r) => r,
                     Err(e) => {
                         warn!(
-                            qualified_name = %qualified_name,
+                            qualified_name = %hit.qualified_name,
                             error = %e,
                             "could not parse qualified name from index; skipping"
                         );
@@ -603,25 +640,18 @@ impl MemoryServer {
                 };
 
                 let rank = results_vec.len();
-                let (snippet, content_length, truncated) = build_snippet(&memory.content);
 
                 log_entries.push(RecallResult {
                     memory_name: memory.name.to_string(),
                     scope: memory.metadata.scope.to_string(),
                     rank,
-                    distance: distance as f64,
+                    // Lexical-only hits have no embedding distance; the -1.0
+                    // sentinel keeps them out of distance-bucketed recall
+                    // stats (which filter on distance >= 0.0).
+                    distance: hit.semantic_distance.map_or(-1.0, f64::from),
                 });
 
-                results_vec.push(serde_json::json!({
-                    "id": memory.id,
-                    "name": memory.name,
-                    "scope": memory.metadata.scope.to_string(),
-                    "tags": memory.metadata.tags,
-                    "content": snippet,
-                    "content_length": content_length,
-                    "truncated": truncated,
-                    "distance": distance,
-                }));
+                results_vec.push(recall_entry_json(&memory, &hit));
             }
 
             if let Some(ref log) = state.recall_log {
@@ -690,6 +720,9 @@ impl MemoryServer {
             let qualified_name = MemoryRef::new(scope.clone(), name.clone()).qualified_path();
             if let Err(e) = state.index.remove(&scope, &qualified_name) {
                 warn!(name = %name, error = %e, "vector removal failed during forget; stale entry will be skipped at recall");
+            }
+            if let Err(e) = state.lexical.remove(&qualified_name) {
+                warn!(name = %name, error = %e, "lexical removal failed during forget; stale entry will be skipped at recall");
             }
 
             info!(
@@ -789,9 +822,23 @@ impl MemoryServer {
 
                 timing.stage = "index";
                 let stage_start = Instant::now();
-                let index_result = state.index.add(&scope, &vector, qualified_name);
+                let index_result = state.index.add(&scope, &vector, qualified_name.clone());
                 timing.index_ms = elapsed_ms(stage_start);
                 index_result.map_err(ErrorData::from)?;
+
+                // Lexical index is best-effort: the next startup rebuild heals it.
+                if let Err(e) =
+                    state
+                        .lexical
+                        .upsert(&qualified_name, memory.name.as_str(), &memory.content)
+                {
+                    warn!(
+                        name = %memory.name,
+                        error = %e,
+                        "lexical index update failed during edit; stale keyword entry \
+                         until restart"
+                    );
+                }
             }
 
             // Persist to repo (last, so partial failures leave recoverable state).
@@ -911,7 +958,7 @@ impl MemoryServer {
             // 4. Add destination to the vector index.
             state
                 .index
-                .add(&to_scope, &vector, dest_qualified)
+                .add(&to_scope, &vector, dest_qualified.clone())
                 .map_err(ErrorData::from)?;
 
             // 5. Remove the source from the vector index (best-effort — stale
@@ -923,6 +970,27 @@ impl MemoryServer {
                     name = %name,
                     error = %e,
                     "vector removal failed during move; stale source entry will be skipped at recall"
+                );
+            }
+
+            // 6. Mirror the move in the lexical index (best-effort).
+            if let Err(e) =
+                state
+                    .lexical
+                    .upsert(&dest_qualified, dest.name.as_str(), &dest.content)
+            {
+                warn!(
+                    name = %new_name,
+                    error = %e,
+                    "lexical index update failed during move; destination will not be \
+                     keyword-searchable until restart"
+                );
+            }
+            if let Err(e) = state.lexical.remove(&source_qualified) {
+                warn!(
+                    name = %name,
+                    error = %e,
+                    "lexical removal failed during move; stale source entry will be skipped at recall"
                 );
             }
 
@@ -1163,6 +1231,7 @@ impl MemoryServer {
                             &state.repo,
                             state.embedding.as_ref(),
                             state.index.as_ref(),
+                            &state.lexical,
                             &changes,
                         )
                         .instrument(tracing::info_span!("server.incremental_reindex"))
@@ -1563,6 +1632,26 @@ impl ServerHandler for MemoryServer {
     }
 }
 
+/// Build one recall result entry as seen on the wire.
+///
+/// `distance` is the semantic (cosine) distance and is `null` for hits that
+/// only the lexical strategy returned. `match_type` says which strategies
+/// contributed: `"semantic"`, `"lexical"`, or `"both"`.
+fn recall_entry_json(memory: &Memory, hit: &FusedHit) -> serde_json::Value {
+    let (snippet, content_length, truncated) = build_snippet(&memory.content);
+    serde_json::json!({
+        "id": memory.id,
+        "name": memory.name,
+        "scope": memory.metadata.scope.to_string(),
+        "tags": memory.metadata.tags,
+        "content": snippet,
+        "content_length": content_length,
+        "truncated": truncated,
+        "distance": hit.semantic_distance,
+        "match_type": hit.match_type(),
+    })
+}
+
 /// Truncate content to [`SNIPPET_MAX_CHARS`] and return `(snippet, content_length, truncated)`.
 fn build_snippet(content: &str) -> (String, usize, bool) {
     let content_length = content.chars().count();
@@ -1755,5 +1844,101 @@ mod tests {
         assert_eq!(snippet, "");
         assert_eq!(content_length, 0);
         assert!(!truncated);
+    }
+
+    // -----------------------------------------------------------------------
+    // Wire-contract tests — the recall result entry shape MCP clients see.
+    // -----------------------------------------------------------------------
+
+    fn wire_test_memory() -> Memory {
+        let metadata = MemoryMetadata::new(Scope::Root, vec!["tag-a".to_string()], None);
+        Memory::new("wire-test", "some content".to_string(), metadata).expect("valid memory")
+    }
+
+    fn entry_keys(entry: &serde_json::Value) -> Vec<&str> {
+        let mut keys: Vec<&str> = entry
+            .as_object()
+            .expect("entry must be an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        keys
+    }
+
+    #[test]
+    fn recall_entry_has_exactly_the_contract_fields() {
+        let hit = FusedHit {
+            qualified_name: "v1:scope=global;name=wire-test".to_string(),
+            semantic_distance: Some(0.25),
+            lexical_score: Some(4.2),
+            score: 0.03,
+        };
+
+        let entry = recall_entry_json(&wire_test_memory(), &hit);
+
+        assert_eq!(
+            entry_keys(&entry),
+            vec![
+                "content",
+                "content_length",
+                "distance",
+                "id",
+                "match_type",
+                "name",
+                "scope",
+                "tags",
+                "truncated",
+            ]
+        );
+    }
+
+    #[test]
+    fn recall_entry_semantic_hit_has_numeric_distance() {
+        let hit = FusedHit {
+            qualified_name: "v1:scope=global;name=wire-test".to_string(),
+            semantic_distance: Some(0.25),
+            lexical_score: None,
+            score: 0.02,
+        };
+
+        let entry = recall_entry_json(&wire_test_memory(), &hit);
+
+        let distance = entry["distance"].as_f64().expect("distance is a number");
+        assert!((distance - 0.25).abs() < 1e-6);
+        assert_eq!(entry["match_type"], "semantic");
+    }
+
+    #[test]
+    fn recall_entry_lexical_only_hit_has_null_distance() {
+        let hit = FusedHit {
+            qualified_name: "v1:scope=global;name=wire-test".to_string(),
+            semantic_distance: None,
+            lexical_score: Some(7.5),
+            score: 0.016,
+        };
+
+        let entry = recall_entry_json(&wire_test_memory(), &hit);
+
+        assert!(
+            entry["distance"].is_null(),
+            "lexical-only hits have no embedding distance"
+        );
+        assert_eq!(entry["match_type"], "lexical");
+    }
+
+    #[test]
+    fn recall_entry_both_hit_keeps_semantic_distance() {
+        let hit = FusedHit {
+            qualified_name: "v1:scope=global;name=wire-test".to_string(),
+            semantic_distance: Some(0.31),
+            lexical_score: Some(2.0),
+            score: 0.033,
+        };
+
+        let entry = recall_entry_json(&wire_test_memory(), &hit);
+
+        assert_eq!(entry["match_type"], "both");
+        assert!(entry["distance"].is_number());
     }
 }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -271,6 +271,8 @@ pub struct AppState {
     pub embedding: Box<dyn EmbeddingBackend>,
     /// In-memory vector index for semantic search (scope-partitioned).
     pub index: Box<dyn VectorStore>,
+    /// In-RAM BM25 index for keyword search (rebuilt from the repo on startup).
+    pub lexical: Arc<crate::search::LexicalIndex>,
     /// Authentication provider for API access control.
     pub auth: AuthProvider,
     /// Branch name used for push/pull operations (default: "main").
@@ -296,6 +298,11 @@ impl AppState {
             repo,
             embedding,
             index,
+            // Constructed here rather than injected: creation is infallible
+            // (a failure yields a disabled instance) and the index starts
+            // empty either way — callers populate it via
+            // `search::rebuild_lexical_from_repo` or the write handlers.
+            lexical: Arc::new(crate::search::LexicalIndex::new()),
             auth,
             branch,
             health,

--- a/tests/hybrid_recall.rs
+++ b/tests/hybrid_recall.rs
@@ -1,0 +1,324 @@
+//! Integration tests for hybrid (semantic + lexical) retrieval.
+//!
+//! The golden test recreates a real recall miss (issue #55): a memory whose
+//! ~3 KB of multi-topic content buries the literal phrase "happy birthday"
+//! mid-document. Whole-memory embeddings dilute the phrase, so pure semantic
+//! recall ranks topically-adjacent decoys above it and the memory falls out
+//! of the top-k entirely. Hybrid retrieval must surface it via BM25.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use memory_mcp::{
+    embedding::EmbeddingBackend,
+    error::MemoryError,
+    index::{InMemoryStore, VectorStore},
+    search::{hybrid_search, LexicalIndex},
+    types::{MemoryName, MemoryRef, Scope, ScopeFilter, ScopePath},
+};
+
+const DIMS: usize = 4;
+
+/// Embedding backend that always returns `vector` — used to position the
+/// *query* in vector space. Memory vectors are inserted into the store
+/// directly, so this is only consulted by `hybrid_search` for the query.
+struct FixedQueryEmbedding {
+    vector: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbeddingBackend for FixedQueryEmbedding {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        Ok(texts.iter().map(|_| self.vector.clone()).collect())
+    }
+
+    fn dimensions(&self) -> usize {
+        DIMS
+    }
+}
+
+/// Embedding backend that always fails — simulates an embedding outage.
+struct FailingEmbedding;
+
+#[async_trait]
+impl EmbeddingBackend for FailingEmbedding {
+    async fn embed(&self, _texts: &[String]) -> Result<Vec<Vec<f32>>, MemoryError> {
+        Err(MemoryError::Embedding("worker unavailable".to_string()))
+    }
+
+    fn dimensions(&self) -> usize {
+        DIMS
+    }
+}
+
+fn key(scope: &Scope, name: &str) -> String {
+    MemoryRef::new(scope.clone(), MemoryName::new(name.to_string()).unwrap()).qualified_path()
+}
+
+/// A ~3 KB multi-topic "communication style" memory with the literal phrase
+/// "happy birthday" buried mid-document. Mirrors the shape of the real
+/// memory that pure semantic recall missed.
+fn golden_content() -> String {
+    let mut content = String::new();
+    content.push_str("# Communication style notes\n\n## Cadence\n");
+    for i in 0..12 {
+        content.push_str(&format!(
+            "Prefers short direct messages over long explanations; thread {i} showed that \
+             replies land better when they lead with the outcome and skip the preamble. \
+             Match her cadence, do not restate shared context, and avoid filler words.\n"
+        ));
+    }
+    content.push_str("\n## Greetings\n");
+    content.push_str(
+        "\"happy birthday\" = her pre-coffee good morning. more polite than saying grrr.\n",
+    );
+    content.push_str("\n## Timing\n");
+    for i in 0..12 {
+        content.push_str(&format!(
+            "Mornings are slow-start; substantive questions get better answers after coffee. \
+             Observation {i}: pings before 9am get one-word replies, so batch non-urgent \
+             items into a single message and send it mid-morning instead.\n"
+        ));
+    }
+    assert!(
+        content.len() > 3000,
+        "golden memory should be ~3KB+, got {}",
+        content.len()
+    );
+    content
+}
+
+/// Topically-adjacent decoy contents: greetings, birthdays, celebrations,
+/// mornings — but never the literal phrase "happy birthday".
+fn decoy_contents() -> Vec<String> {
+    vec![
+        "Birthday party planning for the group: cake, venue, and a shared gift.".to_string(),
+        "Calendar preferences: birthdays and anniversaries synced from Fastmail.".to_string(),
+        "Morning greeting rituals differ per person; some want silence until coffee.".to_string(),
+        "Celebration etiquette: congratulate promptly, keep it short and warm.".to_string(),
+        "Happy hour scheduling notes: Thursdays work best for most of the group.".to_string(),
+        "Gift ideas list, updated quarterly before each birthday season.".to_string(),
+        "Greeting card templates for holidays and special occasions.".to_string(),
+        "Anniversary reminders should fire a week early to allow gift shipping.".to_string(),
+        "Cron definition: morning thought delivered to Lina at 8am local.".to_string(),
+        "Cron definition: haiku posted daily; skip when the channel is busy.".to_string(),
+        "Party playlist collaboration doc lives in the shared drive.".to_string(),
+        "Cake preferences: chocolate wins, no fondant, candles optional.".to_string(),
+    ]
+}
+
+/// Build the miss scenario: 12 decoys sit close to the query vector, the
+/// golden memory sits far away, and only the golden memory contains the
+/// literal phrase. With `limit = 10`, semantic-only recall cannot return
+/// the golden memory at all.
+fn build_miss_scenario(
+    scope: &Scope,
+) -> (
+    FixedQueryEmbedding,
+    InMemoryStore,
+    Arc<LexicalIndex>,
+    String,
+) {
+    let store = InMemoryStore::new(DIMS);
+    let lexical = Arc::new(LexicalIndex::new());
+
+    let golden_key = key(scope, "person-lina-communication");
+    // Golden memory: far from the query vector (its embedding is dominated
+    // by the surrounding multi-topic prose, not the buried phrase).
+    store
+        .add(scope, &[0.0, 0.0, 0.0, 1.0], golden_key.clone())
+        .expect("add golden");
+    lexical
+        .upsert(&golden_key, "person-lina-communication", &golden_content())
+        .expect("upsert golden");
+
+    // Decoys: clustered around the query vector, each slightly different.
+    for (i, content) in decoy_contents().iter().enumerate() {
+        let name = format!("decoy-{i}");
+        let decoy_key = key(scope, &name);
+        #[allow(clippy::cast_precision_loss)]
+        let jitter = 0.01 * (i as f32 + 1.0);
+        store
+            .add(scope, &[1.0, jitter, 0.0, 0.0], decoy_key.clone())
+            .expect("add decoy");
+        lexical
+            .upsert(&decoy_key, &name, content)
+            .expect("upsert decoy");
+    }
+
+    let embedding = FixedQueryEmbedding {
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+    };
+    (embedding, store, lexical, golden_key)
+}
+
+// ---------------------------------------------------------------------------
+// Golden test — the "happy birthday" miss
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn golden_buried_phrase_surfaces_in_top_results() {
+    let scope = Scope::Root;
+    let (embedding, store, lexical, golden_key) = build_miss_scenario(&scope);
+
+    // Precondition: semantic-only search misses the golden memory entirely.
+    let query_vector = embedding.embed_one("happy birthday").await.unwrap();
+    let semantic_only = store
+        .search(&ScopeFilter::RootOnly, &query_vector, 10)
+        .expect("semantic search");
+    assert_eq!(semantic_only.len(), 10, "10 decoys fill the semantic top-k");
+    assert!(
+        !semantic_only.iter().any(|(_, name, _)| name == &golden_key),
+        "precondition: pure semantic recall must miss the golden memory"
+    );
+
+    // Hybrid search must surface it.
+    let hits = hybrid_search(
+        &embedding,
+        &store,
+        &lexical,
+        &ScopeFilter::RootOnly,
+        "happy birthday",
+        10,
+    )
+    .await
+    .expect("hybrid search");
+
+    let position = hits
+        .iter()
+        .position(|h| h.qualified_name == golden_key)
+        .expect("golden memory must appear in hybrid results");
+    // RRF bound: as the top lexical hit (exact phrase match), the golden
+    // memory beats every semantic-only candidate; only candidates returned
+    // by BOTH strategies can outrank it. Exactly three decoys contain a
+    // bare "birthday"/"happy" term, so the worst possible rank is 3.
+    assert!(
+        position <= 3,
+        "golden memory must outrank all semantic-only decoys, got rank {position}"
+    );
+
+    let golden_hit = &hits[position];
+    assert_eq!(
+        golden_hit.match_type(),
+        "lexical",
+        "the golden memory is only reachable via the lexical strategy"
+    );
+    assert_eq!(golden_hit.semantic_distance, None);
+    assert!(golden_hit.lexical_score.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Scope filtering parity
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hybrid_respects_scope_filter() {
+    let root = Scope::Root;
+    let project = Scope::Path(ScopePath::new("other-project").unwrap());
+
+    let store = InMemoryStore::new(DIMS);
+    let lexical = Arc::new(LexicalIndex::new());
+
+    // Same phrase in both scopes; only the root memory may be returned
+    // for a RootOnly filter — via either strategy.
+    for (scope, name) in [(&root, "root-note"), (&project, "project-note")] {
+        let k = key(scope, name);
+        store
+            .add(scope, &[0.0, 0.0, 0.0, 1.0], k.clone())
+            .expect("add");
+        lexical
+            .upsert(&k, name, "the launch codeword is xyzzy, do not lose it")
+            .expect("upsert");
+    }
+
+    let embedding = FixedQueryEmbedding {
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+    };
+
+    let hits = hybrid_search(
+        &embedding,
+        &store,
+        &lexical,
+        &ScopeFilter::RootOnly,
+        "xyzzy",
+        10,
+    )
+    .await
+    .expect("hybrid search");
+
+    assert_eq!(hits.len(), 1, "only the root-scoped memory may be returned");
+    assert_eq!(hits[0].qualified_name, key(&root, "root-note"));
+}
+
+// ---------------------------------------------------------------------------
+// Agreement between strategies
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hit_found_by_both_strategies_is_marked_both_and_ranks_first() {
+    let scope = Scope::Root;
+    let store = InMemoryStore::new(DIMS);
+    let lexical = Arc::new(LexicalIndex::new());
+
+    // "agreed" is both semantically nearest AND the only keyword match.
+    let agreed_key = key(&scope, "agreed");
+    store
+        .add(&scope, &[1.0, 0.0, 0.0, 0.0], agreed_key.clone())
+        .expect("add");
+    lexical
+        .upsert(&agreed_key, "agreed", "the xyzzy incident report")
+        .expect("upsert");
+
+    let other_key = key(&scope, "other");
+    store
+        .add(&scope, &[0.9, 0.1, 0.0, 0.0], other_key.clone())
+        .expect("add");
+    lexical
+        .upsert(&other_key, "other", "unrelated grocery list")
+        .expect("upsert");
+
+    let embedding = FixedQueryEmbedding {
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+    };
+
+    let hits = hybrid_search(
+        &embedding,
+        &store,
+        &lexical,
+        &ScopeFilter::RootOnly,
+        "xyzzy",
+        10,
+    )
+    .await
+    .expect("hybrid search");
+
+    assert_eq!(hits[0].qualified_name, agreed_key);
+    assert_eq!(hits[0].match_type(), "both");
+    assert!(hits[0].semantic_distance.is_some());
+    assert!(hits[0].lexical_score.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// Error surface
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn semantic_failure_is_fatal_preserving_recall_error_surface() {
+    let store = InMemoryStore::new(DIMS);
+    let lexical = Arc::new(LexicalIndex::new());
+
+    let result = hybrid_search(
+        &FailingEmbedding,
+        &store,
+        &lexical,
+        &ScopeFilter::RootOnly,
+        "anything",
+        10,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(MemoryError::Embedding(_))),
+        "an embedding failure must propagate, not silently degrade"
+    );
+}


### PR DESCRIPTION
## Problem

Whole-memory embeddings dilute short exact phrases inside long multi-topic memories: a one-line fact in a ~3 KB memory contributes almost nothing to the document vector, so literal-phrase queries rank it below short memories that are topically adjacent but wrong.

Field case from this morning ([receipt on #55](https://github.com/butterflyskies/memory-mcp/issues/55#issuecomment-4982033784)): the query `happy birthday` (scope: all, limit 10) returned 10 noise results while the memory containing the verbatim phrase never surfaced. Discord's plain substring search found it instantly.

## Approach

Recall runs two strategies in parallel and merges the ranked lists with reciprocal rank fusion (RRF, k=60):

- **Semantic** — existing embedding + HNSW search, unchanged.
- **Lexical** — new `src/search/bm25.rs`: in-RAM Tantivy BM25 index over memory names and content. Rebuilt from the repo on every startup (indexing text is cheap, unlike embedding it), so there is no on-disk index to version or migrate. Every write path mirrors into it: remember, edit, forget, move, incremental reindex.

Design points (full record in **ADR-0038**):

- **Exact-phrase precedence.** BM25 length normalisation lets a short document with one query term outrank a long document containing the exact phrase — the very failure being fixed (the golden test caught this on the first run). Lexical search is two-pass: exact-phrase matches rank strictly above term-only matches. Fusion consumes ranks, not scores, so the top lexical hit mathematically beats every semantic-only candidate.
- **Error asymmetry.** A semantic failure stays fatal (recall's pre-hybrid error surface is preserved); a lexical failure degrades to semantic-only with a warning. `LexicalIndex::new()` is infallible — an init failure yields a disabled instance whose operations all error, which callers already treat as degradation. This keeps `AppState::new` and the public API unchanged (semver-additive).
- **Scope filtering** reuses `ScopeFilter::matches` on scopes parsed from the canonical index key — identical semantics to recall's existing filtering, including hierarchical subtrees.
- **Wire surface.** Recall results gain `match_type` (`semantic`/`lexical`/`both`); `distance` is `null` for lexical-only hits. The recall log stores a `-1.0` sentinel for those, which distance-bucketed stats already exclude (`distance >= 0.0`). Tool description updated.

Out of scope, per #140: chunk-level embeddings (complementary, not a substitute).

## Test evidence

`cargo nextest run --workspace --no-fail-fast`: **297 passed, 2 skipped** (29 new tests). fmt, clippy `-D warnings`, `--features k8s`, and `cargo doc` all clean (remaining doc warnings pre-exist on main).

- **Golden test** (`tests/hybrid_recall.rs`): recreates the miss — a 3 KB multi-topic memory with the literal phrase "happy birthday" buried mid-document, 12 topically-adjacent decoys clustered around the query vector so semantic top-10 provably excludes the golden memory. Hybrid recall surfaces it; the assertion pins the exact RRF bound (only decoys matched by *both* strategies may outrank it).
- **BM25 unit tests**: upsert/remove/rebuild lifecycle, scope-filter parity (root-only, hierarchical subtree, all), case-insensitivity, exact-phrase-beats-length-normalisation, lenient query parsing (unbalanced quotes never error), deterministic tie-breaking, disabled-instance behaviour.
- **Fusion unit tests**: agreement boosting, lexical-only surfacing, deterministic tie-breaks, dedup, truncation.
- **Wire-contract tests**: exact key set of a recall result entry, numeric distance for semantic hits, `null` distance for lexical-only hits, `match_type` values.

Closes #55
