### PR TITLE
fix: pull before index construction on fresh repo startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -822,13 +822,11 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // index freshness check (#327): on a fresh repo path the pull is what
     // populates the repo, so the startup reindex must run against post-pull
     // git truth — otherwise the server reports ready while semantic recall
-    // misses every pulled memory. The pull also seeds the sync reporter with
-    // a known state.
-    let initial_pull = (args.require_remote_sync && remote_url.is_some()).then_some((
-        &repo,
-        &auth,
-        args.branch.as_str(),
-    ));
+    // misses every pulled memory. The pull covers every routed repo (default
+    // + scope-mapped remotes, with branch overrides — #328 review, round 2)
+    // and seeds aggregate sync health with a known state.
+    let initial_pull =
+        (args.require_remote_sync && remote_url.is_some()).then_some((&auth, args.branch.as_str()));
 
     let vector_reporter = health.vector_index.clone();
     let (index, reindex_ok) = memory_mcp::server::startup_prepare_index(

--- a/src/main.rs
+++ b/src/main.rs
@@ -804,10 +804,10 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         }
     };
 
-    // Load the persisted index and check freshness against repo HEAD.
-    // If the SHA doesn't match, discard the loaded index entirely and start
-    // fresh — this prevents ghost entries from deleted memories lingering.
-    let mut index: Box<dyn VectorStore> = Box::new(
+    // Load the persisted index; create fresh if missing or corrupt. Freshness
+    // against repo HEAD is decided inside `startup_prepare_index`, after the
+    // initial pull.
+    let loaded_index: Box<dyn VectorStore> = Box::new(
         UsearchStore::load_with_reporter(&index_dir, dimensions, health.vector_index.clone())
             .unwrap_or_else(|e| {
                 tracing::warn!("could not load index ({}), creating fresh", e);
@@ -816,69 +816,39 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
             }),
     );
 
-    let head_sha = router.head_sha().await;
-    let needs_reindex = head_sha != index.commit_sha();
-    // Track whether the reindex (if it ran) completed without errors.
-    // Used below to gate startup report_ok for embedding and vector_index.
-    let reindex_ok;
-    if needs_reindex {
-        info!(
-            head = ?head_sha,
-            index = ?index.commit_sha(),
-            "index SHA does not match repo HEAD — rebuilding from scratch"
-        );
-        index = Box::new(
-            UsearchStore::new_with_reporter(dimensions, health.vector_index.clone())
-                .expect("failed to create index"),
-        );
-
-        // Certification requires errors == 0 (#293 review, round 3): a
-        // partial rebuild must not stamp the SHA, or the next startup would
-        // see index SHA == HEAD and skip the reindex that repairs the gap.
-        reindex_ok = memory_mcp::server::startup_reindex_and_certify(
-            &router,
-            embedding.as_ref(),
-            index.as_ref(),
-            head_sha.as_deref(),
-        )
-        .instrument(tracing::info_span!("startup.full_reindex"))
-        .await;
-    } else {
-        tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
-        reindex_ok = true;
-    }
-
     let auth = AuthProvider::new();
+
+    // When --require-remote-sync is set, the initial pull runs BEFORE the
+    // index freshness check (#327): on a fresh repo path the pull is what
+    // populates the repo, so the startup reindex must run against post-pull
+    // git truth — otherwise the server reports ready while semantic recall
+    // misses every pulled memory. The pull also seeds the sync reporter with
+    // a known state.
+    let initial_pull = (args.require_remote_sync && remote_url.is_some()).then_some((
+        &repo,
+        &auth,
+        args.branch.as_str(),
+    ));
+
+    let vector_reporter = health.vector_index.clone();
+    let (index, reindex_ok) = memory_mcp::server::startup_prepare_index(
+        initial_pull,
+        &router,
+        embedding.as_ref(),
+        loaded_index,
+        move || {
+            Box::new(
+                UsearchStore::new_with_reporter(dimensions, vector_reporter)
+                    .expect("failed to create index"),
+            )
+        },
+    )
+    .await;
 
     // Tracks whether the vector index verifiably mirrors git truth at startup.
     // A reindex that did not complete cleanly is a gap only the next full
     // reindex closes, so SHA advancement must stay blocked for this process.
-    let mut startup_mirror_gap = !reindex_ok;
-
-    // When --require-remote-sync is set, perform an initial pull so the sync
-    // reporter starts with a known state (and the local repo is up-to-date).
-    if args.require_remote_sync && remote_url.is_some() {
-        info!("--require-remote-sync: performing initial pull");
-        match repo.pull(&auth, &args.branch).await {
-            Ok(result) => {
-                info!(?result, "initial pull completed");
-                if matches!(
-                    result,
-                    memory_mcp::types::PullResult::FastForward { .. }
-                        | memory_mcp::types::PullResult::Merged { .. }
-                ) {
-                    // The pull moved git HEAD past the SHA the index was just
-                    // verified against without mirroring the pulled changes.
-                    // Block SHA advancement so the next startup reindexes them
-                    // instead of a later stamp hiding the gap.
-                    startup_mirror_gap = true;
-                }
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "initial pull failed — sync reporter will show degraded");
-            }
-        }
-    }
+    let startup_mirror_gap = !reindex_ok;
 
     // Only mark subsystems healthy if the reindex succeeded or was skipped
     // (SHA matched). If the reindex had errors, the subsystems have already

