### PR TITLE
docs: reframe README and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to memory-mcp
+
+This project is a Rust MCP server with git-backed durable state and local
+retrieval indexes. Changes to storage, retrieval, wire contracts, or startup
+behavior can affect existing memory repositories, so keep proposals small,
+testable, and explicit about compatibility.
+
+## Set up a development checkout
+
+memory-mcp declares Rust 1.95 as its minimum supported version.
+
+```bash
+git clone https://github.com/butterflyskies/memory-mcp.git
+cd memory-mcp
+git config core.hooksPath .githooks
+cargo check
+```
+
+The repository uses [cargo-nextest](https://nexte.st/) for its full test suite.
+Some dependencies compile native code, so a C/C++ toolchain, CMake,
+`pkg-config`, and D-Bus development headers may be required on Linux.
+
+## Before writing code
+
+- Read the [architecture decision records](docs/adr/) before starting, then
+  revisit the records that govern your change. They are binding unless a new
+  decision explicitly supersedes one.
+- Search existing issues and pull requests before opening another lane for the
+  same problem.
+- Keep one coherent concern per change. Separate dependent concerns into
+  stacked pull requests rather than mixing unrelated work.
+- Preserve public APIs, on-disk memory formats, MCP response contracts, and
+  existing repository data unless the change intentionally includes a
+  compatible migration or versioned break.
+
+For a feature, migration, concurrency change, or other risky work, document the
+problem, requirements, architecture, risks, and test plan under `docs/design/`
+before implementation. Scale the artifact to the change; a local, reversible
+fix does not need a five-document ceremony.
+
+Write a new ADR when alternatives were seriously weighed or the change commits
+the project to an architectural pattern, dependency, security model, or public
+boundary. Follow the existing sequential naming and capture the decision,
+alternatives, consequences, and rationale.
+
+## Implement and test
+
+- Add behavioral tests with the change. Prefer in-process Tower tests over
+  spawning the server unless the binary's startup behavior is the subject.
+- Use `#[tokio::test(start_paused = true)]` for time-dependent behavior.
+- Avoid panics in production code; propagate domain errors through
+  `MemoryError`.
+- Keep public API additions deliberate and documented. `pub(crate)` is the
+  default for implementation details.
+- Update user documentation and `CHANGELOG.md` when behavior visible to users
+  changes.
+
+Run the repository gates before requesting review:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace -- -D warnings
+cargo doc --no-deps
+cargo nextest run --workspace --no-fail-fast
+cargo check --features k8s
+```
+
+Before a version bump, also run:
+
+```bash
+cargo nextest run --workspace --no-fail-fast --all-features
+cargo semver-checks check-release
+```
+
+The configured pre-commit hook runs formatting, clippy, rustdoc, and a staged
+secret scan. It complements the full test and feature checks; it does not
+replace them.
+
+## Open a pull request
+
+Explain the user-visible problem, the chosen behavior, and how the tests prove
+it. Link the issue or design artifact when one exists. Call out compatibility,
+failure recovery, operational impact, and follow-up work instead of leaving
+those decisions only in review comments.
+
+Do not merge or publish a release yourself. The maintainer handles merges and
+releases after review and required checks converge.
+
+Agent-specific workspace and review-loop instructions live in
+[AGENTS.md](AGENTS.md). Human contributors can use this document as the public
+entrypoint.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Significant choices and their trade-offs live in the
 - [Configuration](docs/configuration.md) — server flags, environment variables,
   authentication, and health endpoints
 - [Deployment](docs/deployment.md) — containers and Kubernetes
+- [Security](docs/security.md) — trust boundaries, credential handling,
+  hardened deployment, and supply-chain controls
 - [Architecture](docs/architecture.md) — storage, retrieval, sync, and
   operational boundaries
 - [Documentation map](docs/README.md) — guides, architecture, and contributor

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ that context into a durable system instead of another prompt appendix.
   concept search and a buried exact phrase can both succeed.
 - **Keep inference local.** Embeddings run on your machine with Candle and
   BGE-small-en-v1.5; no embedding API key is required.
-- **Move between machines.** The memory repository can sync through any git
-  remote supported by libgit2.
+- **Move between machines.** The memory repository can sync to a GitHub remote
+  using built-in token-backed authentication.
 - **Learn whether recall works.** Recall IDs and feedback tools turn retrieval
   quality into something you can measure.
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,44 @@
 # memory-mcp
 
-A semantic memory server for AI coding agents. Memories are stored as markdown files in a git repository and indexed for semantic retrieval using local embeddings — no API keys, no cloud dependency for inference.
+Durable, local-first memory for AI agents.
 
-Built on the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) so any compatible agent (Claude Code, Cursor, Windsurf, custom agents) can remember, recall, and sync knowledge across sessions and devices.
+memory-mcp gives any [Model Context Protocol](https://modelcontextprotocol.io/)
+client a memory it can inspect, search, and carry between sessions. Memories stay
+as Markdown in a git repository you control. Retrieval combines local semantic
+embeddings with BM25 keyword search, so both concepts and exact phrases can find
+their way back.
 
-## Why
+## Why memory-mcp?
 
-AI coding agents are stateless between sessions. They lose context about your preferences, your codebase's architecture, past decisions, and hard-won debugging knowledge. memory-mcp gives agents a persistent, searchable memory that:
+Agents forget the useful parts of yesterday: project decisions, debugging clues,
+working preferences, and the reason a strange constraint exists. memory-mcp turns
+that context into a durable system instead of another prompt appendix.
 
-- **Survives across sessions** — what an agent learned yesterday is available today
-- **Syncs across devices** — git push/pull keeps memories consistent everywhere
-- **Stays private** — embeddings run locally (no data leaves your machine), storage is a git repo you control
-- **Scales with you** — semantic search finds relevant memories even as the collection grows into hundreds or thousands
+- **Own the source of truth.** Memories are readable Markdown files with git
+  history, not rows trapped in a hosted service.
+- **Find meaning and wording.** Semantic and lexical rankings are fused, so a
+  concept search and a buried exact phrase can both succeed.
+- **Keep inference local.** Embeddings run on your machine with Candle and
+  BGE-small-en-v1.5; no embedding API key is required.
+- **Move between machines.** The memory repository can sync through any git
+  remote supported by libgit2.
+- **Learn whether recall works.** Recall IDs and feedback tools turn retrieval
+  quality into something you can measure.
 
 ## Quick start
 
-### Install from crates.io
+Install and start the server:
 
 ```bash
 cargo install memory-mcp
-```
-
-### Or from source
-
-```bash
-git clone https://github.com/butterflyskies/memory-mcp.git
-cd memory-mcp
-cargo build --release
-```
-
-### Run the server
-
-On first run, the embedding model (~130MB) is downloaded from HuggingFace Hub.
-You can pre-download it with `memory-mcp warmup`.
-
-```bash
-# Starts on 127.0.0.1:8080 with a local git repo at ~/.memory-mcp
-memory-mcp serve
-
-# Or configure via environment variables
-MEMORY_MCP_BIND=0.0.0.0:9090 \
-MEMORY_MCP_REPO_PATH=/path/to/memories \
 memory-mcp serve
 ```
 
-### Connect your editor
+The first run downloads the embedding model (about 130 MB) from Hugging Face.
+Run `memory-mcp warmup` first if you want to populate the model cache ahead of
+time.
 
-memory-mcp uses [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) transport. Most MCP clients support it natively.
-
-<details>
-<summary><strong>Claude Code</strong></summary>
-
-Add to `~/.claude.json` or your project's `.mcp.json`:
+Point an MCP client at the Streamable HTTP endpoint:
 
 ```json
 {
@@ -64,386 +51,120 @@ Add to `~/.claude.json` or your project's `.mcp.json`:
 }
 ```
 
-</details>
+Client configuration formats differ. See the
+[client setup guide](docs/clients.md) for ready-to-adapt examples.
 
-<details>
-<summary><strong>Cursor</strong></summary>
-
-Add to `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+Once connected, an agent can store a memory:
 
 ```json
-{
-  "mcpServers": {
-    "memory": {
-      "url": "http://localhost:8080/mcp"
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>VS Code (GitHub Copilot)</strong></summary>
-
-Add to `.vscode/mcp.json` in your workspace:
-
-```json
-{
-  "servers": {
-    "memory": {
-      "type": "http",
-      "url": "http://localhost:8080/mcp"
-    }
-  }
-}
-```
-
-Note: VS Code uses `"servers"` as the root key, not `"mcpServers"`.
-
-</details>
-
-<details>
-<summary><strong>Windsurf</strong></summary>
-
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "serverUrl": "http://localhost:8080/mcp"
-    }
-  }
-}
-```
-
-Note: Windsurf uses `"serverUrl"`, not `"url"`.
-
-</details>
-
-<details>
-<summary><strong>Continue.dev</strong></summary>
-
-Add to `.continue/mcpServers/memory.yaml`:
-
-```yaml
-mcpServers:
-  - name: memory
-    type: streamable-http
-    url: http://localhost:8080/mcp
-```
-
-</details>
-
-<details>
-<summary><strong>Claude Desktop</strong></summary>
-
-Add via **Settings > Connectors > Add custom server** with URL `http://localhost:8080/mcp`.
-
-Alternatively, use `mcp-remote` as a stdio bridge in `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "memory": {
-      "command": "npx",
-      "args": ["mcp-remote", "http://localhost:8080/mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary><strong>Zed</strong></summary>
-
-Zed does not yet support Streamable HTTP natively. Use `mcp-remote` as a stdio bridge in `~/.config/zed/settings.json`:
-
-```json
-{
-  "context_servers": {
-    "memory": {
-      "source": "custom",
-      "command": "npx",
-      "args": ["mcp-remote", "http://localhost:8080/mcp"]
-    }
-  }
-}
-```
-
-</details>
-
-The agent can now use `remember`, `recall`, `read`, `edit`, `forget`, `list`, and `sync` as tools.
-
-### Docker
-
-If you have Docker installed, the container image is the fastest way to get running — the embedding model is pre-baked so there's no download delay on first start:
-
-```bash
-docker run -d --name memory-mcp \
-  -p 8080:8080 \
-  -v ~/.memory-mcp:/data/repo \
-  ghcr.io/butterflyskies/memory-mcp:latest
-```
-
-The `-v` volume mount is required for persistence. Without it, memories are lost when the container stops.
-
-To sync memories across devices, initialize a git remote inside the mounted repo:
-
-```bash
-cd ~/.memory-mcp
-git init && git remote add origin git@github.com:you/my-memories.git
-```
-
-Then use the `sync` tool from your editor, or call `memory-mcp sync` directly.
-
-## Tools
-
-| Tool | Description |
-|------|-------------|
-| **remember** | Store a new memory with content, name, tags, and scope. Embeds and indexes it for semantic search. |
-| **recall** | Search memories by natural-language query. Returns the top matches ranked by semantic similarity. |
-| **read** | Fetch a specific memory by name with full content and metadata. |
-| **edit** | Update an existing memory. Supports partial updates — omit fields to preserve them. |
-| **forget** | Delete a memory by name. Removes from git and the search index. |
-| **list** | Browse all memories, optionally filtered by scope. |
-| **sync** | Push/pull the memory repo with a git remote. Handles conflicts via recency-based resolution. |
-
-Successful tool results include `_meta["memory-mcp/serverProcessingDurationMs"]`, measured
-from the server tool-handler boundary through result conversion. This is server processing
-time, not client round-trip time; clients should measure `clientRoundTripDurationMs` around
-the MCP call when end-to-end latency is needed.
-
-### Example: agent remembers a debugging insight
-
-```
-Tool: remember
 {
   "name": "postgres/connection-pool-timeout",
-  "content": "When the connection pool times out under load, the issue is usually...",
-  "tags": ["postgres", "debugging", "performance"],
+  "content": "Under burst load, check whether checkout_timeout is lower than the slowest query.",
+  "tags": ["postgres", "debugging"],
   "scope": "my-api"
 }
 ```
 
-### Example: agent recalls relevant context
+Then retrieve it by meaning or by the words it contains:
 
-```
-Tool: recall
+```json
 {
-  "query": "database connection issues under high load",
+  "query": "database connection failures during traffic spikes",
   "scope": "my-api",
   "limit": 5
 }
 ```
 
-## How it works
+For installation from source, Docker, a first-run walkthrough, and git sync,
+continue with [Getting started](docs/getting-started.md).
 
-```
-Agent ──MCP──▶ memory-mcp ──▶ candle (local BERT embeddings)
-                    │                    │
-                    ▼                    ▼
-              git repo            usearch HNSW index
-            (markdown files)    (semantic search)
+## What ships today
+
+memory-mcp exposes eleven MCP tools:
+
+| Job | Tools |
+|---|---|
+| Write and organize | `remember`, `edit`, `move`, `forget` |
+| Find and inspect | `recall`, `read`, `list` |
+| Synchronize | `sync` |
+| Improve retrieval | `mark_applied`, `batch_mark_applied`, `recall_stats` |
+
+`recall` runs semantic vector search and BM25 lexical search, then combines the
+ranked lists with reciprocal rank fusion. Results say whether they matched via
+`semantic`, `lexical`, or `both`. Exact phrases receive lexical precedence even
+when they are buried in long memories.
+
+Scopes are hierarchical namespaces such as `my-project` or
+`org/team/project`. Querying a scope includes that namespace, its descendants,
+and global memories. Omitting a scope searches global memories only; passing
+`all` explicitly searches every scope. Scopes organize retrieval. They are not
+an access-control boundary.
+
+See the [tool reference](docs/tools.md) for arguments, result contracts, scope
+behavior, and recall feedback.
+
+## How it fits together
+
+```text
+Agent ── Streamable HTTP ──▶ memory-mcp
+                                  │
+                    ┌─────────────┼─────────────┐
+                    ▼             ▼             ▼
+               Markdown + git   BM25          local embeddings
+               source of truth  lexical index HNSW vector index
                     │
                     ▼
-              git remote
-            (sync across devices)
+                git remote
 ```
 
-1. **Storage**: memories are markdown files with YAML frontmatter (tags, scope, timestamps) committed to a local git repository
-2. **Embeddings**: content is embedded locally using [candle](https://github.com/huggingface/candle) with a BERT model — no external API calls
-3. **Search**: embeddings are indexed in an HNSW graph ([usearch](https://github.com/unum-cloud/usearch)) for fast approximate nearest-neighbor search
-4. **Sync**: the git repo can push/pull to a remote (GitHub, GitLab, etc.) for cross-device sync with automatic conflict resolution
-5. **Auth**: GitHub tokens via OAuth device flow (`memory-mcp auth login`), stored in the system keyring or a Kubernetes Secret
+The Markdown repository is authoritative. Search indexes are derived from it and
+can be rebuilt. Memory content is embedded locally; it leaves the machine only
+when you deliberately sync the git repository to a remote.
 
-### Memory format
+Significant choices and their trade-offs live in the
+[architecture overview](docs/architecture.md) and
+[architecture decision records](docs/adr/), including
+[hybrid retrieval](docs/adr/0038-bm25-hybrid-retrieval.md).
 
-```markdown
----
-id: 550e8400-e29b-41d4-a716-446655440000
-name: postgres/connection-pool-timeout
-tags: [postgres, debugging, performance]
-scope:
-  type: Path
-  name: my-api
-created_at: 2026-03-18T12:00:00Z
-updated_at: 2026-03-18T12:00:00Z
-source: debugging-session
----
+## Documentation
 
-When the connection pool times out under load, the issue is usually...
-```
+- [Getting started](docs/getting-started.md) — install, run, connect, and sync
+- [Client setup](docs/clients.md) — MCP configuration examples
+- [Tool reference](docs/tools.md) — tool and retrieval contracts
+- [Configuration](docs/configuration.md) — server flags, environment variables,
+  authentication, and health endpoints
+- [Deployment](docs/deployment.md) — containers and Kubernetes
+- [Architecture](docs/architecture.md) — storage, retrieval, sync, and
+  operational boundaries
+- [Documentation map](docs/README.md) — guides, architecture, and contributor
+  references
+- [Contributing](CONTRIBUTING.md) — development setup, checks, design records,
+  and pull requests
+- [Roadmap](ROADMAP.md) — planned work and open epics
 
-### Scoping
+## Contributing
 
-Memories are organized into namespaces:
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, required
+checks, architecture/design expectations, and pull request guidance.
 
-- **`global`** — root namespace, available everywhere (preferences, standards, general knowledge)
-- **`my-project`** or **`org/team/project`** — path-based namespaces with hierarchical subtree queries (architecture decisions, debugging context, team conventions)
-
-Namespaces organize recall — they are not a security boundary. The legacy `project:{name}` form is still accepted but deprecated; use bare paths instead.
-
-## Configuration
-
-All options can be set via CLI flags or environment variables:
-
-| Flag | Env var | Default | Description |
-|------|---------|---------|-------------|
-| `--bind` | `MEMORY_MCP_BIND` | `127.0.0.1:8080` | Address to bind the HTTP server |
-| `--repo-path` | `MEMORY_MCP_REPO_PATH` | `~/.memory-mcp` | Path to the git-backed memory repository |
-| `--mcp-path` | `MEMORY_MCP_PATH` | `/mcp` | URL path for the MCP endpoint |
-| `--remote-url` | `MEMORY_MCP_REMOTE_URL` | *(none)* | Git remote URL. Omit for local-only mode. |
-| `--branch` | `MEMORY_MCP_BRANCH` | `main` | Branch for push/pull operations |
-| `--max-sessions` | `MEMORY_MCP_MAX_SESSIONS` | `100` | Maximum concurrent MCP sessions |
-| `--session-rate-limit` | `MEMORY_MCP_SESSION_RATE_LIMIT` | `10` | Max new sessions per rate-limit window (0 to disable) |
-| `--session-rate-window-secs` | `MEMORY_MCP_SESSION_RATE_WINDOW_SECS` | `60` | Rate-limit window duration in seconds |
-| `--idle-timeout-secs` | `MEMORY_MCP_IDLE_TIMEOUT_SECS` | `14400` | Idle timeout for sessions in seconds (0 to disable) |
-| `--max-session-lifetime-secs` | `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS` | `0` (disabled) | Absolute max session lifetime in seconds (0 to disable) |
-| `--embed-timeout-secs` | `MEMORY_MCP_EMBED_TIMEOUT_SECS` | `30` | Max seconds per embedding call before timeout |
-| `--embed-queue-size` | `MEMORY_MCP_EMBED_QUEUE_SIZE` | `64` | Embedding request queue capacity |
-| `--require-remote-sync` | `MEMORY_MCP_REQUIRE_REMOTE_SYNC` | `false` | Include sync health in readiness checks. Performs initial pull at startup. |
-| `--health-stale-secs` | `MEMORY_MCP_HEALTH_STALE_SECS` | `0` (disabled) | Seconds before a subsystem with no activity is considered stale. 0 disables. |
-
-## Authentication
-
-For syncing with a private GitHub remote:
+The core verification loop is:
 
 ```bash
-# Interactive OAuth device flow — opens browser, stores token in keyring
-memory-mcp auth login
-
-# Or specify storage explicitly
-memory-mcp auth login --store keyring   # system keyring (default)
-memory-mcp auth login --store file      # ~/.config/memory-mcp/token
-memory-mcp auth login --store stdout    # print token, pipe to your own storage
-
-# Kubernetes deployments (requires --features k8s)
-memory-mcp auth login --store k8s-secret
-
-# Check current auth status
-memory-mcp auth status
-```
-
-Token resolution order: `MEMORY_MCP_GITHUB_TOKEN` env var → `~/.config/memory-mcp/token` file → system keyring.
-
-## Embedding model
-
-Embeddings are computed locally using [candle](https://github.com/huggingface/candle) with [BGE-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) (384 dimensions). The model is downloaded from HuggingFace Hub on first run — no API keys required. Use `memory-mcp warmup` to pre-download.
-
-A dedicated worker thread processes embedding requests sequentially. If a call exceeds `--embed-timeout-secs`, the caller gets an error but the worker recovers automatically and picks up the next request. Panics in the inference engine are caught and recovered from without killing the worker. On startup, the vector index is checked against the repo HEAD and rebuilt if stale or missing (e.g. after a crash).
-
-## Health endpoints
-
-| Endpoint | Purpose | Status code |
-|----------|---------|-------------|
-| `GET /healthz` | Liveness probe — process is running | Always 200 |
-| `GET /readyz` | Readiness probe — subsystems operational | 200 or 503 |
-
-`/readyz` returns structured JSON with per-subsystem status:
-
-```json
-{
-  "status": "ready",
-  "checks": {
-    "git_repo": { "status": "up" },
-    "embedding": { "status": "up" },
-    "vector_index": { "status": "up" },
-    "sync": { "status": "up" }
-  }
-}
-```
-
-The `sync` field appears only when `--require-remote-sync` is enabled. Subsystems report their own health passively during normal operations — the handler reads the latest state with zero probing.
-
-When `--health-stale-secs` is set (e.g. `300`), a subsystem with no successful operations within that window is reported as `"down"` with reason `"stale"`. Disabled by default to prevent idle pods from being evicted.
-
-## Deployment
-
-### Container image
-
-```bash
-# Pull from GitHub Container Registry
-docker pull ghcr.io/butterflyskies/memory-mcp:latest
-
-# Or build locally
-docker build -t memory-mcp .
-```
-
-The container image:
-- Uses a multi-stage build (compile → model warmup → slim runtime)
-- Ships with the embedding model pre-downloaded (no internet needed at startup)
-- Runs as a non-root user (`memory-mcp`, uid 1000)
-- Includes SLSA provenance and SBOM attestations
-
-### Kubernetes
-
-Manifests are provided in `deploy/k8s/`:
-
-```bash
-kubectl apply -f deploy/k8s/namespace.yml
-kubectl apply -f deploy/k8s/rbac.yml
-kubectl apply -f deploy/k8s/pvc.yml
-kubectl apply -f deploy/k8s/service.yml
-kubectl apply -f deploy/k8s/deployment.yml
-```
-
-The deployment is hardened with:
-- `readOnlyRootFilesystem`, `runAsNonRoot`, `drop: [ALL]` capabilities
-- Split ServiceAccounts (runtime vs bootstrap)
-- Seccomp `RuntimeDefault` profile
-- Liveness (`/healthz`) and readiness (`/readyz`) probes
-
-See [docs/deployment.md](docs/deployment.md) for the full guide.
-
-## Architecture decisions
-
-Significant design decisions are documented as Architecture Decision Records in [`docs/adr/`](docs/adr/). Each ADR captures the context, decision, and consequences of a choice — giving future contributors the "why" behind the codebase.
-
-## Security
-
-- **Local inference**: embeddings are computed on your machine. Memory content never leaves your network unless you push to a remote.
-- **Token handling**: tokens are stored in the system keyring (or Kubernetes Secrets), never in CLI arguments or git history. Process umask is set to `0o077`.
-- **Input validation**: memory names, content size, and nesting depth are validated. Path traversal and symlink attacks are blocked.
-- **Container hardening**: non-root user, read-only filesystem, dropped capabilities, seccomp profile.
-- **Supply chain**: CI pins all GitHub Actions to commit SHAs. Container images include SLSA provenance and SBOM attestations. Dependencies are audited with `cargo audit` on every build.
-
-## Roadmap
-
-The core memory engine is stable — store, search, sync, and authenticate all work today. Planned next:
-
-- **BM25 keyword search** alongside semantic search ([#55](https://github.com/butterflyskies/memory-mcp/issues/55))
-- **Cross-platform vector index** with brute-force fallback for Windows ([#56](https://github.com/butterflyskies/memory-mcp/issues/56))
-- **Deduplication** on remember (semantic similarity threshold)
-- **Tag-based filtering** in recall
-- **Richer observability** with structured tracing across all subsystems ([#52](https://github.com/butterflyskies/memory-mcp/issues/52))
-
-See [ROADMAP.md](ROADMAP.md) for the full development plan and [open issues](https://github.com/butterflyskies/memory-mcp/issues) for what's in flight.
-
-## Development
-
-```bash
-# Run tests
 cargo nextest run --workspace --no-fail-fast
-
-# With Kubernetes feature
-cargo nextest run --workspace --no-fail-fast --features k8s
-
-# Lint
 cargo fmt --check
 cargo clippy --workspace -- -D warnings
-
-# Audit dependencies
-cargo audit
+cargo doc --no-deps
 ```
+
+Repository conventions, required checks, and the review loop are documented in
+[CONTRIBUTING.md](CONTRIBUTING.md). Agent-specific workspace instructions live
+separately in [AGENTS.md](AGENTS.md).
 
 ## License
 
-Licensed under either of
+Licensed under either
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](LICENSE-MIT))
 
 at your option.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 
 ## What memory-mcp is
 
-A semantic memory system for AI coding agents. Memories are stored as markdown files in a git repository, indexed locally for semantic retrieval, and synced to a remote. Shipped as a single binary (Rust, candle for local embedding, usearch for HNSW vector index) speaking MCP over streamable HTTP.
+A hybrid memory system for AI coding agents. Memories are stored as markdown files in a git repository, indexed locally for semantic and BM25 lexical retrieval, and synced to a remote. It ships as a single Rust binary speaking MCP over Streamable HTTP.
 
 ## Where it's heading
 
@@ -27,7 +27,7 @@ The highest-priority epic. memory-mcp#262 (HyperMem bridge — graph-aware chunk
 | #262 | Graph-aware chunk index for retrieval (HyperMem bridge) | **Active** |
 | #141 | Upgrade to ModernBERT Embed (8192 token context) | Open |
 | #140 | Chunk long memories for embedding | Open |
-| #55 | BM25 keyword search via Tantivy | Open |
+| #55 | BM25 keyword search via Tantivy | Completed in #308 |
 | #148 | Tag-based filtering in recall | Open |
 | #197 | Threshold-based recall: auto-expand until relevance drops | Open |
 | #129 | Memory consolidation, write discipline, quality metrics | Open |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ first success.
 - [Configuration](configuration.md) — server flags, environment variables,
   authentication, model settings, and health endpoints
 - [Deployment](deployment.md) — run the container image or deploy to Kubernetes
+- [Security](security.md) — trust boundaries, credentials, container hardening,
+  and supply-chain controls
 
 ## Understand and change memory-mcp
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# memory-mcp documentation
+
+The root [README](../README.md) explains why memory-mcp exists and gets a new
+user to a working server. This directory holds the detail needed after that
+first success.
+
+## Use memory-mcp
+
+- [Getting started](getting-started.md) — install, start the server, create a
+  first memory, and configure git sync
+- [Client setup](clients.md) — connect common MCP clients over Streamable HTTP
+- [Tool reference](tools.md) — tool arguments, retrieval behavior, scopes, and
+  feedback
+- [Configuration](configuration.md) — server flags, environment variables,
+  authentication, model settings, and health endpoints
+- [Deployment](deployment.md) — run the container image or deploy to Kubernetes
+
+## Understand and change memory-mcp
+
+- [Contributing](../CONTRIBUTING.md) — development setup, required checks,
+  design records, and pull request expectations
+- [Architecture overview](architecture.md) — current storage, retrieval, sync,
+  and operational boundaries
+- [Architecture decision records](adr/) — binding design decisions and their
+  trade-offs
+- [Design artifacts](design/) — feature design documents produced before
+  implementation
+- [Roadmap](../ROADMAP.md) — open epics and completed work
+- [Changelog](../CHANGELOG.md) — released changes
+
+These Markdown files are arranged so they can become the source of a generated
+documentation site without making that publishing machinery a prerequisite for
+maintaining useful docs today.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,14 @@ content.
 The Markdown repository remains authoritative. Indexes are rebuilt or updated
 from repository state rather than becoming another memory store.
 
+The lexical index is rebuilt from the repository at startup, and later git
+mutations are mirrored into it. Those mirrors follow a complete-or-degraded
+contract. A failed or interrupted mirror is never served as current: recall
+temporarily falls back to semantic-only results while a single-flight
+background repair rebuilds the lexical index from git truth. Repair is also
+retried after startup rebuild failures and when recall observes degradation.
+Lexical degradation does not gate readiness.
+
 ## Scopes
 
 `global` is the root namespace. Bare paths such as `project` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,81 @@
+# Architecture
+
+memory-mcp is a single Rust binary that serves Model Context Protocol over
+Streamable HTTP. Its durable state is a git repository of Markdown files;
+retrieval indexes and recall telemetry are local derived state.
+
+```text
+MCP client
+    │ Streamable HTTP
+    ▼
+Axum + rmcp server
+    ├── MemoryRepo ──▶ Markdown + YAML frontmatter ──▶ git remote
+    ├── CandleEmbeddingEngine ──▶ scope-partitioned usearch indexes
+    ├── LexicalIndex ──▶ in-memory Tantivy BM25 index
+    └── RecallLog ──▶ local SQLite telemetry
+```
+
+## Durable source of truth
+
+Each memory is a Markdown file with YAML frontmatter containing its stable ID,
+name, scope, tags, source, and timestamps. Repository operations stage and
+commit changes through libgit2. The files remain readable and editable without
+memory-mcp, and git preserves their history.
+
+The remote is optional. `sync` pulls, resolves conflicts by `updated_at`, and
+pushes the configured branch. Authentication is acquired only when remote work
+needs it.
+
+## Retrieval
+
+Two derived indexes answer different questions:
+
+- Candle embeds memory content with BGE-small-en-v1.5. usearch stores the
+  vectors in scope-partitioned HNSW indexes for conceptual similarity.
+- Tantivy indexes names and content in memory for BM25 term and exact-phrase
+  retrieval.
+
+`recall` runs both strategies and combines ranks with reciprocal rank fusion.
+The response records whether each result came from semantic search, lexical
+search, or both. Search results carry snippets; callers use `read` for complete
+content.
+
+The Markdown repository remains authoritative. Indexes are rebuilt or updated
+from repository state rather than becoming another memory store.
+
+## Scopes
+
+`global` is the root namespace. Bare paths such as `project` and
+`org/team/project` create hierarchical namespaces. Scope selection determines
+which indexes and repository subtrees a query searches. It does not decide who
+is authorized to read a memory.
+
+## Concurrency and blocking work
+
+The asynchronous HTTP server keeps blocking components behind explicit seams:
+
+- a dedicated worker thread owns the Candle model and serves a bounded queue;
+- libgit2 and SQLite operations run through blocking boundaries;
+- lexical mutations are batched and committed on Tokio's blocking pool;
+- passive subsystem reporters make readiness checks avoid repository or model
+  I/O.
+
+MCP sessions are bounded by count, rate, idle timeout, and optional maximum
+lifetime.
+
+## Telemetry
+
+Structured tracing covers tool handlers and subsystem operations. Successful
+tool responses include server processing duration metadata.
+
+Recall events are written to local SQLite. `mark_applied` and
+`batch_mark_applied` attach usefulness verdicts to a recall, and `recall_stats`
+aggregates them by semantic distance. Telemetry is local derived state and does
+not sync with the Markdown repository.
+
+## Decisions and change control
+
+The [architecture decision records](adr/) are binding. They document transport,
+storage, indexes, authentication, health reporting, metadata, and retrieval
+trade-offs. New architecture changes should update or supersede those records
+rather than silently changing this overview.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,97 @@
+# Client setup
+
+memory-mcp exposes MCP over Streamable HTTP. The default endpoint is
+`http://localhost:8080/mcp`.
+
+Client configuration formats evolve independently from memory-mcp. Treat these
+examples as starting points and consult the client documentation when a current
+release rejects a field or location.
+
+## Claude Code
+
+Add to `~/.claude.json` or a project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+## Cursor
+
+Add to `.cursor/mcp.json` for a project or `~/.cursor/mcp.json` globally:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+## Visual Studio Code with GitHub Copilot
+
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "memory": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+Visual Studio Code uses `servers` as the root key rather than `mcpServers`.
+
+## Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "serverUrl": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+## Continue
+
+Add `.continue/mcpServers/memory.yaml`:
+
+```yaml
+mcpServers:
+  - name: memory
+    type: streamable-http
+    url: http://localhost:8080/mcp
+```
+
+## Clients that require stdio
+
+memory-mcp intentionally ships only Streamable HTTP. A client without native
+HTTP support can use a bridge such as `mcp-remote`:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:8080/mcp"]
+    }
+  }
+}
+```
+
+The bridge is a separate process and dependency; it is not part of memory-mcp.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,78 @@
+# Configuration
+
+Server options are available as command-line flags and environment variables.
+Run `memory-mcp serve --help` against your installed version for the complete,
+authoritative list.
+
+## Server
+
+| Flag | Environment variable | Default | Purpose |
+|---|---|---|---|
+| `--bind` | `MEMORY_MCP_BIND` | `127.0.0.1:8080` | HTTP listener address |
+| `--repo-path` | `MEMORY_MCP_REPO_PATH` | `~/.memory-mcp` | Git-backed memory repository |
+| `--mcp-path` | `MEMORY_MCP_PATH` | `/mcp` | Streamable HTTP MCP path |
+| `--remote-url` | `MEMORY_MCP_REMOTE_URL` | unset | Git remote; omit for local-only mode |
+| `--branch` | `MEMORY_MCP_BRANCH` | `main` | Branch used for push and pull |
+| `--allowed-host` | `MEMORY_MCP_ALLOWED_HOST` | none | Additional accepted HTTP Host value; repeatable |
+| `--require-remote-sync` | `MEMORY_MCP_REQUIRE_REMOTE_SYNC` | `false` | Make remote sync health affect readiness |
+| `--recall-log-busy-timeout` | `MEMORY_MCP_RECALL_LOG_BUSY_TIMEOUT` | `5` | SQLite lock wait in seconds |
+| `--health-stale-secs` | `MEMORY_MCP_HEALTH_STALE_SECS` | `0` | Mark inactive subsystems stale; 0 disables |
+
+## Sessions and embedding work
+
+| Flag | Environment variable | Default | Purpose |
+|---|---|---|---|
+| `--max-sessions` | `MEMORY_MCP_MAX_SESSIONS` | `100` | Maximum concurrent MCP sessions |
+| `--session-rate-limit` | `MEMORY_MCP_SESSION_RATE_LIMIT` | `10` | New sessions per rate window; 0 disables |
+| `--session-rate-window-secs` | `MEMORY_MCP_SESSION_RATE_WINDOW_SECS` | `60` | Session rate-limit window |
+| `--idle-timeout-secs` | `MEMORY_MCP_IDLE_TIMEOUT_SECS` | `14400` | Session idle timeout; 0 disables |
+| `--max-session-lifetime-secs` | `MEMORY_MCP_MAX_SESSION_LIFETIME_SECS` | `0` | Absolute session lifetime; 0 disables |
+| `--embed-timeout-secs` | `MEMORY_MCP_EMBED_TIMEOUT_SECS` | `30` | Maximum time for one embedding call |
+| `--embed-queue-size` | `MEMORY_MCP_EMBED_QUEUE_SIZE` | `64` | Bounded embedding-worker queue |
+
+Builds with the `otlp` feature also expose `--otlp-required` and
+`--otlp-optional` (and matching `MEMORY_MCP_*` variables) to select strict or
+best-effort OTLP span export.
+
+## Authentication
+
+Authenticate to a private GitHub remote with the OAuth device flow:
+
+```bash
+memory-mcp auth login
+memory-mcp auth status
+```
+
+Select storage explicitly when needed:
+
+```bash
+memory-mcp auth login --store keyring
+memory-mcp auth login --store file
+memory-mcp auth login --store stdout
+```
+
+Builds with the `k8s` feature also support `--store k8s-secret`.
+
+At runtime, token resolution checks `MEMORY_MCP_GITHUB_TOKEN`, then the token
+file, then the system keyring. Tokens are never accepted as CLI arguments.
+
+## Embedding model
+
+memory-mcp computes embeddings locally with Candle and BGE-small-en-v1.5
+(384 dimensions). Model files use the Hugging Face cache under `HF_HOME`.
+`memory-mcp warmup` downloads them without starting the server.
+
+A dedicated worker thread owns the embedding engine. The queue is bounded, and
+a timed-out request does not permanently wedge the worker.
+
+## Health endpoints
+
+| Endpoint | Contract |
+|---|---|
+| `GET /healthz` | Liveness; returns 200 while the HTTP process is serving. |
+| `GET /readyz` | Readiness; returns 200 or 503 with passive subsystem status. |
+| `GET /version` | Build and version information. |
+
+`/readyz` reports git, embedding, vector-index, and optional sync health without
+performing I/O inside the probe handler. See [Deployment](deployment.md) for
+Kubernetes manifests and operational guidance.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,8 @@
 # Deployment
 
+For the deployment trust boundary and hardening controls, see
+[Security](security.md).
+
 ## Quick start (any Kubernetes cluster)
 
 The manifests in `deploy/k8s/` are generic and work on any cluster.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,128 @@
+# Getting started
+
+This guide takes memory-mcp from installation to a first successful recall.
+
+## Install
+
+From crates.io:
+
+```bash
+cargo install memory-mcp
+```
+
+Or build the current source:
+
+```bash
+git clone https://github.com/butterflyskies/memory-mcp.git
+cd memory-mcp
+cargo install --path .
+```
+
+## Start the server
+
+```bash
+memory-mcp serve
+```
+
+By default, memory-mcp listens on `127.0.0.1:8080`, exposes MCP at
+`/mcp`, and stores memories in `~/.memory-mcp`.
+
+The first run downloads BGE-small-en-v1.5 (about 130 MB) from Hugging Face.
+Pre-download it when preparing an offline or reproducible environment:
+
+```bash
+memory-mcp warmup
+```
+
+To change the bind address or repository location:
+
+```bash
+MEMORY_MCP_BIND=0.0.0.0:9090 \
+MEMORY_MCP_REPO_PATH=/path/to/memories \
+memory-mcp serve
+```
+
+See [Configuration](configuration.md) for the complete runtime surface.
+
+## Connect an MCP client
+
+Configure the client to use the Streamable HTTP endpoint
+`http://localhost:8080/mcp`. For example, clients using the common
+`mcpServers` shape accept:
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+See [Client setup](clients.md) for client-specific locations and field names.
+
+## Store and retrieve a memory
+
+Ask the connected agent to call `remember`:
+
+```json
+{
+  "name": "postgres/connection-pool-timeout",
+  "content": "Under burst load, check whether checkout_timeout is lower than the slowest query.",
+  "tags": ["postgres", "debugging"],
+  "scope": "my-api"
+}
+```
+
+Then ask it to call `recall`:
+
+```json
+{
+  "query": "database connection failures during traffic spikes",
+  "scope": "my-api",
+  "limit": 5
+}
+```
+
+`recall` combines semantic and keyword rankings. Each result reports its
+`match_type`, a content snippet, and whether the snippet was truncated. Use
+`read` before acting on a truncated result.
+
+## Run with Docker
+
+The published image contains the embedding model, so startup does not need to
+download it:
+
+```bash
+docker run -d --name memory-mcp \
+  -p 8080:8080 \
+  -v "$HOME/.memory-mcp:/data/repo" \
+  ghcr.io/butterflyskies/memory-mcp:latest
+```
+
+The volume is required for persistence. Without it, memories disappear with
+the container.
+
+## Configure git sync
+
+memory-mcp works without a remote. To share the repository across machines,
+configure a remote URL when starting the server:
+
+```bash
+MEMORY_MCP_REMOTE_URL=https://github.com/you/my-memories.git \
+memory-mcp serve
+```
+
+Authenticate first when the remote requires a GitHub token:
+
+```bash
+memory-mcp auth login
+```
+
+The connected agent can then call the `sync` MCP tool. There is no standalone
+`memory-mcp sync` CLI subcommand.
+
+For private remotes, token storage, containers, and Kubernetes, continue with
+[Configuration](configuration.md) and [Deployment](deployment.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,67 @@
+# Security
+
+## Security boundaries
+
+memory-mcp keeps inference and derived search indexes local. Memories remain
+plaintext Markdown in the managed git repository, and their content leaves the
+machine only when an operator deliberately configures and invokes GitHub sync.
+
+Namespace scopes organize retrieval; they are not access-control boundaries.
+The MCP HTTP endpoint does not authenticate clients, so keep the default
+loopback binding or place a remotely exposed endpoint behind an authenticated
+TLS gateway and appropriate network policy.
+
+## Credentials and local files
+
+GitHub tokens are resolved from `MEMORY_MCP_GITHUB_TOKEN`, an owner-readable
+token file, or the system keyring. Kubernetes deployments can inject a token
+from a Secret through the environment variable. The CLI does not accept tokens
+as arguments, and credentials are not written to the memory repository. On
+Unix, the file store creates its directory with mode `0o700` and token file
+with mode `0o600`; memory-mcp also sets process umask `0o077` before creating
+files so group and other permissions are masked off by default.
+
+## Input and repository safety
+
+Memory names, content size, and nesting depth are validated at input
+boundaries. Content is capped at 1 MiB and names at three path components.
+Repository access rejects path traversal and symlink-based escapes, including
+no-follow file opens on supported Unix targets. These checks protect the
+managed repository; they do not turn scopes into authorization policy.
+
+## Container hardening
+
+The provided image runs as the non-root `memory-mcp` user (UID 1000). The
+provided Kubernetes deployment adds controls that the image alone cannot
+enforce: `runAsNonRoot`, a read-only root filesystem, disabled privilege
+escalation, all Linux capabilities dropped, the `RuntimeDefault` seccomp
+profile, and separate runtime and token-bootstrap service accounts. Review and
+preserve those settings when adapting the manifests.
+
+The persistent memory repository and any writable caches still need writable
+volumes with deployment-appropriate access controls. See
+[Deployment](deployment.md) for the concrete manifests and operational notes.
+
+## Supply-chain evidence and audit
+
+External GitHub Actions used by the repository are pinned to full commit SHAs.
+CI-published GHCR images are accompanied by BuildKit provenance in the SLSA
+predicate format and by SBOM attestations; this does not claim a particular
+SLSA level, and local `docker build` output is not attested. Treat those
+attestations as evidence to verify, not as a substitute for registry policy or
+image-signature enforcement.
+
+CI runs `cargo deny check` against RustSec advisories and the repository's
+license, ban, and source policies. Release binaries are built with
+`cargo-auditable`, embedding dependency metadata for later inspection. The
+implementing controls are visible in the
+[CI workflow](../.github/workflows/build.yml),
+[image publishing workflow](../.github/workflows/publish-image.yml), and
+[`deny.toml`](../deny.toml).
+
+## Known limits
+
+memory-mcp currently has no application-layer client authentication,
+authorization policy, or security audit log. Recall feedback is local retrieval
+telemetry, not an audit trail. Protect the endpoint, plaintext repository,
+token, and remote using deployment controls appropriate to their sensitivity.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # MCP tool reference
 
-memory-mcp exposes twelve tools. Tool schemas returned during MCP discovery are
+memory-mcp exposes eleven tools. Tool schemas returned during MCP discovery are
 the authoritative machine-readable contract; this page explains how the tools
 fit together.
 
@@ -17,6 +17,19 @@ fit together.
 
 Memory names may contain up to three path components. Names and scopes are
 validated before they become filesystem paths.
+
+### `list`
+
+`list` returns a bounded page of summaries sorted by scope and name. `limit`
+defaults to 50 and accepts values from 1 through 100. When `has_more` is true,
+pass the opaque `next_cursor` into the next request with the same scope. The
+response distinguishes `count` (all matching memories) from `returned` (this
+page). Cursors use keyset semantics, so concurrent inserts or deletes can change
+later pages without invalidating the cursor.
+
+Use `fields` to request an exact summary projection. Omitting it returns `id`,
+`name`, `scope`, `tags`, `created_at`, and `updated_at`. Each successful page is
+capped at 24 KiB; request fewer fields if a summary is too large.
 
 ## Retrieval
 
@@ -43,6 +56,11 @@ The ranked lists are merged with reciprocal rank fusion. A result includes:
 
 Lower non-negative distances are more similar. Do not interpret `-1.0` as a
 high-confidence semantic match; it means the result had no embedding distance.
+
+If a lexical-index update fails or is interrupted, memory-mcp marks that
+derived index degraded rather than serving stale keyword results. Recall
+continues with semantic-only results while a single-flight background repair
+rebuilds the lexical index from the git-backed source of truth.
 
 ## Scopes
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,87 @@
+# MCP tool reference
+
+memory-mcp exposes twelve tools. Tool schemas returned during MCP discovery are
+the authoritative machine-readable contract; this page explains how the tools
+fit together.
+
+## Memory lifecycle
+
+| Tool | Purpose |
+|---|---|
+| `remember` | Store content, tags, source, and an optional scope; commit it to git and index it. |
+| `read` | Fetch one memory's complete content and metadata by name and scope. |
+| `edit` | Replace content or tags while preserving omitted fields. |
+| `move` | Atomically move a memory to another scope, optionally renaming it. |
+| `forget` | Delete a memory from git and the search indexes. |
+| `list` | List memory summaries without full content. |
+
+Memory names may contain up to three path components. Names and scopes are
+validated before they become filesystem paths.
+
+## Retrieval
+
+### `recall`
+
+`recall` accepts a natural-language `query`, an optional `scope`, and an
+optional `limit` (default 5).
+
+It runs two independent retrieval strategies:
+
+1. local embeddings search the scope-partitioned HNSW vector indexes;
+2. Tantivy searches the in-memory BM25 lexical index, with exact phrases ranked
+   ahead of term-only matches.
+
+The ranked lists are merged with reciprocal rank fusion. A result includes:
+
+- `name`, `scope`, and `tags`;
+- a content snippet of at most 500 characters;
+- `truncated` and `content_length`, so a caller knows when to use `read`;
+- `match_type`: `semantic`, `lexical`, or `both`;
+- `distance`: cosine distance for semantic hits, or `-1.0` for lexical-only
+  hits;
+- a batch-level `recall_id` used by the feedback tools.
+
+Lower non-negative distances are more similar. Do not interpret `-1.0` as a
+high-confidence semantic match; it means the result had no embedding distance.
+
+## Scopes
+
+Scopes are hierarchical namespace paths:
+
+- omit scope or pass `global` to query global memories only;
+- pass `my-project` to query that subtree plus global memories;
+- pass `org/team` to include `org/team` and descendant scopes plus global;
+- pass `all` to explicitly query every scope.
+
+Point tools (`remember`, `read`, `edit`, `move`, and `forget`) address one exact
+scope. Omitting their scope targets global.
+
+Scopes organize storage and retrieval. They do not enforce authorization.
+
+## Synchronization
+
+`sync` pulls before pushing by default. It requires a configured remote for
+remote work; local-only deployments return without trying to push. Git conflicts
+are resolved using the timestamps stored in memory frontmatter, with warnings
+recording the resolution.
+
+## Recall feedback
+
+Every recall returns a `recall_id`. Once an agent decides whether a result was
+useful, it can report:
+
+- `mark_applied` for one result;
+- `batch_mark_applied` for several results in one transaction;
+- `recall_stats` to inspect applied, maybe, not-applied, and unknown results by
+  distance bucket.
+
+Verdicts are `applied`, `maybe`, or `not_applied`. Confidence is `high`,
+`medium`, or `low`. The feedback log is local SQLite telemetry; it is not stored
+in the Markdown memory repository or synced through git.
+
+## Timing metadata
+
+Successful MCP tool results include
+`_meta["memory-mcp/serverProcessingDurationMs"]`. It measures work from the
+server's tool-handler boundary through result conversion. It does not include
+network or client processing time.


### PR DESCRIPTION
## Why

The root README had grown into a 449-line mixture of landing page, client matrix, tool and configuration reference, deployment guide, architecture sketch, and roadmap. It also still described semantic-only retrieval after #308 merged and omitted several shipped tools.

This draft gives memory-mcp a short public front door: explain the value, bootstrap a working server, and route deeper questions into focused documentation.

## What changed

- Reframed the README around durable git-backed memory, local inference, and hybrid semantic + BM25 retrieval.
- Added focused guides for getting started, client setup, tools, configuration, and current architecture.
- Added a documentation map arranged so the Markdown can later become an mdBook-style site without requiring publishing machinery now.
- Added a public `CONTRIBUTING.md`; `AGENTS.md` remains the agent-specific repository entrypoint.
- Corrected the roadmap to mark BM25 issue #55 complete in #308.
- Removed the stale suggestion that `memory-mcp sync` exists as a CLI subcommand; sync is an MCP tool.

## Documentation split

- **README:** sell the work and get a reader to first success.
- **Guides:** installation, client wiring, and first use.
- **Reference:** tools, configuration, and deployment.
- **Architecture:** current system shape plus binding ADRs.
- **Contributing:** public setup, design expectations, checks, and PR flow.

## Validation

- `git diff --check`
- internal Markdown target audit across README, contributing, roadmap, docs, and ADRs
- `cargo run --quiet -- serve --help` cross-check against the configuration reference
- attribution and commit-trailer sweep
- `cargo doc --no-deps` (completed with six pre-existing intra-doc-link warnings outside this docs diff)

## Draft follow-ups before ready for review

This PR intentionally remains draft while the release-safety work is in flight.

- Reconcile startup, readiness, degraded-mode, and lexical repair documentation after #310 establishes the failure/repair contract.
- Reconcile health and lifecycle documentation with ADR-0039 and its listener-first/probe implementation once that work is merged or pinned for review.
- Refresh any affected examples and operational claims against the resulting code before marking this PR ready.

No unmerged #310 or ADR-0039 behavior is presented here as shipped.
