### PR TITLE
docs: reconcile agent instructions with standing policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,81 @@
 # Agent Instructions
 
-## Before you start
+## Authority and orientation
 
-Read all ADRs in `docs/adr/` — they capture binding architectural decisions and constraints. Respect them unless explicitly superseded.
+- Explicit maintainer direction for the current task supersedes repository guidance. If they conflict, surface the conflict and update the durable guidance; do not silently choose the older rule.
+- Read the ADRs applicable to the area you are changing. Respect their status: **Accepted** decisions are binding, **Proposed** decisions are context, and **Superseded** decisions are historical. If an Accepted ADR conflicts with current code, workflows, or maintainer direction, flag it for reconciliation.
 
 ## Pre-commit
 
-A `.githooks/` hook runs several checks before every commit. Activate it once per clone:
+A `.githooks/` hook runs local checks before every commit. Activate and verify it once per clone:
 
 ```sh
 git config core.hooksPath .githooks
+git config --get core.hooksPath
 ```
 
-The hook runs four checks in order:
+The hook runs, in order:
 
-1. **`cargo fmt --check`** — formatting. If rejected, run `cargo fmt` and retry.
-2. **`cargo clippy -- -D warnings`** — lint. Fix all warnings before committing.
-3. **`cargo doc --no-deps`** — doc warnings (broken intra-doc links, missing public docs). Fix before committing.
-4. **`gitleaks protect --staged`** — secrets scan. Development-time dependency; install separately: <https://github.com/gitleaks/gitleaks>. If not installed, the hook warns and continues — it does not block the commit.
+1. `cargo fmt -- --check`
+2. `cargo clippy -- -D warnings`
+3. `cargo doc --no-deps`, rejecting warnings
+4. `gitleaks protect --staged` when `gitleaks` is installed; otherwise it warns and continues
 
-Before every commit, also ensure these pass (not enforced by the hook):
+## Verification
 
-1. `cargo test`
-2. `cargo check --features k8s`
-
-## Testing
-
-- Full suite: `cargo nextest run --workspace --no-fail-fast`
-- Before version bumps: add `--all-features`
-- Prefer in-process tests (`tower::ServiceExt::oneshot`) over subprocess tests
-- Use `#[tokio::test(start_paused = true)]` for time-dependent tests
-- Production code uses `?` / `.map_err()` — never `.unwrap()`. Tests can `.unwrap()`.
+- Canonical full suite: `cargo nextest run --workspace --no-fail-fast`. It uses the repository's nextest configuration; do not substitute `cargo test` for the full-suite receipt.
+- For code changes, run the feature combinations affected by the change. Before declaring a code-changing PR ready, cover default and all-features; mirror the full CI feature matrix when changing feature-gated behavior.
+- Use in-process tests (`tower::ServiceExt::oneshot`) for handler behavior. Use subprocess tests when process startup or shutdown is the behavior under test.
+- Use `#[tokio::test(start_paused = true)]` for deterministic timer, timeout, and backoff semantics when compatible. Use bounded real-time polling for multi-thread scheduling or convergence behavior that paused time cannot represent.
+- Tests must be non-vacuous: name the regression that would turn each important test red.
+- Dependency or feature changes must preserve the declared MSRV, pass applicable `cargo deny` checks, and preserve the TLS, vendoring, and dependency constraints in the relevant Accepted ADRs.
 
 ## Code style
 
-- `#![warn(missing_docs)]` — all public items need doc comments
-- Encode guarantees in the type system: newtypes over primitives, validate at boundaries, use typed versions internally
-- `pub(crate)` by default — only `pub` when external consumers need it
-- `#[non_exhaustive]` on public enums and structs with fields
-- `impl Into<String>` for ergonomic constructors
-- No verbose comments in tests — the interface should be legible without them
+- `#![warn(missing_docs)]` — all public items need doc comments.
+- Encode invariants in the type system: prefer domain newtypes over primitives, validate at boundaries, and use typed values internally.
+- Default to `pub(crate)`; every `pub` item is a semver commitment and needs an external consumer.
+- Public enums are exhaustive by default. Adding a variant is an intentional breaking interface change so downstream exhaustive matches fail to compile. Use `#[non_exhaustive]` only when that specific API explicitly chooses forward-compatible matching. Treat public structs separately based on their contract.
+- Prefer `impl Into<String>` for constructor parameters that take ownership of string data; do not apply it mechanically to every API.
+- Test comments should explain non-obvious contracts, race windows, or failure models. Do not narrate obvious mechanics or preserve historical trivia in canonical code.
 