--- a/src/repo_router.rs
+++ b/src/repo_router.rs
@@ -585,6 +585,55 @@ impl RepoRouter {
         Ok(result)
     }
 
+    /// Pull every repo — the default plus each scope-mapped route, respecting
+    /// per-route branch overrides — without pushing (#328 review, round 2).
+    ///
+    /// This is the startup counterpart of [`RepoRouter::sync_all`]'s pull
+    /// phase: on a fresh deployment the initial pull is what populates each
+    /// repo, so all of them must be pulled before index freshness is decided,
+    /// not just the default. A failure on one repo does not abort the rest.
+    ///
+    /// When the router carries a sync reporter, the aggregate outcome is
+    /// settled once after every repo completes. The per-operation reports
+    /// from [`MemoryRepo::pull`] are last-operation-wins, so a failed
+    /// mapped-remote pull followed by a clean pull would otherwise leave
+    /// shared sync health green while a scope's remote memories are absent.
+    ///
+    /// Returns `true` when every repo pulled cleanly.
+    pub async fn pull_all(&self, auth: &AuthProvider, default_branch: &str) -> bool {
+        let mut failures: Vec<String> = Vec::new();
+        for (label, repo, branch_override, _scope) in self.all_repos() {
+            let branch = branch_override.unwrap_or(default_branch);
+            match repo.pull(auth, branch).await {
+                Ok(result) => info!(label = %label, ?result, "initial pull completed"),
+                Err(e) => {
+                    warn!(
+                        label = %label,
+                        error = %e,
+                        "initial pull failed — continuing with remaining repos"
+                    );
+                    failures.push(format!("{label}: {e}"));
+                }
+            }
+        }
+        if !failures.is_empty() {
+            warn!(
+                failed = failures.len(),
+                "initial pull: {} repo(s) failed: {}",
+                failures.len(),
+                failures.join("; ")
+            );
+        }
+        if let Some(reporter) = &self.sync_reporter {
+            if failures.is_empty() {
+                reporter.report_ok();
+            } else {
+                reporter.report_err("one or more repos failed the initial pull");
+            }
+        }
+        failures.is_empty()
+    }
+
     /// Get a composite HEAD SHA covering all repos.
     ///
     /// When no scope-specific routes are configured, returns the default repo's