-## Error handling
+## Error handling and tracing
 
-- Use `MemoryError` variants — `InvalidInput` for user-facing validation, `Internal` for infrastructure
-- Propagate with `?`, never panic in production code
-- Tracing: span names follow `module.operation`, no sensitive data in spans (R-17)
+- Use the most specific `MemoryError` variant. `InvalidInput` is for caller validation failures; `Internal` is only for unexpected failures without a better variant.
+- Propagate recoverable input, I/O, protocol, and dependency failures with typed errors.
+- `expect` or `unreachable!` is reserved for documented internal invariants or unrecoverable poisoned state where continuing could propagate corruption. Never panic for a recoverable external failure.
+- Tracing follows `docs/design/tracing/requirements.md`: span names use `module.operation` (R-02); never record tokens, credentials, API keys, full memory content, or unredacted credential-bearing URLs (R-16–R-18).
 
-## API surface
+## API surface and semver
 
-- Constructors over public fields — preserves room to evolve without breaking consumers
-- `cargo semver-checks check-release` before any version bump
-- Minimize the surface: fewer `pub` items = fewer commitments
+- Use constructors for validated or invariant-bearing domain types. Public fields are acceptable for intentionally data-like wire DTOs and transparent result aggregates.
+- Minimize the public surface: fewer public items mean fewer compatibility commitments.
+- For a public-API change, run semver checks with the same feature coverage as CI (default plus explicit `k8s`). Intentional breaking changes require explicit maintainer approval, the appropriate version bump, and migration/changelog material.
 
-## CI
+## CI and pull requests
 
-- semver-checks enforced — breaking changes need a version bump
-- Changelog in `CHANGELOG.md` must cover everything since the last release tag
-- Docs-only changes (markdown, licenses, ADRs) skip CI via path filters
+- Required CI runs on every PR, including docs-only changes. The workflows are authoritative for the current feature, MSRV, audit, semver, and cross-platform matrix.
+- PR titles must satisfy `.github/workflows/lint-pr.yml`: use an allowed Conventional Commit type, use `!` for a breaking change, and do not use angle brackets.
+- For GitHub Actions changes, pin third-party actions to full commit SHAs, preserve deny-by-default and least-privilege permissions, and never run untrusted PR code through `pull_request_target`.
+- A semver-check failure is a gate, not a ban on intentional breaking changes. Approved breaks ship with the correct version transition.
 
 ## Releases
 
-- Maintainer (butterflysky) handles merging and releases — never auto-merge or call `gh pr merge`
-- Stacked PRs: each concern gets its own change, merged in order
+- The maintainer owns merges and version-bump approval. Never merge, tag, publish, or invoke a release command without explicit authorization.
+- After an approved version bump reaches `main` and CI passes, workflows create the tag and publish the release artifacts automatically.
+- A version-bump/release change updates `CHANGELOG.md` for everything since the previous tag.
+- Stacked PRs keep separate concerns in separate PRs and merge in dependency order against the correct base branches.
 
 ## ADRs
 
-When making architectural or design decisions, write a new ADR in `docs/adr/` following the existing format and sequential numbering. Capture what was decided, alternatives considered, tradeoffs accepted, and why. Use ADRs for decisions where alternatives were seriously weighed, technology/dependency choices, architectural patterns, or security decisions — not every change needs one.
+For a design decision where alternatives were seriously weighed, add an ADR in `docs/adr/` using the next available number and existing format. Record the decision, alternatives, tradeoffs, and consequences. When policy changes, supersede or amend the affected ADR so stale Accepted text does not remain binding.
 
 ## Code review
 
-After a PR passes checks (tests, clippy, fmt):
+1. The implementer runs a review-fix loop before announcing the change.
+2. A sibling performs the independent certification review using the review capability available in their environment.
+3. Triage every finding. Fix accepted findings; record and escalate genuine disagreements instead of making a harmful change to satisfy a review counter.
+4. Any artifact or governing-instruction change invalidates the prior review receipt. Re-review the exact new head.
+5. Repeat until an independent review of the exact current head reports zero findings at or above Low severity.
 
-1. Run `/code-review` on the branch.
-2. Fix all findings (P1, P2, P3).
-3. Re-run review. Repeat fix-then-review up to 5 rounds.
-4. If findings persist after 5 rounds, surface them for human review.
-
-Code review is required before a PR is considered ready for human review.
+The maintainer remains the merge latch. A green test run or an author's self-review is not merge authorization.

--- a/docs/adr/0019-serde-non-exhaustive-strategy.md
+++ b/docs/adr/0019-serde-non-exhaustive-strategy.md
@@ -1,7 +1,7 @@
 # ADR-0019: Serde + #[non_exhaustive] strategy for public types
 
 ## Status
-Accepted
+Accepted. ADR-0040 supersedes only this ADR's Rust API-surface consequence; the strict serde decision remains binding.
 
 ## Context
 Public enums like `Scope` are `#[non_exhaustive]` for semver safety (new variants don't break downstream `match`).
@@ -23,5 +23,5 @@ This preserves data integrity — if you can't understand it, don't touch it.
 - Old binaries encountering new `Scope` variants will warn and skip those memories, not crash
 - No risk of silent data corruption from round-tripping an `Unknown` variant
 - Users see clear warnings to upgrade when new variants appear
-- `#[non_exhaustive]` continues to protect Rust consumers at compile time
+- The former blanket `#[non_exhaustive]` consequence is superseded by ADR-0040; strict deserialization remains unchanged
 - Subsumes #65 and #67 — no format versioning needed at this stage

--- a/docs/adr/0040-exhaustive-public-enums.md
+++ b/docs/adr/0040-exhaustive-public-enums.md
@@ -1,0 +1,30 @@
+# ADR-0040: Public enums are exhaustive by default
+
+## Status
+
+Accepted
+
+Supersedes the `#[non_exhaustive]` default in ADR-0019.
+
+## Context
+
+`#[non_exhaustive]` lets a library add enum variants without a Rust semver break, but downstream consumers must use a wildcard match. That wildcard also removes the compiler's guarantee that consumers have handled every state the interface defines.
+
+For memory-mcp's public contracts, a new enum variant is an interface change. Downstream exhaustive matches should fail to compile so consumers must make an explicit decision about the new state.
+
+The former repository-wide rule applied `#[non_exhaustive]` mechanically to every public enum and fielded struct. That erased the distinction between APIs that deliberately promise forward-compatible matching and APIs that deliberately require exhaustive handling.
+
+## Decision
+
+- Public enums are exhaustive by default.
+- Adding a public enum variant is an intentional breaking change and requires the corresponding version transition and migration guidance.
+- `#[non_exhaustive]` may be used only when a specific public API deliberately chooses forward-compatible matching and documents why wildcard handling is correct for its consumers.
+- Public structs are evaluated separately according to their construction and compatibility contract; there is no blanket attribute rule.
+- Existing public types that already carry `#[non_exhaustive]` keep their published behavior until a deliberate breaking change removes it.
+
+## Consequences
+
+- Downstream exhaustive matches provide a compile-time inventory when an interface changes.
+- Interface evolution may require more major-version changes, by design.
+- Reviewers must reason from the concrete API contract instead of enforcing a universal attribute convention.
+- ADR-0019 remains binding for strict serde compatibility; only its blanket Rust API-surface consequence no longer governs new types.


### PR DESCRIPTION
## Summary

- reconcile `AGENTS.md` with current maintainer direction, repository workflows, and shared engineering principles
- make public enums exhaustive by default and reserve `#[non_exhaustive]` for explicit per-API decisions
- preserve ADR-0019's strict-serde decision while superseding only its blanket Rust API consequence via ADR-0040
- replace stale CI, release, error-taxonomy, panic, and review-process claims with current contracts

## Evidence

The file was independently audited from three directions:

- current repository code, workflows, ADR status, and git history
- collective-conscious design principles and standing review/testing policy
- an independent exact-patch review after reconciliation

The final patch review returned zero findings at or above Low severity.

## Verification

- `cargo fmt --check`
- `git diff --check`
- claim-by-claim comparison against current GitHub workflows and referenced ADRs

## Ordering

Draft until #314 lands ADR-0039; this change intentionally uses ADR-0040.