@@ -1165,6 +1214,57 @@ mod tests {
         assert!(
             health.sync.load().healthy,
             "a fully clean sync must settle the reporter healthy"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Startup pull-all aggregate health (#328 review, round 2)
+    //
+    // `pull_all` is the startup counterpart of `sync_all`'s pull phase and
+    // carries the same last-operation-wins hazard: a failed mapped-remote
+    // pull followed by a clean pull would leave the shared sync reporter
+    // healthy while a scope's remote memories are absent. The router must
+    // settle sync health once from the complete outcome.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_pull_health_reflects_failed_mapped_remote_not_last_pull() {
+        let (_default_remote, default_url) = seeded_remote("seed-default").await;
+        let default_dir = tempfile::tempdir().unwrap();
+        let default_repo =
+            Arc::new(MemoryRepo::init_or_open(default_dir.path(), Some(&default_url)).unwrap());
+
+        // Route order is prefix-length descending, so "broken" (unreachable
+        // remote) pulls BEFORE "work" (clean): the last per-operation report
+        // is the clean pull, and only the aggregate settle keeps readiness
+        // honest.
+        let (_work_remote, work_url) = seeded_remote("seed-work").await;
+        let broken_dir = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+        let health = crate::health::HealthRegistry::new();
+        let mappings = vec![
+            crate::config::RemoteMapping {
+                scope: "broken".to_string(),
+                url: "file:///nonexistent/memory-mcp-test-remote.git".to_string(),
+                path: Some(broken_dir.path().display().to_string()),
+                branch: None,
+            },
+            crate::config::RemoteMapping {
+                scope: "work".to_string(),
+                url: work_url,
+                path: Some(work_dir.path().display().to_string()),
+                branch: None,
+            },
+        ];
+        let router =
+            RepoRouter::from_config(default_repo, &mappings, &health.git, &health.sync).unwrap();
+
+        let all_ok = router.pull_all(&sync_test_auth(), "main").await;
+        assert!(!all_ok, "pull_all must report the failed mapped remote");
+        assert!(
+            !health.sync.load().healthy,
+            "aggregate sync health must reflect the failed mapped-remote \
+             pull, not the last repo's clean pull"
         );
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -988,6 +988,67 @@ pub async fn startup_reindex_and_certify(
     }
 }
 
+/// Prepare the vector index to serve from at startup: run the initial pull
+/// (when requested) **before** deciding index freshness, then rebuild and
+/// certify against post-pull git truth when the stored SHA is stale.
+///
+/// The ordering is the contract (#327): on a fresh repo path with a
+/// configured remote, the initial pull is what populates the repo. Deciding
+/// freshness — or rebuilding — before the pull completes certifies an index
+/// of the pre-pull (typically empty) tree, and the server signals ready
+/// while semantic recall misses every pulled memory.
+///
+/// `initial_pull` carries `(repo, auth, branch)` when `--require-remote-sync`
+/// is set; a pull failure is logged and startup continues (the sync reporter
+/// shows degraded), matching the previous behavior.
+///
+/// Returns the index to serve from plus `reindex_ok`: `false` when a rebuild
+/// ran and did not certify cleanly, in which case the caller must record a
+/// startup mirror gap so SHA advancement stays blocked for this process.
+pub async fn startup_prepare_index(
+    initial_pull: Option<(&Arc<MemoryRepo>, &crate::auth::AuthProvider, &str)>,
+    router: &crate::repo_router::RepoRouter,
+    embedding: &dyn EmbeddingBackend,
+    loaded_index: Box<dyn VectorStore>,
+    fresh_index: impl FnOnce() -> Box<dyn VectorStore>,
+) -> (Box<dyn VectorStore>, bool) {
+    if let Some((repo, auth, branch)) = initial_pull {
+        info!("--require-remote-sync: performing initial pull");
+        match repo.pull(auth, branch).await {
+            Ok(result) => info!(?result, "initial pull completed"),
+            Err(e) => {
+                warn!(error = %e, "initial pull failed — sync reporter will show degraded");
+            }
+        }
+    }
+
+    // Freshness is judged against git truth as it stands *after* the pull.
+    // If the stored SHA doesn't match, discard the loaded index entirely and
+    // rebuild from scratch — this prevents ghost entries from deleted
+    // memories lingering.
+    let head_sha = router.head_sha().await;
+    if head_sha == loaded_index.commit_sha() {
+        tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
+        return (loaded_index, true);
+    }
+
+    info!(
+        head = ?head_sha,
+        index = ?loaded_index.commit_sha(),
+        "index SHA does not match repo HEAD — rebuilding from scratch"
+    );
+    let index = fresh_index();
+
+    // Certification requires errors == 0 (#293 review, round 3): a partial
+    // rebuild must not stamp the SHA, or the next startup would see index
+    // SHA == HEAD and skip the reindex that repairs the gap.
+    let reindex_ok =
+        startup_reindex_and_certify(router, embedding, index.as_ref(), head_sha.as_deref())
+            .instrument(tracing::info_span!("startup.full_reindex"))
+            .await;
+    (index, reindex_ok)
+}
+
 /// Persist the vector index at graceful shutdown.
 ///
 /// Advances the stored composite SHA to the router's current HEAD only when
@@ -4443,6 +4504,95 @@ mod tests {
                 clean_index.commit_sha(),
                 head,
                 "a clean rebuild must stamp the head SHA"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Startup ordering: pull before index construction (#327)
+        //
+        // Fresh repo path + configured non-empty remote (fresh-clone
+        // deployment): the initial pull must complete BEFORE index freshness
+        // is decided, so the startup reindex runs against post-pull git
+        // truth. Previously the index was rebuilt and certified against the
+        // local init commit, and the server reported ready with a semantic
+        // index that missed every memory on the remote.
+        // -------------------------------------------------------------------
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn startup_prepare_index_pulls_before_freshness_on_fresh_repo() {
+            // Non-empty remote: a writer pushes one memory to a bare origin.
+            let remote_dir = tempfile::tempdir().expect("tempdir");
+            git2::Repository::init_bare(remote_dir.path()).expect("bare init");
+            let remote_url = format!("file://{}", remote_dir.path().display());
+
+            let writer_dir = tempfile::tempdir().expect("tempdir");
+            let writer = Arc::new(
+                MemoryRepo::init_or_open(writer_dir.path(), Some(&remote_url))
+                    .expect("writer repo"),
+            );
+            let pulled = Memory::from_validated(
+                MemoryName::new("pulled".to_string()).unwrap(),
+                "pulledword payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            writer.save_memory(&pulled).await.expect("writer save");
+            writer.push(&sync_auth(), "main").await.expect("push");
+
+            // Fresh server path: init_or_open creates a local init commit
+            // and configures origin, but never fetches — the fresh-boot
+            // branch of the startup sequence.
+            let server_dir = tempfile::tempdir().expect("tempdir");
+            let repo = Arc::new(
+                MemoryRepo::init_or_open(server_dir.path(), Some(&remote_url))
+                    .expect("server repo"),
+            );
+            let router = RepoRouter::single(Arc::clone(&repo));
+            let pre_pull_head = router.head_sha().await;
+            assert!(pre_pull_head.is_some(), "fresh repo must have init commit");
+
+            // Fresh boot: no persisted index (commit_sha None), so a rebuild
+            // runs either way — the regression is WHAT it runs against.
+            let auth = sync_auth();
+            let (index, reindex_ok) = startup_prepare_index(
+                Some((&repo, &auth, "main")),
+                &router,
+                &MockEmbedding,
+                Box::new(InMemoryStore::new(4)),
+                || Box::new(InMemoryStore::new(4)),
+            )
+            .await;
+
+            assert!(reindex_ok, "clean rebuild over pulled truth must certify");
+
+            // The pull ran before freshness was decided: HEAD moved past the
+            // local init commit and the certified SHA is post-pull truth.
+            let head = router.head_sha().await;
+            assert!(head.is_some(), "git truth must yield a head SHA");
+            assert_ne!(
+                head, pre_pull_head,
+                "initial pull must advance HEAD past the local init commit"
+            );
+            assert_eq!(
+                index.commit_sha(),
+                head,
+                "startup must certify the index against post-pull git truth"
+            );
+
+            // …and recall sees the pulled memory before ready is signaled:
+            // the index handed to the server already contains it.
+            let qualified =
+                MemoryRef::new(Scope::Root, MemoryName::new("pulled".to_string()).unwrap())
+                    .qualified_path();
+            assert!(
+                index.find_by_name(&qualified).is_some(),
+                "pulled memory must be present in the startup index"
+            );
+            let hits = index
+                .search(&ScopeFilter::All, &[0.0, 0.0, 0.0, 1.0], 10)
+                .expect("search");
+            assert!(
+                hits.iter().any(|(_, name, _)| name == &qualified),
+                "semantic search must surface the pulled memory, got: {hits:?}"
             );
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -998,27 +998,32 @@ pub async fn startup_reindex_and_certify(
 /// of the pre-pull (typically empty) tree, and the server signals ready
 /// while semantic recall misses every pulled memory.
 ///
-/// `initial_pull` carries `(repo, auth, branch)` when `--require-remote-sync`
-/// is set; a pull failure is logged and startup continues (the sync reporter
-/// shows degraded), matching the previous behavior.
+/// The pull covers **every** routed repo — the default plus each configured
+/// scope-mapped remote, respecting per-route branch overrides (#328 review,
+/// round 2). Pulling only the default repo would leave mapped repos at their
+/// local init commits: the composite-HEAD reindex would certify their empty
+/// trees and readiness could go green while every remotely stored
+/// mapped-scope memory is absent until an explicit sync.
+///
+/// `initial_pull` carries `(auth, default_branch)` when
+/// `--require-remote-sync` is set; a pull failure on any repo is logged and
+/// startup continues (aggregate sync health shows degraded), matching the
+/// previous behavior.
 ///
 /// Returns the index to serve from plus `reindex_ok`: `false` when a rebuild
 /// ran and did not certify cleanly, in which case the caller must record a
 /// startup mirror gap so SHA advancement stays blocked for this process.
 pub async fn startup_prepare_index(
-    initial_pull: Option<(&Arc<MemoryRepo>, &crate::auth::AuthProvider, &str)>,
+    initial_pull: Option<(&crate::auth::AuthProvider, &str)>,
     router: &crate::repo_router::RepoRouter,
     embedding: &dyn EmbeddingBackend,
     loaded_index: Box<dyn VectorStore>,
     fresh_index: impl FnOnce() -> Box<dyn VectorStore>,
 ) -> (Box<dyn VectorStore>, bool) {
-    if let Some((repo, auth, branch)) = initial_pull {
-        info!("--require-remote-sync: performing initial pull");
-        match repo.pull(auth, branch).await {
-            Ok(result) => info!(?result, "initial pull completed"),
-            Err(e) => {
-                warn!(error = %e, "initial pull failed — sync reporter will show degraded");
-            }
+    if let Some((auth, default_branch)) = initial_pull {
+        info!("--require-remote-sync: performing initial pull across all repos");
+        if !router.pull_all(auth, default_branch).await {
+            warn!("initial pull failed for one or more repos — sync health will show degraded");
         }
     }
 
@@ -4554,7 +4559,7 @@ mod tests {
             // runs either way — the regression is WHAT it runs against.
             let auth = sync_auth();
             let (index, reindex_ok) = startup_prepare_index(
-                Some((&repo, &auth, "main")),
+                Some((&auth, "main")),
                 &router,
                 &MockEmbedding,
                 Box::new(InMemoryStore::new(4)),
@@ -4593,6 +4598,151 @@ mod tests {
             assert!(
                 hits.iter().any(|(_, name, _)| name == &qualified),
                 "semantic search must surface the pulled memory, got: {hits:?}"
+            );
+        }
+
+        // -------------------------------------------------------------------
+        // Startup ordering, second lane: scope-mapped remotes (#328 review,
+        // round 2)
+        //
+        // Fresh deployment with a default remote AND a configured
+        // scope-mapped remote, both non-empty: the startup pull must cover
+        // every routed repo — respecting per-route branch overrides — before
+        // the composite-HEAD freshness decision. Pulling only the default
+        // repo would certify the mapped repo's empty local-init commit and
+        // readiness could go green while every remotely stored mapped-scope
+        // memory is absent until an explicit sync.
+        // -------------------------------------------------------------------
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn startup_prepare_index_pulls_mapped_remotes_before_freshness() {
+            let auth = sync_auth();
+
+            // Default remote: a writer pushes one root-scope memory to main.
+            let default_remote_dir = tempfile::tempdir().expect("tempdir");
+            git2::Repository::init_bare(default_remote_dir.path()).expect("bare init");
+            let default_url = format!("file://{}", default_remote_dir.path().display());
+            let default_writer_dir = tempfile::tempdir().expect("tempdir");
+            let default_writer = Arc::new(
+                MemoryRepo::init_or_open(default_writer_dir.path(), Some(&default_url))
+                    .expect("default writer repo"),
+            );
+            let default_memory = Memory::from_validated(
+                MemoryName::new("pulled-default".to_string()).unwrap(),
+                "defaultword payload".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            default_writer
+                .save_memory(&default_memory)
+                .await
+                .expect("default writer save");
+            default_writer.push(&auth, "main").await.expect("push");
+
+            // Mapped remote: a writer pushes one work-scope memory, then the
+            // bare repo's only branch is renamed to `develop` — the memory
+            // exists ONLY on the route's override branch, so it is reachable
+            // only if the startup pull respects the override.
+            let work_scope = Scope::Path(crate::types::ScopePath::new("work").unwrap());
+            let work_remote_dir = tempfile::tempdir().expect("tempdir");
+            git2::Repository::init_bare(work_remote_dir.path()).expect("bare init");
+            let work_url = format!("file://{}", work_remote_dir.path().display());
+            let work_writer_dir = tempfile::tempdir().expect("tempdir");
+            let work_writer = Arc::new(
+                MemoryRepo::init_or_open(work_writer_dir.path(), Some(&work_url))
+                    .expect("work writer repo"),
+            );
+            let work_memory = Memory::from_validated(
+                MemoryName::new("pulled-work".to_string()).unwrap(),
+                "mappedword payload".to_string(),
+                MemoryMetadata::new(work_scope.clone(), vec![], None),
+            );
+            work_writer
+                .save_memory(&work_memory)
+                .await
+                .expect("work writer save");
+            work_writer.push(&auth, "main").await.expect("push");
+            git2::Repository::open(work_remote_dir.path())
+                .expect("open bare")
+                .find_reference("refs/heads/main")
+                .expect("main ref")
+                .rename("refs/heads/develop", true, "seed develop only")
+                .expect("rename to develop");
+
+            // Fresh server side: default repo and mapped repo are both
+            // locally initialised, never fetched — the fresh-boot branch of
+            // the startup sequence with per-scope remotes configured.
+            let server_default_dir = tempfile::tempdir().expect("tempdir");
+            let default_repo = Arc::new(
+                MemoryRepo::init_or_open(server_default_dir.path(), Some(&default_url))
+                    .expect("server default repo"),
+            );
+            let server_work_dir = tempfile::tempdir().expect("tempdir");
+            let health = HealthRegistry::new();
+            let mapping = RemoteMapping {
+                scope: "work".to_string(),
+                url: work_url,
+                path: Some(server_work_dir.path().display().to_string()),
+                branch: Some("develop".to_string()),
+            };
+            let router = RepoRouter::from_config(
+                default_repo,
+                std::slice::from_ref(&mapping),
+                &health.git,
+                &health.sync,
+            )
+            .expect("router from config");
+            let pre_pull_head = router.head_sha().await;
+            assert!(
+                pre_pull_head.is_some(),
+                "fresh repos must have init commits"
+            );
+
+            let (index, reindex_ok) = startup_prepare_index(
+                Some((&auth, "main")),
+                &router,
+                &MockEmbedding,
+                Box::new(InMemoryStore::new(4)),
+                || Box::new(InMemoryStore::new(4)),
+            )
+            .await;
+
+            assert!(reindex_ok, "clean rebuild over pulled truth must certify");
+
+            // Every routed repo was pulled before freshness was decided: the
+            // composite HEAD moved past the local init commits and the
+            // certified SHA is post-pull truth.
+            let head = router.head_sha().await;
+            assert_ne!(
+                head, pre_pull_head,
+                "initial pull must advance the composite HEAD past the local init commits"
+            );
+            assert_eq!(
+                index.commit_sha(),
+                head,
+                "startup must certify the index against post-pull composite git truth"
+            );
+
+            // BOTH memories are indexed before ready is signaled.
+            for (scope, name) in [(Scope::Root, "pulled-default"), (work_scope, "pulled-work")] {
+                let qualified = MemoryRef::new(scope, MemoryName::new(name.to_string()).unwrap())
+                    .qualified_path();
+                assert!(
+                    index.find_by_name(&qualified).is_some(),
+                    "{qualified} must be present in the startup index"
+                );
+                let hits = index
+                    .search(&ScopeFilter::All, &[0.0, 0.0, 0.0, 1.0], 10)
+                    .expect("search");
+                assert!(
+                    hits.iter().any(|(_, hit, _)| hit == &qualified),
+                    "semantic search must surface {qualified}, got: {hits:?}"
+                );
+            }
+
+            // A fully clean startup pull settles aggregate sync health ok.
+            assert!(
+                health.sync.load().healthy,
+                "a fully clean initial pull must settle aggregate sync health"
             );
         }
 


### PR DESCRIPTION
## Behavior

v0.17.0, fresh repo path with a configured remote and `--require-remote-sync` (fresh-clone deployment, e.g. a new pod with an empty volume): `/readyz` goes green while semantic recall misses every memory on the remote. Restarting the server fixes it.

## Root cause

`run_serve` decided index freshness and ran the startup reindex **before** the initial pull. On a fresh path the repo holds only the local init commit, so the reindex certified an empty tree and stamped its SHA; the pull then fast-forwarded HEAD past everything the index was just certified against. The existing mitigation (marking a startup mirror gap when the pull moves HEAD) only scheduled a reindex for the *next* startup — the process served an empty semantic index for its entire first lifetime.

## Fix

Extract the ordering into `server::startup_prepare_index`: the initial pull (when `--require-remote-sync` is set) now completes **before** index freshness is decided, so a fresh boot against a non-empty remote rebuilds and certifies the index against post-pull git truth before ready is signaled. The FastForward/Merged startup mirror-gap special case is removed — the reindex now runs after the pull, so there is no pre-pull certification left to invalidate. Pull-failure behavior is unchanged (warn, continue, sync reporter degraded).

## Tests

- New regression test `startup_prepare_index_pulls_before_freshness_on_fresh_repo`: non-empty bare fixture remote + fresh local repo path → the startup index contains the pulled memory, semantic search surfaces it, and the certified SHA is the post-pull HEAD (which must have advanced past the local init commit).
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full `cargo nextest run`: 454 passed, 2 skipped.

## Release note

This is the designated cherry-pick for `release/0.17.1` (to be cherry-picked onto the release branch from the v0.17.0 tag — the branch is intentionally not created here). The commit touches only `src/main.rs` and `src/server.rs`, which are unchanged since v0.17.0, so it applies independently of #324/slice-1.

Closes #327