### PR TITLE
feat: stdio transport with single-writer lock

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,5 +2,5 @@
 max-threads = 1
 
 [[profile.default.overrides]]
-filter = "binary(candle_embedding) | (binary(auth) & test(memory_mcp_bind)) | (binary(otlp_startup) & test(binds))"
+filter = "binary(candle_embedding) | binary(stdio_transport) | (binary(auth) & test(memory_mcp_bind)) | (binary(otlp_startup) & test(binds))"
 test-group = "embedding"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-19
+
 ### Added
 
 - **Chunk-addressable retrieval contract** (#262 slice 1, ADR-0042): typed identity and wire shapes for fact-level retrieval units — deterministic `FactId` (parent id + chunker version + source span + content digest, canonical `fact:v1:...` string form), validated non-empty UTF-8 `SourceSpan`, `ChunkerVersion`, and the crate-internal catalog (`FactRecord`) and recall-provenance (`MatchedChunk`) shapes, which go public when their slices wire them. Contract only — no behavioral wiring; the deterministic chunker, derived catalog, chunk indexes, and response wiring land in later slices. `MemoryRef` gains strict `Serialize`/`Deserialize` support for shapes that embed a parent reference. Existing whole-memory retrieval is unchanged. ADR-0042 carries the #262 invariant ledger (each invariant mapped to enforcement, test, and owning slice) and the index-persistence posture; `proptest` lands as a dev-dependency seeding the repository's property-based-testing layer (serde round-trip totality, canonical-form totality, span validity, and collision-resistance evidence over generated inputs).
+- **Native stdio transport for single-user local deployments** (#104, #329, ADR-0040): `memory-mcp serve --transport stdio` lets an MCP client own the server process lifecycle without a daemon, port, bind address, or Host allowlist; stdin EOF and termination signals drain in-flight mutations before index persistence, and stdout remains JSON-RPC-only while tracing stays on stderr. Streamable HTTP remains the default and the supported networked/multi-client transport. Both transports now enforce one writer per default or scope-mapped repository with a symlink-safe advisory lock, so a second stdio process or HTTP daemon fails fast instead of racing git, the vector index, or the recall log.
 
 ## [0.17.1] - 2026-07-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "memory-mcp"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memory-mcp"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "MCP server for semantic memory — pure-Rust embeddings, vector search, git-backed storage"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ native-certs = ["reqwest/rustls-tls-native-roots", "dep:ureq"]
 otlp = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]
 
 [dependencies]
-rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server"] }
+rmcp = { version = "1.1", features = ["server", "macros", "transport-streamable-http-server", "transport-io"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 git2 = { version = "0.21", features = ["https", "vendored-openssl"] }

--- a/docs/adr/0001-streamable-http-only.md
+++ b/docs/adr/0001-streamable-http-only.md
@@ -1,7 +1,9 @@
 # ADR-0001: Streamable HTTP Only
 
 ## Status
-Accepted
+Accepted. Superseded in part by ADR-0040: stdio is now available as an opt-in
+transport for single-user local deployments; Streamable HTTP remains the
+default and the only supported transport for networked deployments.
 
 ## Context
 MCP supports three server transports: stdio, SSE, and Streamable HTTP. The server needs to

--- a/docs/adr/0040-stdio-transport-single-writer-lock.md
+++ b/docs/adr/0040-stdio-transport-single-writer-lock.md
@@ -1,0 +1,52 @@
+# ADR-0040: stdio Transport for Single-User Local Deployments
+
+## Status
+Accepted. Supersedes ADR-0001 in part: Streamable HTTP is no longer the sole
+transport, but remains the default and the only supported transport for
+networked/multi-client deployments.
+
+## Context
+ADR-0001 chose Streamable HTTP as the only transport, sized for k8s and
+multi-machine access. The first external adopters run the server on the same
+machine as their MCP client, where HTTP means managing a background daemon,
+a bind address, and a Host-header allowlist — all friction with no benefit
+for a single local user. MCP clients (including Claude Code) manage process
+lifecycle natively when a server speaks stdio (#104).
+
+stdio changes the concurrency model: one process per client, but all
+processes share one repo directory. The git repo, the usearch index files,
+and the recall log are owned exclusively by a single process today — sqlite
+has a busy timeout, but git commits and the shutdown index save do not
+tolerate a second writer.
+
+## Decision
+- Add `serve --transport {http|stdio}` (env `MEMORY_MCP_TRANSPORT`), default
+  `http`. stdio serves one client over stdin/stdout via rmcp's stdio
+  transport; stdout carries only JSON-RPC framing (tracing is stderr-only).
+- Enforce a single writer per repository with an OS advisory lock
+  (`flock` semantics) on `<repo>/.memory-mcp-index/.lock`, acquired before
+  any subsystem opens. A second server process — stdio or HTTP — fails fast
+  with an error naming the holder's pid. No waiting, no retries.
+
+## Rejected alternatives
+- **Multi-writer coordination** (shared locks around git/index/recall-log
+  operations): large surface, and cross-process cache coherence for the
+  in-RAM vector and lexical indexes would still be unsolved. A second local
+  process is a deployment error, not a use case.
+- **Lease/TTL lockfiles**: stale-lock heuristics and clock dependence for a
+  problem the kernel already solves — an advisory lock is released on process
+  exit, including crashes, and can never go stale.
+- **Documenting a single-client constraint** without enforcement: silent
+  index or repo corruption when the constraint is violated accidentally
+  (e.g. a stdio instance started while the HTTP daemon runs).
+
+## Consequences
+- Local single-user setups need no daemon, no port, no Host allowlist; the
+  client owns the process lifecycle and stdin EOF is a clean shutdown (the
+  vector index is persisted on exit, as with HTTP).
+- One process per client means one embedding model load per client; anyone
+  needing concurrent clients or networked access should run the HTTP server.
+- The lock applies to HTTP too: two HTTP daemons on one repo now fail fast
+  instead of corrupting state — a latent foot-gun closed.
+- Session-scoped observability degrades gracefully under stdio: there is no
+  `Mcp-Session-Id` header, so spans carry the literal session id `stdio`.

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,7 +1,8 @@
 # Client setup
 
-memory-mcp exposes MCP over Streamable HTTP. The default endpoint is
-`http://localhost:8080/mcp`.
+memory-mcp exposes MCP over Streamable HTTP (the default; endpoint
+`http://localhost:8080/mcp`) or, for single-user local setups, over stdio
+with `memory-mcp serve --transport stdio`.
 
 Client configuration formats evolve independently from memory-mcp. Treat these
 examples as starting points and consult the client documentation when a current
@@ -78,20 +79,24 @@ mcpServers:
     url: http://localhost:8080/mcp
 ```
 
-## Clients that require stdio
+## stdio (no daemon)
 
-memory-mcp intentionally ships only Streamable HTTP. A client without native
-HTTP support can use a bridge such as `mcp-remote`:
+For single-user local use, let the client manage the server process directly —
+no background daemon, port, or Host allowlist needed. Claude Code example:
 
 ```json
 {
   "mcpServers": {
     "memory": {
-      "command": "npx",
-      "args": ["mcp-remote", "http://localhost:8080/mcp"]
+      "command": "memory-mcp",
+      "args": ["serve", "--transport", "stdio"]
     }
   }
 }
 ```
 
-The bridge is a separate process and dependency; it is not part of memory-mcp.
+Each stdio client gets its own server process (and its own embedding model in
+memory), and all processes must share one repository sequentially: a second
+server against the same repo exits with an error while another is running
+(ADR-0040). Prefer the HTTP daemon when more than one client is connected at
+a time.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ authoritative list.
 
 | Flag | Environment variable | Default | Purpose |
 |---|---|---|---|
+| `--transport` | `MEMORY_MCP_TRANSPORT` | `http` | MCP transport: `http` (Streamable HTTP daemon) or `stdio` (one process per client, managed by the MCP client) |
 | `--bind` | `MEMORY_MCP_BIND` | `127.0.0.1:8080` | HTTP listener address |
 | `--repo-path` | `MEMORY_MCP_REPO_PATH` | `~/.memory-mcp` | Git-backed memory repository |
 | `--config` | `MEMORY_MCP_CONFIG` | `~/.config/memory-mcp/config.toml` | TOML config file for per-scope remote mapping; empty string disables config loading |
@@ -18,6 +19,13 @@ authoritative list.
 | `--require-remote-sync` | `MEMORY_MCP_REQUIRE_REMOTE_SYNC` | `false` | Make remote sync health affect readiness |
 | `--recall-log-busy-timeout` | `MEMORY_MCP_RECALL_LOG_BUSY_TIMEOUT` | `5` | SQLite lock wait in seconds |
 | `--health-stale-secs` | `MEMORY_MCP_HEALTH_STALE_SECS` | `0` | Mark inactive subsystems stale; 0 disables |
+
+Under `--transport stdio` the HTTP-only flags (`--bind`, `--mcp-path`,
+`--allowed-host`, and the session limits below) are ignored: stdout carries
+JSON-RPC framing, all logs go to stderr, and the MCP client owns the process
+lifecycle. Regardless of transport, only one server process may serve a
+repository at a time — a second instance exits immediately with an error
+naming the process that holds the lock (ADR-0040).
 
 ## Sessions and embedding work
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,12 @@ pub enum MemoryError {
     /// Catch-all for unexpected internal failures.
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// The server sealed mutation admission for shutdown; the request was
+    /// rejected before any state changed and can be safely retried against
+    /// the next server instance.
+    #[error("server is shutting down; request rejected before any state changed")]
+    ShuttingDown,
 }
 
 impl From<MemoryError> for rmcp::model::ErrorData {

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -231,6 +231,25 @@ impl Drop for TempGuard<'_> {
 ///
 /// Callers must ensure no concurrent writes target the same `path`.
 pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    atomic_write_with_parent_sync(path, data, false, fsync_dir)
+}
+
+/// Atomically write `data` and require the parent-directory fsync to succeed.
+///
+/// Use this for tiny correctness markers whose caller must distinguish a
+/// crash-durable rename from a rename that merely reached the page cache.
+/// The ordinary [`atomic_write`] keeps its historical best-effort directory
+/// fsync behavior for callers where the rename itself is sufficient.
+pub(crate) fn atomic_write_durable(path: &Path, data: &[u8]) -> std::io::Result<()> {
+    atomic_write_with_parent_sync(path, data, true, fsync_dir)
+}
+
+fn atomic_write_with_parent_sync(
+    path: &Path,
+    data: &[u8],
+    require_parent_sync: bool,
+    sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> std::io::Result<()> {
     let parent = path.parent().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -259,7 +278,10 @@ pub(crate) fn atomic_write(path: &Path, data: &[u8]) -> std::io::Result<()> {
     // Fsync the parent directory so the rename is durable even on hard crash.
     // Best-effort: the rename already committed, so a dir-fsync failure should
     // not cause callers to treat the write as failed.
-    if let Err(e) = fsync_dir(parent) {
+    if let Err(e) = sync_parent(parent) {
+        if require_parent_sync {
+            return Err(e);
+        }
         tracing::warn!("fsync of parent directory failed (data is written): {e}");
     }
 
@@ -323,6 +345,31 @@ mod tests {
         atomic_write(&target, b"new content").unwrap();
 
         assert_eq!(fs::read_to_string(&target).unwrap(), "new content");
+    }
+
+    #[test]
+    fn durable_atomic_write_propagates_parent_fsync_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("marker");
+
+        let err = atomic_write_with_parent_sync(&target, b"revoked", true, |_| {
+            Err(std::io::Error::other("injected parent fsync failure"))
+        })
+        .expect_err("strict durability must propagate parent fsync failure");
+
+        assert!(
+            err.to_string().contains("injected parent fsync failure"),
+            "the exact durability failure must reach the caller: {err}"
+        );
+        assert_eq!(
+            fs::read(&target).unwrap(),
+            b"revoked",
+            "the rename may have completed, but must not be certified durable"
+        );
+        assert!(
+            !dir.path().join(".marker.tmp").exists(),
+            "the temp file must not linger after the post-rename failure"
+        );
     }
 
     #[cfg(unix)]

--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -257,7 +257,8 @@ pub const REVOKED_COMMIT_SHA_SENTINEL: &str = "revoked:shutdown-drain-timeout";
 /// the startup freshness check reads via [`UsearchStore::load`] — to
 /// [`REVOKED_COMMIT_SHA_SENTINEL`]. The snapshot's key map and vector data
 /// are preserved untouched, and dirty in-memory index state is never
-/// persisted. The rewrite goes through [`crate::fs_util::atomic_write`]
+/// persisted. The rewrite goes through the hardened
+/// `crate::fs_util::atomic_write_durable` helper
 /// (fsynced temp file, `O_NOFOLLOW` on Unix, atomic rename, parent-dir
 /// fsync), so the revocation is crash-durable and symlink-safe.
 ///
@@ -286,7 +287,7 @@ pub fn revoke_persisted_certification(dir: &Path) -> std::io::Result<()> {
     }
     value["commit_sha"] = serde_json::Value::from(REVOKED_COMMIT_SHA_SENTINEL);
     let payload = serde_json::to_string(&value).map_err(std::io::Error::other)?;
-    crate::fs_util::atomic_write(&keys_path, payload.as_bytes())
+    crate::fs_util::atomic_write_durable(&keys_path, payload.as_bytes())
 }
 
 /// Convert a `RawIndexError` to `MemoryError::Index`, preserving the message

--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -243,6 +243,52 @@ fn load_key_map(path_str: &str) -> Result<KeyMapData, MemoryError> {
     }
 }
 
+/// Sentinel written into a persisted key map's `commit_sha` when shutdown
+/// could not leave the durable reindex-required marker (#329 review,
+/// round 5). Never a valid git SHA, so the startup freshness comparison can
+/// never match it against HEAD — whether HEAD is a real commit or absent.
+pub const REVOKED_COMMIT_SHA_SENTINEL: &str = "revoked:shutdown-drain-timeout";
+
+/// Durably revoke the certification stored in the on-disk index snapshot.
+///
+/// Fallback for a failed reindex-required marker write (#329 review,
+/// round 5): rewrites only the `commit_sha` field of
+/// `<dir>/all/index.usearch.keys.json` — the authoritative certification
+/// the startup freshness check reads via [`UsearchStore::load`] — to
+/// [`REVOKED_COMMIT_SHA_SENTINEL`]. The snapshot's key map and vector data
+/// are preserved untouched, and dirty in-memory index state is never
+/// persisted. The rewrite goes through [`crate::fs_util::atomic_write`]
+/// (fsynced temp file, `O_NOFOLLOW` on Unix, atomic rename, parent-dir
+/// fsync), so the revocation is crash-durable and symlink-safe.
+///
+/// A missing, legacy (bare key map, no `commit_sha` field), or unparseable
+/// key-map file already cannot certify the snapshot at startup — absence
+/// loads as no stored SHA, and a corrupt file fails the snapshot load so a
+/// fresh uncertified index is built — so those cases are treated as
+/// success.
+pub fn revoke_persisted_certification(dir: &Path) -> std::io::Result<()> {
+    let keys_path = dir.join("all").join("index.usearch.keys.json");
+    let json = match std::fs::read_to_string(&keys_path) {
+        Ok(json) => json,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    let mut value: serde_json::Value = match serde_json::from_str(&json) {
+        Ok(v) => v,
+        // Unparseable snapshots cannot certify: loading them fails and
+        // startup falls back to a fresh, uncertified index.
+        Err(_) => return Ok(()),
+    };
+    // Legacy bare-HashMap files carry no commit_sha field; they load with
+    // no stored SHA and therefore cannot pass the freshness check.
+    if !value.is_object() || value.get("key_map").is_none() {
+        return Ok(());
+    }
+    value["commit_sha"] = serde_json::Value::from(REVOKED_COMMIT_SHA_SENTINEL);
+    let payload = serde_json::to_string(&value).map_err(std::io::Error::other)?;
+    crate::fs_util::atomic_write(&keys_path, payload.as_bytes())
+}
+
 /// Convert a `RawIndexError` to `MemoryError::Index`, preserving the message
 /// but stripping backend-specific type identity.
 fn raw_err(e: RawIndexError) -> MemoryError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Context;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use mcp_session::BoundedSessionManagerBuilder;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use tokio_util::sync::CancellationToken;
@@ -82,8 +82,25 @@ struct LoginArgs {
     k8s_secret_name: String,
 }
 
+/// MCP transport for the `serve` command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum Transport {
+    /// Streamable HTTP server on `--bind` (default). Shared daemon; serves
+    /// many clients and networked deployments (ADR-0001).
+    Http,
+    /// JSON-RPC over stdin/stdout. One process per client, lifecycle managed
+    /// by the MCP client; for single-user local use (ADR-0040).
+    Stdio,
+}
+
 #[derive(Args)]
 struct ServeArgs {
+    /// MCP transport. `http` serves Streamable HTTP on --bind; `stdio`
+    /// serves a single client over stdin/stdout. HTTP-only flags (--bind,
+    /// --mcp-path, session limits, --allowed-host) are ignored under stdio.
+    #[arg(long, value_enum, default_value = "http", env = "MEMORY_MCP_TRANSPORT")]
+    transport: Transport,
+
     /// Address to bind the HTTP server to.
     #[arg(long, default_value = "127.0.0.1:8080", env = "MEMORY_MCP_BIND")]
     bind: String,
@@ -702,10 +719,67 @@ async fn main() -> anyhow::Result<()> {
 }
 
 // ---------------------------------------------------------------------------
+// Single-writer lock
+// ---------------------------------------------------------------------------
+
+/// Acquire the advisory single-writer lock for a memory repository.
+///
+/// The server assumes exclusive ownership of the git repo, the usearch index
+/// files, and the recall log; none of these tolerate a second writer
+/// (ADR-0040). The lock is an OS advisory lock ([`std::fs::File::try_lock`],
+/// `flock` semantics on Linux) on `<index_dir>/.lock`, so the kernel releases
+/// it when the process exits — including on crash — and it can never go stale.
+///
+/// Fails fast when another process holds the lock, naming the holder's pid.
+/// No waiting, no lease heuristics: a second server on the same repository is
+/// a deployment error regardless of which transport either process uses.
+///
+/// The returned guard must be kept alive for the lifetime of the server;
+/// dropping it releases the lock.
+fn acquire_single_writer_lock(index_dir: &std::path::Path) -> anyhow::Result<std::fs::File> {
+    std::fs::create_dir_all(index_dir)
+        .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
+    let lock_path = index_dir.join(".lock");
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+    match file.try_lock() {
+        Ok(()) => {
+            // Best-effort holder breadcrumb for the contention error below.
+            // The lock itself is the flock, not this content.
+            file.set_len(0).ok();
+            use std::io::Write;
+            let _ = (&file).write_all(format!("{}\n", std::process::id()).as_bytes());
+            Ok(file)
+        }
+        Err(std::fs::TryLockError::WouldBlock) => {
+            let holder = std::fs::read_to_string(&lock_path)
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "unknown".to_string());
+            anyhow::bail!(
+                "another memory-mcp process (pid {holder}) is already serving this \
+                 repository (lock file: {}). The server requires exclusive access \
+                 to the memory repo, its vector index, and its recall log — stop \
+                 the other instance or point --repo-path at a different repository.",
+                lock_path.display()
+            )
+        }
+        Err(e) => Err(e).with_context(|| format!("failed to lock {}", lock_path.display())),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Server startup
 // ---------------------------------------------------------------------------
 
-/// Start and run the MCP HTTP server with the provided arguments.
+/// Start and run the MCP server with the provided arguments, over the
+/// selected transport (streamable HTTP by default, or stdio).
 async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Validate branch name early to prevent ref injection.
     validate_branch_name(&args.branch).context("invalid --branch value")?;
@@ -721,8 +795,17 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         .context("failed to canonicalize repo path")?;
     info!("repo path: {}", repo_path.display());
 
+    // Data-dir layout: the vector index, recall log, and single-writer lock
+    // all live under `.memory-mcp-index` inside the repo path.
+    let index_dir = repo_path.join(".memory-mcp-index");
+
+    // Enforce single-writer before any subsystem opens: the git repo, index
+    // files, and recall log all assume exclusive ownership (ADR-0040).
+    // Acquiring before the (slow) embedding init makes contention fail fast.
+    let _single_writer_lock = acquire_single_writer_lock(&index_dir)?;
+
     // Filter out empty string to treat MEMORY_MCP_REMOTE_URL="" as unset.
-    let remote_url = args.remote_url.filter(|u| !u.is_empty());
+    let remote_url = args.remote_url.clone().filter(|u| !u.is_empty());
 
     if args.require_remote_sync && remote_url.is_none() {
         anyhow::bail!("--require-remote-sync requires --remote-url to be set");
@@ -756,9 +839,6 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     );
 
     let dimensions = embedding.dimensions();
-
-    // Attempt to load the scoped index; create fresh if missing or corrupt.
-    let index_dir = repo_path.join(".memory-mcp-index");
 
     // Remove legacy single-index files if they still exist from an old install.
     let old_index = index_dir.join("index.usearch");
@@ -918,6 +998,31 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // Keep a reference for post-shutdown index persistence.
     let state_for_shutdown = Arc::clone(&state);
 
+    match args.transport {
+        Transport::Http => serve_http(&args, Arc::clone(&state)).await?,
+        Transport::Stdio => serve_stdio(Arc::clone(&state)).await?,
+    }
+
+    // Persist the scoped vector index so the next startup can skip a full
+    // reindex. The stored SHA only advances when the in-process mirror is
+    // intact — a recorded mirror gap keeps the last verified SHA so the next
+    // startup rebuilds from git truth.
+    if let Err(e) =
+        memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
+    {
+        tracing::warn!("failed to persist vector index on shutdown: {}", e);
+    } else {
+        info!("vector index saved to {}", index_dir.display());
+    }
+
+    Ok(())
+}
+
+/// Serve MCP over streamable HTTP (ADR-0001): axum router with health
+/// endpoints, bounded session manager, graceful shutdown on SIGINT/SIGTERM.
+async fn serve_http(args: &ServeArgs, state: Arc<AppState>) -> anyhow::Result<()> {
+    let state_for_routes = Arc::clone(&state);
+
     // Build the MCP service.
     let ct = CancellationToken::new();
     let ct_child = ct.child_token();
@@ -962,7 +1067,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         .route("/healthz", axum::routing::get(healthz_handler))
         .route("/readyz", axum::routing::get(readyz_handler))
         .route("/version", axum::routing::get(version_handler))
-        .with_state(Arc::clone(&state_for_shutdown))
+        .with_state(state_for_routes)
         .nest_service(&mcp_path, service);
 
     let listener = tokio::net::TcpListener::bind(&args.bind)
@@ -994,16 +1099,43 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         .await
         .context("server error")?;
 
-    // Persist the scoped vector index so the next startup can skip a full
-    // reindex. The stored SHA only advances when the in-process mirror is
-    // intact — a recorded mirror gap keeps the last verified SHA so the next
-    // startup rebuilds from git truth.
-    if let Err(e) =
-        memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
+    Ok(())
+}
+
+/// Serve MCP over stdio (ADR-0040): stdout carries JSON-RPC framing (all
+/// tracing goes to stderr), stdin EOF is the normal end-of-session signal.
+/// One process serves exactly one client; the MCP client owns the lifecycle.
+async fn serve_stdio(state: Arc<AppState>) -> anyhow::Result<()> {
+    info!("serving MCP over stdio (stdout is the protocol channel)");
+
+    let service = rmcp::serve_server(MemoryServer::new(state), rmcp::transport::stdio())
+        .await
+        .context("failed to initialize stdio transport")?;
+
+    // Quit when the client closes stdin (normal MCP lifecycle) or on a
+    // shutdown signal — either way the caller persists the index afterwards.
+    #[cfg(unix)]
     {
-        tracing::warn!("failed to persist vector index on shutdown: {}", e);
-    } else {
-        info!("vector index saved to {}", index_dir.display());
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+        tokio::select! {
+            quit = service.waiting() => {
+                let reason = quit.context("stdio transport task failed")?;
+                info!(?reason, "stdio transport closed");
+            }
+            _ = tokio::signal::ctrl_c() => info!("shutdown signal received"),
+            _ = sigterm.recv() => info!("shutdown signal received"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::select! {
+            quit = service.waiting() => {
+                let reason = quit.context("stdio transport task failed")?;
+                info!(?reason, "stdio transport closed");
+            }
+            _ = tokio::signal::ctrl_c() => info!("shutdown signal received"),
+        }
     }
 
     Ok(())
@@ -1139,6 +1271,57 @@ mod tests {
             Some(Command::Serve(args)) => assert_eq!(args.bind, "0.0.0.0:9090"),
             _ => panic!("expected Serve command"),
         }
+    }
+
+    #[test]
+    fn test_cli_serve_transport_defaults_to_http() {
+        let cli = Cli::try_parse_from(["memory-mcp", "serve"]).expect("serve should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.transport, Transport::Http),
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_transport_stdio_parses() {
+        let cli = Cli::try_parse_from(["memory-mcp", "serve", "--transport", "stdio"])
+            .expect("serve --transport stdio should parse");
+        match cli.command {
+            Some(Command::Serve(args)) => assert_eq!(args.transport, Transport::Stdio),
+            _ => panic!("expected Serve command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_serve_transport_rejects_unknown_value() {
+        assert!(
+            Cli::try_parse_from(["memory-mcp", "serve", "--transport", "carrier-pigeon"]).is_err(),
+            "unknown transport value must be rejected"
+        );
+    }
+
+    #[test]
+    fn single_writer_lock_excludes_second_acquisition_and_releases_on_drop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let index_dir = tmp.path().join(".memory-mcp-index");
+
+        let guard = acquire_single_writer_lock(&index_dir).expect("first acquire");
+
+        // flock is per open-file-description, so a second acquisition from
+        // the same process still contends — same shape as a second process.
+        let err = acquire_single_writer_lock(&index_dir).expect_err("second acquire must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("already serving"),
+            "error should explain the contention: {msg}"
+        );
+        assert!(
+            msg.contains(&std::process::id().to_string()),
+            "error should name the holder pid: {msg}"
+        );
+
+        drop(guard);
+        let _reacquired = acquire_single_writer_lock(&index_dir).expect("re-acquire after release");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1095,11 +1095,11 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // The transport drain above cannot vouch for application mutations:
     // rmcp bounds its awaited response drain (~2s) and detaches handler
     // tasks, so a mutation stalled past that window is still running when
-    // the transport reports closed (#329 review, round 3). Await the
-    // application's own mutation registry before touching the index. On
-    // deadline expiry the helper records a mirror gap, so persistence below
-    // keeps the last verified SHA instead of certifying an index a killed
-    // mutation never finished mirroring.
+    // the transport reports closed (#329 review, round 3). Seal admission
+    // and await the application's own mutation registry before touching the
+    // index (#329 review, round 4: the seal closes the window where a
+    // detached handler not yet polled could register *after* the drain
+    // observed zero in-flight).
     if memory_mcp::server::drain_mutations_before_persist(
         &state_for_shutdown,
         SHUTDOWN_MUTATION_DRAIN_DEADLINE,
@@ -1107,18 +1107,34 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     .await
     {
         info!("mutation units drained — persisting vector index");
-    }
 
-    // Persist the scoped vector index so the next startup can skip a full
-    // reindex. The stored SHA only advances when the in-process mirror is
-    // intact — a recorded mirror gap keeps the last verified SHA so the next
-    // startup rebuilds from git truth.
-    if let Err(e) =
-        memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
-    {
-        tracing::warn!("failed to persist vector index on shutdown: {}", e);
+        // Persist the scoped vector index so the next startup can skip a
+        // full reindex. The stored SHA only advances when the in-process
+        // mirror is intact — a recorded mirror gap keeps the last verified
+        // SHA so the next startup rebuilds from git truth.
+        if let Err(e) =
+            memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
+        {
+            tracing::warn!("failed to persist vector index on shutdown: {}", e);
+        } else {
+            info!("vector index saved to {}", index_dir.display());
+        }
     } else {
-        info!("vector index saved to {}", index_dir.display());
+        // Drain deadline expired with a mutation abandoned mid-flight. Do
+        // not touch the on-disk index at all (#329 review, round 4): the
+        // in-memory index may hold that unit's partial mirror *without* git
+        // HEAD having advanced, so writing it out — even with the last
+        // verified SHA — could hand the next startup a dirty index whose
+        // stored SHA still equals HEAD. The untouched on-disk snapshot was
+        // consistent with git when it was written: if the abandoned unit's
+        // commit landed, HEAD moved and the SHA check forces a reindex; if
+        // it never landed, the snapshot still mirrors git truth. The drain
+        // helper has also revoked the in-memory certification for any other
+        // persistence path.
+        tracing::warn!(
+            "mutation drain deadline expired — leaving the on-disk vector index \
+             untouched; the next startup reindexes from git truth as needed"
+        );
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -726,14 +726,26 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// How long shutdown waits for in-flight application mutation units after
+/// the transport has closed, before giving up and persisting the index
+/// *uncertified* (#329 review, round 3).
+///
+/// Generous on purpose: a unit mid-embedding on a cold CPU backend can
+/// legitimately take tens of seconds. Expiry never certifies — the drain
+/// helper records a mirror gap so the persisted index keeps its last
+/// verified SHA and the next startup reindexes from git truth.
+const SHUTDOWN_MUTATION_DRAIN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Terminate the process explicitly after a stdio serve session.
 ///
 /// tokio's `Stdin` performs reads on the blocking thread pool; a read that
 /// is still pending — the client held its end of the pipe open while we shut
 /// down on a signal — keeps the runtime's drop at the end of `main` waiting
 /// indefinitely. All durable state (git repos, vector index, recall log) has
-/// already been flushed by `run_serve` by the time it returns, so exiting
-/// here loses nothing and makes SIGTERM shutdown deterministic.
+/// already been flushed by `run_serve` by the time it returns — including
+/// awaiting the in-flight mutation registry, or refusing index certification
+/// when its deadline expired — so exiting here loses nothing and makes
+/// SIGTERM shutdown deterministic.
 fn exit_after_stdio_serve(result: anyhow::Result<()>) -> ! {
     match result {
         Ok(()) => std::process::exit(0),
@@ -1080,6 +1092,23 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         Transport::Stdio => serve_stdio(Arc::clone(&state)).await?,
     }
 
+    // The transport drain above cannot vouch for application mutations:
+    // rmcp bounds its awaited response drain (~2s) and detaches handler
+    // tasks, so a mutation stalled past that window is still running when
+    // the transport reports closed (#329 review, round 3). Await the
+    // application's own mutation registry before touching the index. On
+    // deadline expiry the helper records a mirror gap, so persistence below
+    // keeps the last verified SHA instead of certifying an index a killed
+    // mutation never finished mirroring.
+    if memory_mcp::server::drain_mutations_before_persist(
+        &state_for_shutdown,
+        SHUTDOWN_MUTATION_DRAIN_DEADLINE,
+    )
+    .await
+    {
+        info!("mutation units drained — persisting vector index");
+    }
+
     // Persist the scoped vector index so the next startup can skip a full
     // reindex. The stored SHA only advances when the in-process mirror is
     // intact — a recorded mirror gap keeps the last verified SHA so the next
@@ -1189,6 +1218,13 @@ async fn serve_stdio(state: Arc<AppState>) -> anyhow::Result<()> {
 /// mutation (#329 review, round 2). So on shutdown this cancels through the
 /// service's token and then awaits the same waiting future, making
 /// drain-before-persist a contract instead of a coincidence.
+///
+/// That contract is *bounded*: rmcp 1.8 drains handler responses for at
+/// most ~2 seconds and its handler tasks are detached, so a mutation
+/// stalled past the window outlives this function (#329 review, round 3).
+/// Returning here therefore only means the transport is closed —
+/// `run_serve` must still await the application's mutation registry
+/// (`drain_mutations_before_persist`) before index persistence may certify.
 async fn drive_service_until_quit<S>(
     service: rmcp::service::RunningService<rmcp::RoleServer, S>,
     shutdown: impl std::future::Future<Output = ()>,
@@ -1901,12 +1937,16 @@ mod tests {
     }
 
     /// Test handler whose only tool call blocks until released, recording
-    /// entry and completion so tests can assert drain ordering.
+    /// entry and completion so tests can assert drain ordering. When a
+    /// mutation registry is supplied, the call holds a registry slot for its
+    /// full duration — the same accounting `shielded_mutation_unit` gives
+    /// real mutation units.
     #[derive(Clone)]
     struct BlockingToolServer {
         entered: Arc<tokio::sync::Notify>,
         release: Arc<tokio::sync::Notify>,
         done: Arc<std::sync::atomic::AtomicBool>,
+        registry: Option<Arc<memory_mcp::types::MutationRegistry>>,
     }
 
     impl rmcp::ServerHandler for BlockingToolServer {
@@ -1915,6 +1955,7 @@ mod tests {
             _request: rmcp::model::CallToolRequestParams,
             _context: rmcp::service::RequestContext<rmcp::RoleServer>,
         ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+            let _slot = self.registry.as_ref().map(|r| r.enter());
             self.entered.notify_one();
             self.release.notified().await;
             self.done.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -1922,31 +1963,14 @@ mod tests {
         }
     }
 
-    /// Regression for #329 review round 2 (medium): a shutdown signal must
-    /// not let `drive_service_until_quit` return while a tool call is still
-    /// executing. `run_serve` persists the vector index immediately after
-    /// this function returns, so returning early would race persistence
-    /// against the in-flight mutation. The blocked handler is released only
-    /// 250ms *after* the shutdown fires; the old drop-the-waiting-future
-    /// code returned immediately and failed the `done` assertion.
-    #[tokio::test]
-    async fn shutdown_signal_drains_in_flight_tool_call_before_returning() {
+    /// Drive the client half of an in-memory stdio transport: initialize
+    /// handshake, then a `tools/call` that blocks inside the handler. Holds
+    /// its end of the pipe open, draining server output until close.
+    fn spawn_blocking_tool_client(
+        client_io: tokio::io::DuplexStream,
+    ) -> tokio::task::JoinHandle<()> {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-
-        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
-
-        let entered = Arc::new(tokio::sync::Notify::new());
-        let release = Arc::new(tokio::sync::Notify::new());
-        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let handler = BlockingToolServer {
-            entered: Arc::clone(&entered),
-            release: Arc::clone(&release),
-            done: Arc::clone(&done),
-        };
-
-        // Drive the client side over the in-memory transport: initialize
-        // handshake, then a tools/call that blocks inside the handler.
-        let client = tokio::spawn(async move {
+        tokio::spawn(async move {
             let (read_half, mut write_half) = tokio::io::split(client_io);
             let mut lines = BufReader::new(read_half).lines();
             write_half
@@ -1985,7 +2009,31 @@ mod tests {
             // whatever the server sends until it closes the transport.
             while let Ok(Some(_)) = lines.next_line().await {}
             drop(write_half);
-        });
+        })
+    }
+
+    /// Regression for #329 review round 2 (medium): a shutdown signal must
+    /// not let `drive_service_until_quit` return while a tool call is still
+    /// executing. `run_serve` persists the vector index immediately after
+    /// this function returns, so returning early would race persistence
+    /// against the in-flight mutation. The blocked handler is released only
+    /// 250ms *after* the shutdown fires; the old drop-the-waiting-future
+    /// code returned immediately and failed the `done` assertion.
+    #[tokio::test]
+    async fn shutdown_signal_drains_in_flight_tool_call_before_returning() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler = BlockingToolServer {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            done: Arc::clone(&done),
+            registry: None,
+        };
+
+        let client = spawn_blocking_tool_client(client_io);
 
         let service = rmcp::serve_server(handler, server_io)
             .await
@@ -2015,6 +2063,93 @@ mod tests {
             done.load(std::sync::atomic::Ordering::SeqCst),
             "service returned before the in-flight tool call completed — \
              index persistence would race the mutation"
+        );
+        releaser.await.expect("releaser task");
+        client.abort();
+    }
+
+    /// Regression for #329 review round 3 (medium): rmcp's awaited
+    /// cancellation drain is bounded (~2s in rmcp 1.8) and its handler tasks
+    /// are detached, so a mutation blocked *beyond* that window outlives
+    /// `waiting()` — the round-2 test above releases at 250ms, inside the
+    /// window, and cannot exercise this boundary. Here the handler holds a
+    /// mutation-registry slot (the same accounting `shielded_mutation_unit`
+    /// gives real units) and stays blocked until 4s after the shutdown
+    /// signal, proving:
+    ///
+    /// 1. the transport drain returns first with the mutation still
+    ///    executing (`done` is false) — exactly the state in which
+    ///    `run_serve` previously began stamping the index, and
+    /// 2. the registry drain — the gate `run_serve` now applies before
+    ///    persistence — does not pass until the mutation completes, with no
+    ///    2s ceiling.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn shutdown_awaits_mutation_blocked_beyond_rmcp_drain_window() {
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        let registry = Arc::new(memory_mcp::types::MutationRegistry::default());
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler = BlockingToolServer {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            done: Arc::clone(&done),
+            registry: Some(Arc::clone(&registry)),
+        };
+
+        let client = spawn_blocking_tool_client(client_io);
+
+        let service = rmcp::serve_server(handler, server_io)
+            .await
+            .expect("initialize over in-memory transport");
+
+        // Wait until the mutation is provably in flight and registered.
+        entered.notified().await;
+        assert_eq!(registry.in_flight(), 1, "handler must hold its slot");
+
+        // Release the blocked handler 4s after the signal fires — well
+        // *outside* rmcp's ~2s cancellation drain window.
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(4)).await;
+            release.notify_one();
+        });
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        shutdown_tx.send(()).expect("send shutdown signal");
+        drive_service_until_quit(service, async {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .expect("drive_service_until_quit");
+
+        // The transport gave up before the mutation finished. If this fires,
+        // rmcp's bounded-drain behavior changed (it now awaits handlers
+        // fully) — re-evaluate whether the registry gate and this regression
+        // still model reality.
+        assert!(
+            !done.load(std::sync::atomic::Ordering::SeqCst),
+            "expected the transport drain to return while the mutation was \
+             still blocked (rmcp's ~2s drain ceiling); it drained fully instead"
+        );
+        assert_eq!(
+            registry.in_flight(),
+            1,
+            "the abandoned mutation must still hold its registry slot"
+        );
+
+        // The gate `run_serve` applies before persistence: it must wait out
+        // the mutation rather than inherit the transport's ceiling.
+        assert!(
+            registry
+                .drained_within(std::time::Duration::from_secs(30))
+                .await,
+            "registry drain must resolve once the mutation completes"
+        );
+        assert!(
+            done.load(std::sync::atomic::Ordering::SeqCst),
+            "registry drained before the mutation completed — index \
+             persistence would still race the mutation"
         );
         releaser.await.expect("releaser task");
         client.abort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1101,47 +1101,61 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // index (#329 review, round 4: the seal closes the window where a
     // detached handler not yet polled could register *after* the drain
     // observed zero in-flight).
-    if memory_mcp::server::drain_mutations_before_persist(
+    match memory_mcp::server::drain_mutations_before_persist(
         &state_for_shutdown,
         &index_dir,
         SHUTDOWN_MUTATION_DRAIN_DEADLINE,
     )
     .await
     {
-        info!("mutation units drained — persisting vector index");
+        Ok(true) => {
+            info!("mutation units drained — persisting vector index");
 
-        // Persist the scoped vector index so the next startup can skip a
-        // full reindex. The stored SHA only advances when the in-process
-        // mirror is intact — a recorded mirror gap keeps the last verified
-        // SHA so the next startup rebuilds from git truth.
-        if let Err(e) =
-            memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
-        {
-            tracing::warn!("failed to persist vector index on shutdown: {}", e);
-        } else {
-            info!("vector index saved to {}", index_dir.display());
+            // Persist the scoped vector index so the next startup can skip a
+            // full reindex. The stored SHA only advances when the in-process
+            // mirror is intact — a recorded mirror gap keeps the last verified
+            // SHA so the next startup rebuilds from git truth.
+            if let Err(e) =
+                memory_mcp::server::persist_index_on_shutdown(&state_for_shutdown, &index_dir).await
+            {
+                tracing::warn!("failed to persist vector index on shutdown: {}", e);
+            } else {
+                info!("vector index saved to {}", index_dir.display());
+            }
         }
-    } else {
-        // Drain deadline expired with a mutation abandoned mid-flight. Do
-        // not touch the on-disk index at all (#329 review, round 4): the
-        // in-memory index may hold that unit's partial mirror *without* git
-        // HEAD having advanced, so writing it out — even with the last
-        // verified SHA — could hand the next startup a dirty index whose
-        // stored SHA still equals HEAD. The untouched on-disk snapshot was
-        // consistent with git when it was written: if the abandoned unit's
-        // commit landed, HEAD moved and the SHA check forces a reindex; if
-        // it never landed, the snapshot still mirrors git truth. The drain
-        // helper has also revoked the in-memory certification for any other
-        // persistence path, and — because that revocation dies with this
-        // process while the old snapshot's stored SHA may still equal an
-        // unadvanced HEAD — written a durable reindex-required marker so the
-        // next startup rebuilds regardless of SHA/HEAD equality (#329
-        // review, round 4).
-        tracing::warn!(
-            "mutation drain deadline expired — leaving the on-disk vector index \
-             untouched; the reindex-required marker forces the next startup to \
-             rebuild from git truth"
-        );
+        Ok(false) => {
+            // Drain deadline expired with a mutation abandoned mid-flight. Do
+            // not touch the on-disk index at all (#329 review, round 4): the
+            // in-memory index may hold that unit's partial mirror *without* git
+            // HEAD having advanced, so writing it out — even with the last
+            // verified SHA — could hand the next startup a dirty index whose
+            // stored SHA still equals HEAD. The untouched on-disk snapshot was
+            // consistent with git when it was written: if the abandoned unit's
+            // commit landed, HEAD moved and the SHA check forces a reindex; if
+            // it never landed, the snapshot still mirrors git truth. The drain
+            // helper has also revoked the in-memory certification for any other
+            // persistence path, and — because that revocation dies with this
+            // process while the old snapshot's stored SHA may still equal an
+            // unadvanced HEAD — durably recorded the forced next-start reindex
+            // (reindex-required marker, or on marker-write failure the
+            // persisted certification itself is revoked) so the next startup
+            // rebuilds regardless of SHA/HEAD equality (#329 review, rounds
+            // 4–5).
+            tracing::warn!(
+                "mutation drain deadline expired — leaving the on-disk vector index \
+                 untouched; the durable revocation forces the next startup to \
+                 rebuild from git truth"
+            );
+        }
+        Err(e) => {
+            // Neither durable revocation channel could be recorded (#329
+            // review, round 5): exiting normally here would let the next
+            // startup wrongly certify the stale on-disk snapshot when HEAD
+            // did not advance. Propagate so shutdown reports failure
+            // (non-zero exit) instead of logging the guarantee away.
+            return Err(anyhow::Error::from(e)
+                .context("shutdown could not durably revoke index certification"));
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,13 +789,31 @@ fn acquire_single_writer_lock(repo_path: &std::path::Path) -> anyhow::Result<std
     std::fs::create_dir_all(&index_dir)
         .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
     let lock_path = index_dir.join(".lock");
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(not(unix))]
+    if std::fs::symlink_metadata(&lock_path).is_ok_and(|metadata| metadata.file_type().is_symlink())
+    {
+        anyhow::bail!(
+            "refusing symlink at single-writer lock path {}",
+            lock_path.display()
+        );
+    }
+    let file = options
         .open(&lock_path)
         .with_context(|| format!("failed to open lock file {}", lock_path.display()))?;
+    anyhow::ensure!(
+        file.metadata()
+            .with_context(|| format!("failed to inspect lock file {}", lock_path.display()))?
+            .is_file(),
+        "single-writer lock path is not a regular file: {}",
+        lock_path.display()
+    );
     match file.try_lock() {
         Ok(()) => {
             // Best-effort holder breadcrumb for the contention error below.
@@ -806,9 +824,12 @@ fn acquire_single_writer_lock(repo_path: &std::path::Path) -> anyhow::Result<std
             Ok(file)
         }
         Err(std::fs::TryLockError::WouldBlock) => {
-            let holder = std::fs::read_to_string(&lock_path)
+            use std::io::Read;
+            let mut holder_text = String::new();
+            let holder = (&file)
+                .read_to_string(&mut holder_text)
                 .ok()
-                .map(|s| s.trim().to_string())
+                .map(|_| holder_text.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "unknown".to_string());
             anyhow::bail!(
@@ -1493,6 +1514,29 @@ mod tests {
 
         drop(guard);
         let _reacquired = acquire_single_writer_lock(&index_dir).expect("re-acquire after release");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn single_writer_lock_rejects_planted_symlink_without_clobbering_target() {
+        let repo = tempfile::tempdir().expect("tempdir");
+        let index_dir = repo.path().join(".memory-mcp-index");
+        std::fs::create_dir(&index_dir).expect("index dir");
+        let target = repo.path().join("decoy");
+        std::fs::write(&target, b"do not clobber\n").expect("seed target");
+        std::os::unix::fs::symlink(&target, index_dir.join(".lock")).expect("plant symlink");
+
+        let err = acquire_single_writer_lock(repo.path())
+            .expect_err("O_NOFOLLOW must reject a planted lock symlink");
+        assert!(
+            format!("{err:#}").contains("failed to open lock file"),
+            "startup must fail loudly at the unsafe lock path: {err:#}"
+        );
+        assert_eq!(
+            std::fs::read(&target).expect("read target"),
+            b"do not clobber\n",
+            "PID breadcrumb writes must never reach the symlink target"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1002,6 +1002,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         initial_pull,
         &router,
         embedding.as_ref(),
+        &index_dir,
         loaded_index,
         move || {
             Box::new(
@@ -1102,6 +1103,7 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // observed zero in-flight).
     if memory_mcp::server::drain_mutations_before_persist(
         &state_for_shutdown,
+        &index_dir,
         SHUTDOWN_MUTATION_DRAIN_DEADLINE,
     )
     .await
@@ -1130,10 +1132,15 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
         // commit landed, HEAD moved and the SHA check forces a reindex; if
         // it never landed, the snapshot still mirrors git truth. The drain
         // helper has also revoked the in-memory certification for any other
-        // persistence path.
+        // persistence path, and — because that revocation dies with this
+        // process while the old snapshot's stored SHA may still equal an
+        // unadvanced HEAD — written a durable reindex-required marker so the
+        // next startup rebuilds regardless of SHA/HEAD equality (#329
+        // review, round 4).
         tracing::warn!(
             "mutation drain deadline expired — leaving the on-disk vector index \
-             untouched; the next startup reindexes from git truth as needed"
+             untouched; the reindex-required marker forces the next startup to \
+             rebuild from git truth"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -652,6 +652,7 @@ async fn main() -> anyhow::Result<()> {
             let cli = Cli::parse_from(["memory-mcp", "serve"]);
             match cli.command {
                 Some(Command::Serve(args)) => {
+                    let is_stdio = args.transport == Transport::Stdio;
                     #[cfg(feature = "otlp")]
                     let _otlp_provider = init_tracing_for_serve(&args);
                     let result = run_serve(args).await;
@@ -659,18 +660,25 @@ async fn main() -> anyhow::Result<()> {
                     if let Some(provider) = _otlp_provider {
                         let _ = provider.shutdown();
                     }
+                    if is_stdio {
+                        exit_after_stdio_serve(result);
+                    }
                     result?;
                 }
                 _ => unreachable!(),
             }
         }
         Some(Command::Serve(args)) => {
+            let is_stdio = args.transport == Transport::Stdio;
             #[cfg(feature = "otlp")]
             let _otlp_provider = init_tracing_for_serve(&args);
             let result = run_serve(args).await;
             #[cfg(feature = "otlp")]
             if let Some(provider) = _otlp_provider {
                 let _ = provider.shutdown();
+            }
+            if is_stdio {
+                exit_after_stdio_serve(result);
             }
             result?;
         }
@@ -718,26 +726,55 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Terminate the process explicitly after a stdio serve session.
+///
+/// tokio's `Stdin` performs reads on the blocking thread pool; a read that
+/// is still pending — the client held its end of the pipe open while we shut
+/// down on a signal — keeps the runtime's drop at the end of `main` waiting
+/// indefinitely. All durable state (git repos, vector index, recall log) has
+/// already been flushed by `run_serve` by the time it returns, so exiting
+/// here loses nothing and makes SIGTERM shutdown deterministic.
+fn exit_after_stdio_serve(result: anyhow::Result<()>) -> ! {
+    match result {
+        Ok(()) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            std::process::exit(1);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Single-writer lock
 // ---------------------------------------------------------------------------
 
-/// Acquire the advisory single-writer lock for a memory repository.
+/// Acquire the advisory single-writer lock for one memory repository.
 ///
-/// The server assumes exclusive ownership of the git repo, the usearch index
-/// files, and the recall log; none of these tolerate a second writer
-/// (ADR-0040). The lock is an OS advisory lock ([`std::fs::File::try_lock`],
-/// `flock` semantics on Linux) on `<index_dir>/.lock`, so the kernel releases
-/// it when the process exits — including on crash — and it can never go stale.
+/// The server assumes exclusive ownership of every git repo it opens, the
+/// usearch index files, and the recall log; none of these tolerate a second
+/// writer (ADR-0040). That covers not just the default `--repo-path` repo
+/// but every scope-mapped repository from config — two processes with
+/// different defaults can still share a mapped repo, so `run_serve` calls
+/// this once per distinct canonical repo path, in sorted order, and retains
+/// all guards. Sorted acquisition keeps contention deterministic: processes
+/// sharing any subset of repos always collide on the first shared path.
 ///
-/// Fails fast when another process holds the lock, naming the holder's pid.
-/// No waiting, no lease heuristics: a second server on the same repository is
-/// a deployment error regardless of which transport either process uses.
+/// The lock is an OS advisory lock ([`std::fs::File::try_lock`], `flock`
+/// semantics on Linux) on `<repo>/.memory-mcp-index/.lock`, so the kernel
+/// releases it when the process exits — including on crash — and it can
+/// never go stale.
+///
+/// Fails fast when another process holds the lock, naming the holder's pid
+/// and the contended repository path. No waiting, no lease heuristics: a
+/// second server writing the same repository is a deployment error
+/// regardless of which transport either process uses or whether the repo is
+/// a default or a mapping.
 ///
 /// The returned guard must be kept alive for the lifetime of the server;
 /// dropping it releases the lock.
-fn acquire_single_writer_lock(index_dir: &std::path::Path) -> anyhow::Result<std::fs::File> {
-    std::fs::create_dir_all(index_dir)
+fn acquire_single_writer_lock(repo_path: &std::path::Path) -> anyhow::Result<std::fs::File> {
+    let index_dir = repo_path.join(".memory-mcp-index");
+    std::fs::create_dir_all(&index_dir)
         .with_context(|| format!("failed to create index dir {}", index_dir.display()))?;
     let lock_path = index_dir.join(".lock");
     let file = std::fs::OpenOptions::new()
@@ -763,10 +800,13 @@ fn acquire_single_writer_lock(index_dir: &std::path::Path) -> anyhow::Result<std
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "unknown".to_string());
             anyhow::bail!(
-                "another memory-mcp process (pid {holder}) is already serving this \
-                 repository (lock file: {}). The server requires exclusive access \
-                 to the memory repo, its vector index, and its recall log — stop \
-                 the other instance or point --repo-path at a different repository.",
+                "another memory-mcp process (pid {holder}) is already serving the \
+                 repository at {} (lock file: {}). The server requires exclusive \
+                 access to every memory repo it opens — default or scope-mapped — \
+                 including its vector index and recall log. Stop the other \
+                 instance, or remove the shared repository from one of the \
+                 configurations.",
+                repo_path.display(),
                 lock_path.display()
             )
         }
@@ -799,10 +839,58 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
     // all live under `.memory-mcp-index` inside the repo path.
     let index_dir = repo_path.join(".memory-mcp-index");
 
-    // Enforce single-writer before any subsystem opens: the git repo, index
+    // Load per-scope remote config BEFORE locking: scope-mapped repositories
+    // are written by this process exactly like the default one, so the
+    // single-writer guarantee must cover every repo the config names — two
+    // processes with distinct defaults sharing one mapped repo would
+    // otherwise hold different locks while mutating the same git tree
+    // (#329 review, round 2).
+    let config = {
+        let config_path = match &args.config {
+            Some(p) if p.is_empty() => None,
+            Some(p) => Some(expand_path(p)?),
+            None => memory_mcp::config::Config::resolve_path().ok(),
+        };
+        match config_path {
+            Some(path) => Some(
+                memory_mcp::config::Config::load(&path)
+                    .with_context(|| format!("failed to load config from {}", path.display()))?,
+            ),
+            None => None,
+        }
+    };
+
+    // Collect every distinct repository this process will write: the default
+    // plus all mapped paths, canonicalized so different spellings of one
+    // location cannot yield different lock files. BTreeSet gives sorted,
+    // deduplicated acquisition order — deterministic contention, and no
+    // self-conflict when a mapping resolves to the default repo (the router
+    // rejects that collision later with a clearer error).
+    let mut lock_targets = std::collections::BTreeSet::new();
+    lock_targets.insert(repo_path.clone());
+    if let Some(config) = &config {
+        for mapping in &config.remotes {
+            let mapped = mapping
+                .resolved_path()
+                .with_context(|| format!("failed to resolve path for scope '{}'", mapping.scope))?;
+            let mapped =
+                memory_mcp::fs_util::canonicalize_allow_missing(&mapped).with_context(|| {
+                    format!(
+                        "failed to canonicalize repo path for scope '{}'",
+                        mapping.scope
+                    )
+                })?;
+            lock_targets.insert(mapped);
+        }
+    }
+
+    // Enforce single-writer before any subsystem opens: the git repos, index
     // files, and recall log all assume exclusive ownership (ADR-0040).
     // Acquiring before the (slow) embedding init makes contention fail fast.
-    let _single_writer_lock = acquire_single_writer_lock(&index_dir)?;
+    let _single_writer_locks: Vec<std::fs::File> = lock_targets
+        .iter()
+        .map(|repo| acquire_single_writer_lock(repo))
+        .collect::<anyhow::Result<_>>()?;
 
     // Filter out empty string to treat MEMORY_MCP_REMOTE_URL="" as unset.
     let remote_url = args.remote_url.clone().filter(|u| !u.is_empty());
@@ -857,31 +945,20 @@ async fn run_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     let repo = Arc::new(repo);
 
-    // Load per-scope remote config and build the repo router.
-    let router = {
-        let config_path = match &args.config {
-            Some(p) if p.is_empty() => None,
-            Some(p) => Some(expand_path(p)?),
-            None => memory_mcp::config::Config::resolve_path().ok(),
-        };
-
-        if let Some(ref path) = config_path {
-            let config = memory_mcp::config::Config::load(path)
-                .with_context(|| format!("failed to load config from {}", path.display()))?;
-            if config.remotes.is_empty() {
-                memory_mcp::repo_router::RepoRouter::single(Arc::clone(&repo))
-            } else {
-                memory_mcp::repo_router::RepoRouter::from_config(
-                    Arc::clone(&repo),
-                    &config.remotes,
-                    &health.git,
-                    &health.sync,
-                )
-                .context("failed to initialise scope-specific repos from config")?
-            }
-        } else {
-            memory_mcp::repo_router::RepoRouter::single(Arc::clone(&repo))
+    // Build the repo router from the config loaded above (before lock
+    // acquisition) — every repo the router opens is already covered by a
+    // single-writer lock held by this process.
+    let router = match &config {
+        Some(config) if !config.remotes.is_empty() => {
+            memory_mcp::repo_router::RepoRouter::from_config(
+                Arc::clone(&repo),
+                &config.remotes,
+                &health.git,
+                &health.sync,
+            )
+            .context("failed to initialise scope-specific repos from config")?
         }
+        _ => memory_mcp::repo_router::RepoRouter::single(Arc::clone(&repo)),
     };
 
     // Load the persisted index; create fresh if missing or corrupt. Freshness
@@ -1078,21 +1155,7 @@ async fn serve_http(args: &ServeArgs, state: Arc<AppState>) -> anyhow::Result<()
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            #[cfg(unix)]
-            {
-                use tokio::signal::unix::{signal, SignalKind};
-                let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
-                tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {},
-                    _ = sigterm.recv() => {},
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                tokio::signal::ctrl_c()
-                    .await
-                    .expect("failed to listen for ctrl-c");
-            }
+            shutdown_signal().await;
             info!("shutdown signal received");
             ct.cancel();
         })
@@ -1112,33 +1175,68 @@ async fn serve_stdio(state: Arc<AppState>) -> anyhow::Result<()> {
         .await
         .context("failed to initialize stdio transport")?;
 
-    // Quit when the client closes stdin (normal MCP lifecycle) or on a
-    // shutdown signal — either way the caller persists the index afterwards.
+    drive_service_until_quit(service, shutdown_signal()).await
+}
+
+/// Run an initialized rmcp service until the client closes the session or
+/// `shutdown` resolves (SIGINT/SIGTERM in production).
+///
+/// The signal path must not simply drop the `waiting()` future: rmcp only
+/// guarantees cleanup ordering — draining in-flight handler responses, then
+/// closing the transport — for an *awaited* cancellation; a dropped future
+/// leaves the drop guard cancelling asynchronously while `run_serve`
+/// proceeds to stamp and persist the vector index, racing any in-flight
+/// mutation (#329 review, round 2). So on shutdown this cancels through the
+/// service's token and then awaits the same waiting future, making
+/// drain-before-persist a contract instead of a coincidence.
+async fn drive_service_until_quit<S>(
+    service: rmcp::service::RunningService<rmcp::RoleServer, S>,
+    shutdown: impl std::future::Future<Output = ()>,
+) -> anyhow::Result<()>
+where
+    S: rmcp::service::Service<rmcp::RoleServer>,
+{
+    // Grab the cancellation token before `waiting()` consumes the service.
+    let ct = service.cancellation_token();
+    let waiting = service.waiting();
+    tokio::pin!(waiting);
+    tokio::pin!(shutdown);
+
+    tokio::select! {
+        quit = &mut waiting => {
+            let reason = quit.context("stdio transport task failed")?;
+            info!(?reason, "stdio transport closed");
+        }
+        _ = &mut shutdown => {
+            info!("shutdown signal received — draining service before index persistence");
+            ct.cancel();
+            let reason = waiting
+                .await
+                .context("stdio transport task failed during shutdown drain")?;
+            info!(?reason, "stdio transport drained and closed");
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolve when the process receives SIGINT (ctrl-c) or, on unix, SIGTERM.
+async fn shutdown_signal() {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{signal, SignalKind};
         let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
         tokio::select! {
-            quit = service.waiting() => {
-                let reason = quit.context("stdio transport task failed")?;
-                info!(?reason, "stdio transport closed");
-            }
-            _ = tokio::signal::ctrl_c() => info!("shutdown signal received"),
-            _ = sigterm.recv() => info!("shutdown signal received"),
+            _ = tokio::signal::ctrl_c() => {},
+            _ = sigterm.recv() => {},
         }
     }
     #[cfg(not(unix))]
     {
-        tokio::select! {
-            quit = service.waiting() => {
-                let reason = quit.context("stdio transport task failed")?;
-                info!(?reason, "stdio transport closed");
-            }
-            _ = tokio::signal::ctrl_c() => info!("shutdown signal received"),
-        }
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to listen for ctrl-c");
     }
-
-    Ok(())
 }
 
 /// Print recall precision statistics bucketed by distance range.
@@ -1800,5 +1898,125 @@ mod tests {
             },
             _ => panic!("expected Auth command"),
         }
+    }
+
+    /// Test handler whose only tool call blocks until released, recording
+    /// entry and completion so tests can assert drain ordering.
+    #[derive(Clone)]
+    struct BlockingToolServer {
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+        done: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl rmcp::ServerHandler for BlockingToolServer {
+        async fn call_tool(
+            &self,
+            _request: rmcp::model::CallToolRequestParams,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> Result<rmcp::model::CallToolResult, rmcp::ErrorData> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            self.done.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(rmcp::model::CallToolResult::success(vec![]))
+        }
+    }
+
+    /// Regression for #329 review round 2 (medium): a shutdown signal must
+    /// not let `drive_service_until_quit` return while a tool call is still
+    /// executing. `run_serve` persists the vector index immediately after
+    /// this function returns, so returning early would race persistence
+    /// against the in-flight mutation. The blocked handler is released only
+    /// 250ms *after* the shutdown fires; the old drop-the-waiting-future
+    /// code returned immediately and failed the `done` assertion.
+    #[tokio::test]
+    async fn shutdown_signal_drains_in_flight_tool_call_before_returning() {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let handler = BlockingToolServer {
+            entered: Arc::clone(&entered),
+            release: Arc::clone(&release),
+            done: Arc::clone(&done),
+        };
+
+        // Drive the client side over the in-memory transport: initialize
+        // handshake, then a tools/call that blocks inside the handler.
+        let client = tokio::spawn(async move {
+            let (read_half, mut write_half) = tokio::io::split(client_io);
+            let mut lines = BufReader::new(read_half).lines();
+            write_half
+                .write_all(
+                    concat!(
+                        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":"#,
+                        r#"{"protocolVersion":"2025-03-26","capabilities":{},"#,
+                        r#""clientInfo":{"name":"drain-test","version":"0"}}}"#,
+                        "\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write initialize");
+            lines
+                .next_line()
+                .await
+                .expect("read initialize response")
+                .expect("initialize response before EOF");
+            write_half
+                .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+                .await
+                .expect("write initialized notification");
+            write_half
+                .write_all(
+                    concat!(
+                        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":"#,
+                        r#"{"name":"block","arguments":{}}}"#,
+                        "\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .expect("write tools/call");
+            // Hold the connection open (keeping write_half alive) and drain
+            // whatever the server sends until it closes the transport.
+            while let Ok(Some(_)) = lines.next_line().await {}
+            drop(write_half);
+        });
+
+        let service = rmcp::serve_server(handler, server_io)
+            .await
+            .expect("initialize over in-memory transport");
+
+        // Wait until the mutation is provably in flight.
+        entered.notified().await;
+
+        // Release the blocked handler 250ms after the signal fires — well
+        // inside rmcp's cancellation drain window — from a separate task, so
+        // an implementation that returns without draining is caught red-
+        // handed by the `done` flag.
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            release.notify_one();
+        });
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        shutdown_tx.send(()).expect("send shutdown signal");
+        drive_service_until_quit(service, async {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .expect("drive_service_until_quit");
+
+        assert!(
+            done.load(std::sync::atomic::Ordering::SeqCst),
+            "service returned before the in-flight tool call completed — \
+             index persistence would race the mutation"
+        );
+        releaser.await.expect("releaser task");
+        client.abort();
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -435,17 +435,25 @@ impl Drop for EditStageTiming {
 /// requester is needed to observe the failure. The `JoinError` arm below is
 /// only the *reporting* path for a requester that is still awaiting; it is
 /// not what the contract relies on.
-async fn shielded_mutation_unit<T, F>(
-    lexical: &Arc<LexicalIndex>,
-    unit: F,
-) -> Result<T, MemoryError>
+///
+/// Every unit also registers with [`AppState::mutations`] before it is
+/// spawned (#329 review, round 3): the transport's shutdown drain is bounded
+/// and detaches handler tasks, so index persistence gates on this registry —
+/// not the transport — to know when application mutations have quiesced. The
+/// slot is held by an RAII guard inside the detached task, so panic unwinds
+/// and task drops release it alongside the `DegradeOnDrop` marking.
+async fn shielded_mutation_unit<T, F>(state: &Arc<AppState>, unit: F) -> Result<T, MemoryError>
 where
     F: std::future::Future<Output = Result<T, MemoryError>> + Send + 'static,
     T: Send + 'static,
 {
-    let guard_lexical = Arc::clone(lexical);
+    // Enter the registry before spawning: from this point shutdown cannot
+    // certify index persistence until the unit's slot is released.
+    let mutation_slot = state.mutations.enter();
+    let guard_lexical = Arc::clone(&state.lexical);
     let worker = tokio::spawn(
         async move {
+            let _mutation_slot = mutation_slot;
             let guard = DegradeOnDrop::new(guard_lexical, "mutation unit died before completing");
             let outcome = unit.await;
             guard.defuse();
@@ -1067,7 +1075,51 @@ pub async fn startup_prepare_index(
 /// failed and the sync mirror refused SHA advancement — the index
 /// keeps the SHA it last legitimately verified, so the next startup sees the
 /// mismatch against git HEAD and rebuilds the vector index from git truth
-/// instead of trusting the incomplete mirror (#293 review, round 2).
+/// Await in-flight application mutation units before shutdown persistence.
+///
+/// The transport's own shutdown drain cannot vouch for these: rmcp's awaited
+/// cancellation bounds its response drain (~2s in rmcp 1.8) and detaches
+/// handler tasks, so a mutation stalled past the window — e.g. an embedding
+/// call after the git commit already landed — is still running when
+/// `waiting()` returns (#329 review, round 3). This waits on the
+/// application's [`MutationRegistry`](crate::types::MutationRegistry)
+/// instead, with no transport-imposed ceiling.
+///
+/// Returns `true` when every unit completed within `deadline`. On timeout it
+/// records a mirror gap and returns `false`: persistence then keeps the last
+/// verified SHA instead of stamping the (already mutated) git HEAD onto an
+/// index whose mirror the killed unit never finished, so the next startup
+/// detects the mismatch and reindexes from git truth. A hard shutdown
+/// deadline may abandon a mutation, but it must never certify the index as
+/// intact.
+pub async fn drain_mutations_before_persist(
+    state: &AppState,
+    deadline: std::time::Duration,
+) -> bool {
+    if state.mutations.drained_within(deadline).await {
+        true
+    } else {
+        warn!(
+            in_flight = state.mutations.in_flight(),
+            deadline_ms = deadline.as_millis() as u64,
+            "mutation units still in flight at shutdown drain deadline — \
+             refusing index certification so the next startup reindexes from git truth"
+        );
+        state.mark_index_mirror_incomplete();
+        false
+    }
+}
+
+/// Persist the vector index at graceful shutdown.
+///
+/// Advances the stored composite SHA to the router's current HEAD only when
+/// the in-process mirror is intact ([`AppState::index_mirror_is_intact`]).
+/// When a mirror gap was recorded — e.g. a sync's post-pull change discovery
+/// failed and the sync mirror refused SHA advancement, or the shutdown
+/// mutation drain deadline expired — the index keeps the SHA it last
+/// legitimately verified, so the next startup sees the mismatch against git
+/// HEAD and rebuilds the vector index from git truth instead of trusting the
+/// incomplete mirror (#293 review, round 2).
 pub async fn persist_index_on_shutdown(
     state: &AppState,
     index_dir: &std::path::Path,
@@ -1163,7 +1215,7 @@ impl MemoryServer {
             // git while stranding the mirror dispatch (#310, ADR-0039).
             let start = Instant::now();
             let unit_state = Arc::clone(&state);
-            let memory = shielded_mutation_unit(&state.lexical, async move {
+            let memory = shielded_mutation_unit(&state, async move {
                 unit_state.router.save_memory(&memory).await?;
                 info!(repo_ms = start.elapsed().as_millis(), "saved to repo");
 
@@ -1392,7 +1444,7 @@ impl MemoryServer {
             // deletion while stranding the index removals (#310, ADR-0039).
             let unit_state = Arc::clone(&state);
             let unit_name = name.clone();
-            shielded_mutation_unit(&state.lexical, async move {
+            shielded_mutation_unit(&state, async move {
                 // Delete from repo first — if this fails, index is untouched,
                 // memory stays functional.
                 unit_state
@@ -1527,7 +1579,7 @@ impl MemoryServer {
             // git while stranding the mirror dispatch (#310, ADR-0039).
             timing.stage = "repo_save";
             let unit_state = Arc::clone(&state);
-            let (memory, mut timing) = shielded_mutation_unit(&state.lexical, async move {
+            let (memory, mut timing) = shielded_mutation_unit(&state, async move {
                 let stage_start = Instant::now();
                 let save_result = unit_state.router.save_memory(&memory).await;
                 timing.repo_save_ms = elapsed_ms(stage_start);
@@ -1663,7 +1715,7 @@ impl MemoryServer {
             let unit_new_name = new_name.clone();
             let unit_from_scope = from_scope.clone();
             let unit_to_scope = to_scope.clone();
-            let dest = shielded_mutation_unit(&state.lexical, async move {
+            let dest = shielded_mutation_unit(&state, async move {
                 // 2. Atomically read source, write destination, delete source
                 //    in one git commit. Must happen before index mutations so a
                 //    failure leaves the index consistent with the repo on disk.
@@ -1930,7 +1982,7 @@ impl MemoryServer {
             let unit_state = Arc::clone(&state);
             let unit_branch = branch.clone();
             let (sync_result, total_reindex, any_reindex) =
-                shielded_mutation_unit(&state.lexical, async move {
+                shielded_mutation_unit(&state, async move {
                     let sync_result = unit_state
                         .router
                         .sync_all(&unit_state.auth, &unit_branch, pull_first)
@@ -4925,6 +4977,124 @@ mod tests {
             );
         }
 
+        /// #329 review round 3: a shutdown drain deadline that expires with
+        /// a mutation unit still in flight must never certify the index.
+        /// The unit here holds its registry slot while git HEAD has already
+        /// advanced (the unit's commit landed; its index mirror has not) —
+        /// the exact `move` failure mode from the review. The drain must
+        /// time out, record a mirror gap, and persistence must keep the
+        /// last verified SHA so the next startup reindexes from git truth.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn shutdown_drain_timeout_refuses_index_certification() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            // Verified state at A: git truth exists, mirror is intact, and
+            // shutdown-style persistence stamps HEAD-A.
+            let note_a = Memory::from_validated(
+                MemoryName::new("note-a".to_string()).unwrap(),
+                "payload a".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&note_a).await.expect("save a");
+            let dir_a = tempfile::tempdir().expect("index dir a");
+            persist_index_on_shutdown(&state, dir_a.path())
+                .await
+                .expect("persist at A");
+            let sha_a = state.index.commit_sha().expect("verified SHA at A");
+
+            // A mutation unit is in flight past the drain deadline: its git
+            // commit already moved HEAD past A, its index mirror is pending.
+            let stuck_unit_slot = state.mutations.enter();
+            let note_b = Memory::from_validated(
+                MemoryName::new("note-b".to_string()).unwrap(),
+                "payload b".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&note_b).await.expect("save b");
+            let head_b = state.router.head_sha().await.expect("git HEAD at B");
+            assert_ne!(head_b, sha_a, "git must have advanced past A");
+
+            // The deadline expires: certification must be refused…
+            let drained =
+                drain_mutations_before_persist(&state, std::time::Duration::from_millis(50)).await;
+            assert!(!drained, "drain must report the expired deadline");
+            assert!(
+                !state.index_mirror_is_intact(),
+                "an expired drain deadline must record a mirror gap — \
+                 certifying here is exactly the round-3 data-loss path"
+            );
+
+            // …so persistence keeps the SHA verified at A, not HEAD-B.
+            let dir_b = tempfile::tempdir().expect("index dir b");
+            persist_index_on_shutdown(&state, dir_b.path())
+                .await
+                .expect("persist after timeout");
+            assert_eq!(
+                state.index.commit_sha().as_deref(),
+                Some(sha_a.as_str()),
+                "timeout persistence must keep the last verified SHA"
+            );
+            assert_ne!(
+                state.index.commit_sha().as_deref(),
+                Some(head_b.as_str()),
+                "stamping HEAD after an expired drain would make the next \
+                 startup skip the reindex that repairs the missing mirror"
+            );
+            drop(stuck_unit_slot);
+        }
+
+        /// #329 review round 3: `shielded_mutation_unit` must account its
+        /// unit in the shutdown mutation registry for the unit's full
+        /// duration — the registry, not the transport, is what gates index
+        /// persistence at shutdown.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn shielded_mutation_unit_holds_registry_slot_until_completion() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            let entered = Arc::new(tokio::sync::Notify::new());
+            let release = Arc::new(tokio::sync::Notify::new());
+            let unit_entered = Arc::clone(&entered);
+            let unit_release = Arc::clone(&release);
+            let requester_state = Arc::clone(&state);
+            let requester = tokio::spawn(async move {
+                shielded_mutation_unit::<(), _>(&requester_state, async move {
+                    unit_entered.notify_one();
+                    unit_release.notified().await;
+                    Ok(())
+                })
+                .await
+            });
+
+            entered.notified().await;
+            assert_eq!(
+                state.mutations.in_flight(),
+                1,
+                "a running unit must hold exactly one registry slot"
+            );
+            assert!(
+                !state
+                    .mutations
+                    .drained_within(std::time::Duration::from_millis(50))
+                    .await,
+                "the registry must not drain while the unit is executing"
+            );
+
+            release.notify_one();
+            requester
+                .await
+                .expect("requester task")
+                .expect("unit outcome");
+            assert!(
+                state
+                    .mutations
+                    .drained_within(std::time::Duration::from_secs(5))
+                    .await,
+                "the slot must be released when the unit completes"
+            );
+        }
+
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn post_pull_diff_failure_marks_degraded_and_schedules_repair() {
             let tmp = tempfile::tempdir().expect("tempdir");
@@ -5061,9 +5231,9 @@ mod tests {
 
             let unit_state = Arc::clone(&state);
             let unit_release = Arc::clone(&release);
-            let requester_lexical = Arc::clone(&state.lexical);
+            let requester_state = Arc::clone(&state);
             let requester = tokio::spawn(async move {
-                shielded_mutation_unit::<(), _>(&requester_lexical, async move {
+                shielded_mutation_unit::<(), _>(&requester_state, async move {
                     // Real git commit — the unit dies *after* truth moved.
                     let memory = Memory::from_validated(
                         MemoryName::new("committed".to_string()).unwrap(),
@@ -5089,6 +5259,17 @@ mod tests {
             // The Drop-guard owned by the detached task must record the
             // divergence with no requester left to observe a JoinError.
             await_degraded(&state).await;
+
+            // The panicked unit must also release its shutdown-registry
+            // slot (#329 review, round 3) — a leaked slot would hold up
+            // shutdown persistence until the drain deadline every time.
+            assert!(
+                state
+                    .mutations
+                    .drained_within(std::time::Duration::from_secs(5))
+                    .await,
+                "a panicked mutation unit must release its registry slot"
+            );
 
             // Git truth holds the memory the panic stranded.
             state

--- a/src/server.rs
+++ b/src/server.rs
@@ -1054,6 +1054,7 @@ pub async fn startup_prepare_index(
     initial_pull: Option<(&crate::auth::AuthProvider, &str)>,
     router: &crate::repo_router::RepoRouter,
     embedding: &dyn EmbeddingBackend,
+    index_dir: &std::path::Path,
     loaded_index: Box<dyn VectorStore>,
     fresh_index: impl FnOnce() -> Box<dyn VectorStore>,
 ) -> (Box<dyn VectorStore>, bool) {
@@ -1069,7 +1070,11 @@ pub async fn startup_prepare_index(
     // rebuild from scratch — this prevents ghost entries from deleted
     // memories lingering.
     let head_sha = router.head_sha().await;
-    if head_sha == loaded_index.commit_sha() {
+    if !startup_needs_reindex(
+        index_dir,
+        head_sha.as_deref(),
+        loaded_index.commit_sha().as_deref(),
+    ) {
         tracing::debug!(sha = ?head_sha, "index SHA matches repo HEAD — skipping reindex");
         return (loaded_index, true);
     }
@@ -1088,17 +1093,93 @@ pub async fn startup_prepare_index(
         startup_reindex_and_certify(router, embedding, index.as_ref(), head_sha.as_deref())
             .instrument(tracing::info_span!("startup.full_reindex"))
             .await;
+    if reindex_ok {
+        clear_reindex_required_marker(index_dir);
+    }
     (index, reindex_ok)
 }
 
-/// Persist the vector index at graceful shutdown.
+/// File name of the durable reindex-required marker inside the index dir.
 ///
-/// Advances the stored composite SHA to the router's current HEAD only when
-/// the in-process mirror is intact ([`AppState::index_mirror_is_intact`]).
-/// When a mirror gap was recorded — e.g. a sync's post-pull change discovery
-/// failed and the sync mirror refused SHA advancement — the index
-/// keeps the SHA it last legitimately verified, so the next startup sees the
-/// mismatch against git HEAD and rebuilds the vector index from git truth
+/// Written when the shutdown mutation drain deadline expires. In-memory
+/// certification revocation alone is not durable on that path: `run_serve`
+/// deliberately skips index persistence after a timeout, so the previous
+/// clean on-disk snapshot survives — and its stored SHA can still equal an
+/// unadvanced git HEAD (#329 review, round 4). The marker outlives the
+/// process so the next startup forces a rebuild *before* any SHA freshness
+/// comparison, honouring the invariant that every timeout guarantees a
+/// next-start reindex independently of HEAD.
+pub const REINDEX_REQUIRED_MARKER: &str = ".reindex-required";
+
+fn reindex_marker_path(index_dir: &std::path::Path) -> std::path::PathBuf {
+    index_dir.join(REINDEX_REQUIRED_MARKER)
+}
+
+/// Durably record that the next startup must rebuild the vector index.
+///
+/// Crash-safe-ish: the content is written to a temp file and renamed into
+/// place, so a partially written marker never exists under the final name.
+/// Only this tiny marker touches disk — the dirty in-memory index state is
+/// never persisted on the timeout path.
+pub fn write_reindex_required_marker(index_dir: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(index_dir)?;
+    let tmp = index_dir.join(".reindex-required.tmp");
+    std::fs::write(
+        &tmp,
+        b"shutdown mutation drain deadline expired; the on-disk index snapshot \
+          is no longer certified - startup must rebuild from git truth\n",
+    )?;
+    std::fs::rename(&tmp, reindex_marker_path(index_dir))
+}
+
+/// Whether a durable reindex-required marker is present in the index dir.
+pub fn reindex_required_marker_present(index_dir: &std::path::Path) -> bool {
+    reindex_marker_path(index_dir).exists()
+}
+
+/// Remove the reindex-required marker after a clean startup rebuild.
+///
+/// Call only once the rebuild certified (`startup_reindex_and_certify`
+/// returned `true`): clearing earlier would drop the forced-reindex
+/// guarantee if the process died mid-rebuild while the old snapshot still
+/// matched HEAD. Absence is not an error; any other removal failure is
+/// logged and left in place — a lingering marker only costs a redundant
+/// rebuild, never correctness.
+pub fn clear_reindex_required_marker(index_dir: &std::path::Path) {
+    if let Err(e) = std::fs::remove_file(reindex_marker_path(index_dir)) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            warn!(
+                error = %e,
+                "failed to clear reindex-required marker — the next startup \
+                 will redundantly rebuild the vector index"
+            );
+        }
+    }
+}
+
+/// Decide whether startup must rebuild the vector index from git truth.
+///
+/// The durable reindex-required marker is checked *before* the SHA
+/// freshness comparison: a drain-timeout shutdown revokes certification
+/// only in memory and skips persistence entirely, so the surviving on-disk
+/// snapshot can still carry a stored SHA equal to an unadvanced HEAD (#329
+/// review, round 4). Without the marker taking precedence, that equality
+/// would skip the rebuild the timeout contract promised.
+pub fn startup_needs_reindex(
+    index_dir: &std::path::Path,
+    head_sha: Option<&str>,
+    stored_sha: Option<&str>,
+) -> bool {
+    if reindex_required_marker_present(index_dir) {
+        info!(
+            "reindex-required marker present — forcing rebuild from git truth \
+             regardless of stored-SHA/HEAD equality"
+        );
+        return true;
+    }
+    head_sha != stored_sha
+}
+
 /// Await in-flight application mutation units before shutdown persistence.
 ///
 /// The transport's own shutdown drain cannot vouch for these: rmcp's awaited
@@ -1117,18 +1198,21 @@ pub async fn startup_prepare_index(
 ///
 /// Returns `true` when every unit completed within `deadline`. On timeout it
 /// records a mirror gap, *revokes the index's stored certification SHA*, and
-/// returns `false`. Revocation must not depend on HEAD comparison (#329
+/// writes a durable reindex-required marker into `index_dir` before
+/// returning `false`. Revocation must not depend on HEAD comparison (#329
 /// review, round 4): an abandoned `remember`/`edit` may have mutated the
 /// vector index while its shielded git save never advanced HEAD, so the
 /// previously verified SHA can still equal HEAD while the index is dirty —
 /// keeping it would let the next startup certify the dirty index and skip
-/// the reindex. With the SHA revoked (and `run_serve` additionally skipping
-/// persistence entirely on timeout), the next startup can never match
-/// stored-SHA == HEAD and always rebuilds from git truth. A hard shutdown
-/// deadline may abandon a mutation, but it must never certify the index as
-/// intact.
+/// the reindex. And because `run_serve` deliberately skips persistence on
+/// timeout, the in-memory revocation alone would die with the process while
+/// the old clean snapshot (stored SHA possibly == unadvanced HEAD) survived
+/// — only the on-disk marker makes the forced next-start reindex durable
+/// (#329 review, round 4, remaining Low). A hard shutdown deadline may
+/// abandon a mutation, but it must never certify the index as intact.
 pub async fn drain_mutations_before_persist(
     state: &AppState,
+    index_dir: &std::path::Path,
     deadline: std::time::Duration,
 ) -> bool {
     state.mutations.seal();
@@ -1146,6 +1230,16 @@ pub async fn drain_mutations_before_persist(
         // the vector index without advancing git HEAD, so the last verified
         // SHA is no longer trustworthy evidence of freshness.
         state.index.set_commit_sha(None);
+        // The in-memory revocation dies with this process while persistence
+        // is skipped — make the forced next-start reindex durable.
+        if let Err(e) = write_reindex_required_marker(index_dir) {
+            tracing::error!(
+                error = %e,
+                "failed to write reindex-required marker — if git HEAD did \
+                 not advance, the next startup may wrongly certify the old \
+                 on-disk snapshot as fresh"
+            );
+        }
         false
     }
 }
@@ -4713,6 +4807,7 @@ mod tests {
                 Some((&auth, "main")),
                 &router,
                 &MockEmbedding,
+                server_dir.path().join(".memory-mcp-index").as_path(),
                 Box::new(InMemoryStore::new(4)),
                 || Box::new(InMemoryStore::new(4)),
             )
@@ -4852,6 +4947,7 @@ mod tests {
                 Some((&auth, "main")),
                 &router,
                 &MockEmbedding,
+                server_default_dir.path().join(".memory-mcp-index").as_path(),
                 Box::new(InMemoryStore::new(4)),
                 || Box::new(InMemoryStore::new(4)),
             )
@@ -5104,9 +5200,17 @@ mod tests {
             assert_ne!(head_b, sha_a, "git must have advanced past A");
 
             // The deadline expires: certification must be refused…
-            let drained =
-                drain_mutations_before_persist(&state, std::time::Duration::from_millis(50)).await;
+            let drained = drain_mutations_before_persist(
+                &state,
+                dir_a.path(),
+                std::time::Duration::from_millis(50),
+            )
+            .await;
             assert!(!drained, "drain must report the expired deadline");
+            assert!(
+                reindex_required_marker_present(dir_a.path()),
+                "an expired drain deadline must leave a durable marker"
+            );
             assert!(
                 !state.index_mirror_is_intact(),
                 "an expired drain deadline must record a mirror gap — \
@@ -5140,76 +5244,186 @@ mod tests {
             drop(stuck_unit_slot);
         }
 
-        /// #329 review round 4: the round-3 test above advances HEAD A→B
+        /// #329 review rounds 4–5: the round-3 test above advances HEAD A→B
         /// before the timeout, so it only ever exercises the SHA-mismatch
-        /// path. Here the abandoned unit has dirtied the *vector index*
-        /// while git HEAD never advanced — `remember`/`edit` mutate the
-        /// index before their shielded git save — so the previously
-        /// verified SHA still equals current HEAD. Certification must be
-        /// revoked independently of HEAD equality, or the next startup
-        /// would accept the dirty index and skip the reindex.
+        /// path. Here git HEAD never advances — `remember`/`edit` mutate the
+        /// vector index before their shielded git save — so the previously
+        /// certified on-disk snapshot's SHA still equals current HEAD at the
+        /// next boot. In-memory revocation alone is not durable on this path
+        /// because production (`run_serve`) deliberately *skips* persistence
+        /// after a timeout (round 4, remaining Low). This test follows the
+        /// exact production ordering — timeout → revoke → skip persistence →
+        /// process exit — then reloads with unchanged HEAD and proves the
+        /// durable marker forces the rebuild and is consumed by it.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn shutdown_drain_timeout_forces_reindex_without_head_advance() {
             let tmp = tempfile::tempdir().expect("tempdir");
-            let state = test_state(&tmp);
+            let index_dir = tempfile::tempdir().expect("index dir");
+            let usearch_state = |tmp: &tempfile::TempDir, index: Box<dyn VectorStore>| {
+                let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo init");
+                Arc::new(AppState::new(
+                    Arc::new(repo),
+                    "main".to_string(),
+                    Box::new(MockEmbedding),
+                    index,
+                    AuthProvider::new(),
+                    HealthRegistry::new(),
+                    None,
+                ))
+            };
 
-            // Verified state at A: stored SHA == git HEAD.
-            let note_a = Memory::from_validated(
-                MemoryName::new("note-a".to_string()).unwrap(),
-                "payload a".to_string(),
-                MemoryMetadata::new(Scope::Root, vec![], None),
+            // ---- Session 1: a clean shutdown leaves an on-disk snapshot
+            // certified at HEAD-A.
+            let sha_a = {
+                let state = usearch_state(
+                    &tmp,
+                    Box::new(crate::index::UsearchStore::new(4).expect("usearch store")),
+                );
+                let note_a = Memory::from_validated(
+                    MemoryName::new("note-a".to_string()).unwrap(),
+                    "payload a".to_string(),
+                    MemoryMetadata::new(Scope::Root, vec![], None),
+                );
+                state.repo.save_memory(&note_a).await.expect("save a");
+                assert!(
+                    drain_mutations_before_persist(
+                        &state,
+                        index_dir.path(),
+                        std::time::Duration::from_millis(200)
+                    )
+                    .await,
+                    "an idle registry must drain cleanly"
+                );
+                persist_index_on_shutdown(&state, index_dir.path())
+                    .await
+                    .expect("persist at A");
+                state.index.commit_sha().expect("verified SHA at A")
+            };
+            assert!(
+                !reindex_required_marker_present(index_dir.path()),
+                "a clean shutdown must not leave a reindex-required marker"
             );
-            state.repo.save_memory(&note_a).await.expect("save a");
-            let dir_a = tempfile::tempdir().expect("index dir a");
-            persist_index_on_shutdown(&state, dir_a.path())
-                .await
-                .expect("persist at A");
-            let sha_a = state.index.commit_sha().expect("verified SHA at A");
 
-            // An admitted unit dirties the vector index (the pre-shielded
-            // `remember`/`edit` step) and then stalls before its git save —
-            // HEAD does NOT advance.
-            let stuck_unit_slot = state.mutations.enter();
-            state
-                .index
-                .add(
-                    &Scope::Root,
-                    &[0.0, 0.0, 1.0, 0.0],
-                    qualified(&Scope::Root, "ghost"),
+            // ---- Session 2: production ordering on a drain timeout. The
+            // snapshot is loaded from disk exactly as `run_serve` does.
+            {
+                let loaded = crate::index::UsearchStore::load(index_dir.path(), 4)
+                    .expect("load snapshot at A");
+                assert_eq!(
+                    loaded.commit_sha().as_deref(),
+                    Some(sha_a.as_str()),
+                    "precondition: the loaded snapshot is certified at A"
+                );
+                let state = usearch_state(&tmp, Box::new(loaded));
+
+                // An admitted unit dirties the in-memory vector index (the
+                // pre-shielded `remember`/`edit` step) and stalls before its
+                // git save — HEAD does NOT advance.
+                let stuck_unit_slot = state.mutations.enter();
+                state
+                    .index
+                    .add(
+                        &Scope::Root,
+                        &[0.0, 0.0, 1.0, 0.0],
+                        qualified(&Scope::Root, "ghost"),
+                    )
+                    .expect("dirty the vector index without a git commit");
+                assert_eq!(
+                    state.router.head_sha().await.as_deref(),
+                    Some(sha_a.as_str()),
+                    "precondition: git HEAD must not have advanced past A"
+                );
+
+                // Timeout: revoke in memory + write the durable marker…
+                let drained = drain_mutations_before_persist(
+                    &state,
+                    index_dir.path(),
+                    std::time::Duration::from_millis(50),
                 )
-                .expect("dirty the vector index without a git commit");
-            assert_eq!(
-                state.router.head_sha().await.as_deref(),
-                Some(sha_a.as_str()),
-                "precondition: git HEAD must not have advanced past A"
-            );
+                .await;
+                assert!(!drained, "drain must report the expired deadline");
+                assert_eq!(
+                    state.index.commit_sha(),
+                    None,
+                    "certification must be revoked even though stored SHA \
+                     still equals HEAD"
+                );
+                assert!(
+                    reindex_required_marker_present(index_dir.path()),
+                    "the timeout must leave a durable reindex-required marker"
+                );
 
-            let drained =
-                drain_mutations_before_persist(&state, std::time::Duration::from_millis(50)).await;
-            assert!(!drained, "drain must report the expired deadline");
+                // …then production explicitly SKIPS persist_index_on_shutdown
+                // (`run_serve` leaves the on-disk index untouched on timeout),
+                // and the process exits — the dirty in-memory index and the
+                // in-memory revocation both die here.
+                drop(stuck_unit_slot);
+            }
 
-            // The falsely fresh SHA (old SHA == current HEAD) must be gone…
+            // ---- Session 3: restart with UNCHANGED git HEAD.
+            let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo reopen");
+            let router = RepoRouter::single(Arc::new(repo));
+            let head = router.head_sha().await;
+            let loaded =
+                crate::index::UsearchStore::load(index_dir.path(), 4).expect("reload snapshot");
             assert_eq!(
-                state.index.commit_sha(),
+                loaded.find_by_name(&qualified(&Scope::Root, "ghost")),
                 None,
-                "certification must be revoked even though stored SHA still \
-                 equals HEAD — HEAD equality is not evidence of a clean mirror"
+                "the dirty in-memory state must never have been persisted"
+            );
+            // The trap the marker exists to disarm: the surviving snapshot's
+            // stored SHA equals the unadvanced HEAD, so the SHA check alone
+            // would skip the reindex.
+            assert_eq!(
+                loaded.commit_sha().as_deref(),
+                Some(sha_a.as_str()),
+                "precondition: the old snapshot still carries the SHA \
+                 certified at A"
+            );
+            assert_eq!(
+                head.as_deref(),
+                Some(sha_a.as_str()),
+                "precondition: git HEAD is unchanged, so stored SHA == HEAD"
+            );
+            assert!(
+                startup_needs_reindex(
+                    index_dir.path(),
+                    head.as_deref(),
+                    loaded.commit_sha().as_deref()
+                ),
+                "the durable marker must force the rebuild before the \
+                 SHA==HEAD comparison can skip it"
             );
 
-            // …including through any persistence that runs afterwards, so
-            // the next boot can never see stored-SHA == HEAD and must
-            // reindex from git truth.
-            let dir_b = tempfile::tempdir().expect("index dir b");
-            persist_index_on_shutdown(&state, dir_b.path())
-                .await
-                .expect("persist after timeout");
-            assert_eq!(state.index.commit_sha(), None);
-            assert_ne!(
-                state.index.commit_sha().as_deref(),
-                state.router.head_sha().await.as_deref(),
-                "the dirty index must not be bootable as fresh"
+            // Startup discards the loaded snapshot and rebuilds from git
+            // truth (mirroring `run_serve`), then consumes the marker only
+            // once the rebuild certified.
+            let fresh = crate::index::UsearchStore::new(4).expect("fresh store");
+            assert!(
+                startup_reindex_and_certify(&router, &MockEmbedding, &fresh, head.as_deref()).await,
+                "the forced rebuild from git truth must certify"
             );
-            drop(stuck_unit_slot);
+            assert!(
+                fresh
+                    .find_by_name(&qualified(&Scope::Root, "note-a"))
+                    .is_some(),
+                "the rebuild must reindex git truth"
+            );
+            assert_eq!(fresh.commit_sha(), head, "the rebuild must stamp HEAD");
+            clear_reindex_required_marker(index_dir.path());
+            assert!(
+                !reindex_required_marker_present(index_dir.path()),
+                "a certified rebuild must consume the marker"
+            );
+            assert!(
+                !startup_needs_reindex(
+                    index_dir.path(),
+                    head.as_deref(),
+                    fresh.commit_sha().as_deref()
+                ),
+                "with the marker consumed and the rebuild certified, the \
+                 next boot may skip the reindex again"
+            );
         }
 
         /// #329 review round 4: once the shutdown drain seals admission,
@@ -5223,9 +5437,19 @@ mod tests {
             let server = MemoryServer::new(Arc::clone(&state));
 
             // An idle shutdown drain seals admission and reports drained.
+            let marker_dir = tempfile::tempdir().expect("marker dir");
             assert!(
-                drain_mutations_before_persist(&state, std::time::Duration::from_millis(200)).await,
+                drain_mutations_before_persist(
+                    &state,
+                    marker_dir.path(),
+                    std::time::Duration::from_millis(200)
+                )
+                .await,
                 "an idle registry must drain cleanly"
+            );
+            assert!(
+                !reindex_required_marker_present(marker_dir.path()),
+                "a clean drain must not leave a reindex-required marker"
             );
 
             // A handler arriving after the seal (e.g. a detached task the

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,13 +7,10 @@ const SNIPPET_MAX_CHARS: usize = 500;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::Utc;
 use rmcp::{
-    handler::server::{
-        router::tool::ToolRouter,
-        tool::{Extension, ToolCallContext},
-        wrapper::Parameters,
-    },
+    handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
     model::{
-        CallToolRequestParams, CallToolResult, ErrorData, Meta, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResult, ErrorData, Extensions, Meta, ServerCapabilities,
+        ServerInfo,
     },
     service::RequestContext,
     tool, tool_handler, tool_router, RoleServer, ServerHandler,
@@ -21,11 +18,19 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn, Instrument};
 
-/// Extract the `Mcp-Session-Id` header from HTTP request parts.
+/// Extract the `Mcp-Session-Id` header from the request's HTTP parts.
+///
+/// The streamable HTTP transport stores `http::request::Parts` in the request
+/// extensions; over stdio there is no HTTP request, so the parts are absent
+/// and the session is labelled `"stdio"` (one stdio process serves exactly
+/// one client, so no further disambiguation is needed).
 ///
 /// Returns `"unknown"` if the header is absent or not valid UTF-8.
 /// Truncates to 128 chars to bound span field size from untrusted input.
-fn extract_session_id(parts: &http::request::Parts) -> String {
+fn extract_session_id(extensions: &Extensions) -> String {
+    let Some(parts) = extensions.get::<http::request::Parts>() else {
+        return "stdio".to_owned();
+    };
     let raw = parts
         .headers
         .get("mcp-session-id")
@@ -1108,7 +1113,7 @@ impl MemoryServer {
     async fn remember(
         &self,
         Parameters(args): Parameters<RememberArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.len() > MAX_CONTENT_SIZE {
@@ -1120,7 +1125,7 @@ impl MemoryServer {
                 ),
             }));
         }
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let content_size = args.content.len();
         let span = tracing::info_span!(
             "handler.remember",
@@ -1224,9 +1229,9 @@ impl MemoryServer {
     async fn recall(
         &self,
         Parameters(args): Parameters<RecallArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let recall_id = RecallLog::generate_recall_id();
         // Note: query text is intentionally omitted from the span (R-17 privacy decision).
         let span = tracing::info_span!(
@@ -1366,10 +1371,10 @@ impl MemoryServer {
     async fn forget(
         &self,
         Parameters(args): Parameters<ForgetArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.forget",
             session_id = %session_id,
@@ -1445,7 +1450,7 @@ impl MemoryServer {
     async fn edit(
         &self,
         Parameters(args): Parameters<EditArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let mut timing = EditStageTiming::new();
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
@@ -1465,7 +1470,7 @@ impl MemoryServer {
                 }));
             }
         }
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let content_size = args.content.as_ref().map(|c| c.len()).unwrap_or(0);
         let span = tracing::info_span!(
             "handler.edit",
@@ -1596,14 +1601,14 @@ impl MemoryServer {
     async fn move_memory(
         &self,
         Parameters(args): Parameters<MoveArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         let new_name = match args.new_name {
             Some(n) => MemoryName::new(n).map_err(ErrorData::from)?,
             None => name.clone(),
         };
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.move",
             session_id = %session_id,
@@ -1775,9 +1780,9 @@ impl MemoryServer {
     async fn list(
         &self,
         Parameters(args): Parameters<ListToolArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.list",
             session_id = %session_id,
@@ -1848,10 +1853,10 @@ impl MemoryServer {
     async fn read(
         &self,
         Parameters(args): Parameters<ReadArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.read",
             session_id = %session_id,
@@ -1905,10 +1910,10 @@ impl MemoryServer {
     async fn sync(
         &self,
         Parameters(args): Parameters<SyncArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
         let pull_first = args.pull_first.unwrap_or(true);
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.sync",
             session_id = %session_id,
@@ -2019,9 +2024,9 @@ impl MemoryServer {
     async fn mark_applied(
         &self,
         Parameters(args): Parameters<MarkAppliedArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.mark_applied",
             session_id = %session_id,
@@ -2113,9 +2118,9 @@ impl MemoryServer {
     async fn batch_mark_applied(
         &self,
         Parameters(args): Parameters<BatchMarkAppliedArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let count = args.verdicts.len();
         let span = tracing::info_span!(
             "handler.batch_mark_applied",
@@ -2231,9 +2236,9 @@ impl MemoryServer {
     async fn recall_stats(
         &self,
         Parameters(_args): Parameters<RecallStatsArgs>,
-        Extension(parts): Extension<http::request::Parts>,
+        extensions: Extensions,
     ) -> Result<String, ErrorData> {
-        let session_id = extract_session_id(&parts);
+        let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.recall_stats",
             session_id = %session_id,
@@ -2558,12 +2563,15 @@ mod tests {
         MemoryServer::new(state)
     }
 
-    fn list_test_parts() -> http::request::Parts {
-        http::Request::builder()
+    fn list_test_extensions() -> Extensions {
+        let parts = http::Request::builder()
             .body(())
             .expect("request")
             .into_parts()
-            .0
+            .0;
+        let mut ext = Extensions::new();
+        ext.insert(parts);
+        ext
     }
 
     #[test]
@@ -2596,7 +2604,7 @@ mod tests {
                     cursor: None,
                     fields: None,
                 }),
-                Extension(list_test_parts()),
+                list_test_extensions(),
             )
             .await
             .expect_err("zero limit must fail");
@@ -2610,7 +2618,7 @@ mod tests {
                     cursor: Some("garbage".to_string()),
                     fields: None,
                 }),
-                Extension(list_test_parts()),
+                list_test_extensions(),
             )
             .await
             .expect_err("malformed cursor must fail");
@@ -2639,7 +2647,7 @@ mod tests {
                         cursor,
                         fields: Some(vec![ListField::Name]),
                     }),
-                    Extension(list_test_parts()),
+                    list_test_extensions(),
                 )
                 .await
                 .expect("list page");
@@ -2688,7 +2696,7 @@ mod tests {
                     cursor: None,
                     fields: Some(vec![ListField::Name]),
                 }),
-                Extension(list_test_parts()),
+                list_test_extensions(),
             )
             .await
             .expect("default-limit page");
@@ -3325,13 +3333,16 @@ mod tests {
             }
         }
 
-        fn parts() -> http::request::Parts {
-            http::Request::builder()
+        fn test_extensions() -> Extensions {
+            let parts = http::Request::builder()
                 .uri("/")
                 .body(())
                 .expect("request")
                 .into_parts()
-                .0
+                .0;
+            let mut ext = Extensions::new();
+            ext.insert(parts);
+            ext
         }
 
         fn test_state(tmp: &tempfile::TempDir) -> Arc<AppState> {
@@ -3391,7 +3402,7 @@ mod tests {
                         scope: None,
                         source: None,
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
         }
@@ -3437,7 +3448,7 @@ mod tests {
                         tags: None,
                         scope: None,
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
                 .expect("edit must stay best-effort despite the lexical failure");
@@ -3468,7 +3479,7 @@ mod tests {
                         name: "doomed".to_string(),
                         scope: None,
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
                 .expect("forget must stay best-effort despite the lexical failure");
@@ -3496,7 +3507,7 @@ mod tests {
                         to_scope: "proj".to_string(),
                         new_name: None,
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
                 .expect("move must stay best-effort despite the lexical failure");
@@ -3607,7 +3618,7 @@ mod tests {
                         scope: None,
                         limit: Some(5),
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
                 .expect("recall must serve semantic-only while degraded");
@@ -3694,7 +3705,7 @@ mod tests {
                             tags: None,
                             scope: None,
                         }),
-                        Extension(parts()),
+                        test_extensions(),
                     )
                     .await
             });
@@ -3742,7 +3753,7 @@ mod tests {
                             name: "doomed".to_string(),
                             scope: None,
                         }),
-                        Extension(parts()),
+                        test_extensions(),
                     )
                     .await
             });
@@ -3789,7 +3800,7 @@ mod tests {
                             to_scope: "proj".to_string(),
                             new_name: None,
                         }),
-                        Extension(parts()),
+                        test_extensions(),
                     )
                     .await
             });
@@ -3922,7 +3933,7 @@ mod tests {
                     Parameters(SyncArgs {
                         pull_first: Some(pull_first),
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
         }
@@ -5008,7 +5019,7 @@ mod tests {
                         scope: None,
                         limit: Some(5),
                     }),
-                    Extension(parts()),
+                    test_extensions(),
                 )
                 .await
                 .expect("recall must serve semantic-only while degraded");

--- a/src/server.rs
+++ b/src/server.rs
@@ -1117,24 +1117,38 @@ fn reindex_marker_path(index_dir: &std::path::Path) -> std::path::PathBuf {
 
 /// Durably record that the next startup must rebuild the vector index.
 ///
-/// Crash-safe-ish: the content is written to a temp file and renamed into
-/// place, so a partially written marker never exists under the final name.
-/// Only this tiny marker touches disk — the dirty in-memory index state is
-/// never persisted on the timeout path.
+/// Goes through [`crate::fs_util::atomic_write`] (#329 review, round 5):
+/// the temp file is fsynced before the atomic rename and the parent
+/// directory is fsynced after it, so the marker survives power loss once
+/// this returns and a partially written marker never exists under the final
+/// name. On Unix the temp file is opened with `O_NOFOLLOW`, so a
+/// pre-planted symlink at the temp path fails the write instead of
+/// truncating its target; a symlink planted at the final marker path is
+/// atomically replaced by the rename without ever writing through it. Only
+/// this tiny marker touches disk — the dirty in-memory index state is never
+/// persisted on the timeout path.
 pub fn write_reindex_required_marker(index_dir: &std::path::Path) -> std::io::Result<()> {
     std::fs::create_dir_all(index_dir)?;
-    let tmp = index_dir.join(".reindex-required.tmp");
-    std::fs::write(
-        &tmp,
+    crate::fs_util::atomic_write(
+        &reindex_marker_path(index_dir),
         b"shutdown mutation drain deadline expired; the on-disk index snapshot \
           is no longer certified - startup must rebuild from git truth\n",
-    )?;
-    std::fs::rename(&tmp, reindex_marker_path(index_dir))
+    )
 }
 
 /// Whether a durable reindex-required marker is present in the index dir.
-pub fn reindex_required_marker_present(index_dir: &std::path::Path) -> bool {
-    reindex_marker_path(index_dir).exists()
+///
+/// Inspects with `symlink_metadata` (#329 review, round 5): a dangling
+/// symlink at the marker path still counts as present, and every other
+/// inspection error propagates as `Err` instead of collapsing to `false`.
+/// Callers must fail closed — "cannot inspect" is not evidence of absence,
+/// so an `Err` must be treated as reindex-required.
+pub fn reindex_required_marker_present(index_dir: &std::path::Path) -> std::io::Result<bool> {
+    match std::fs::symlink_metadata(reindex_marker_path(index_dir)) {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
 }
 
 /// Remove the reindex-required marker after a clean startup rebuild.
@@ -1170,12 +1184,27 @@ pub fn startup_needs_reindex(
     head_sha: Option<&str>,
     stored_sha: Option<&str>,
 ) -> bool {
-    if reindex_required_marker_present(index_dir) {
-        info!(
-            "reindex-required marker present — forcing rebuild from git truth \
-             regardless of stored-SHA/HEAD equality"
-        );
-        return true;
+    match reindex_required_marker_present(index_dir) {
+        Ok(true) => {
+            info!(
+                "reindex-required marker present — forcing rebuild from git truth \
+                 regardless of stored-SHA/HEAD equality"
+            );
+            return true;
+        }
+        Ok(false) => {}
+        // Fail closed (#329 review, round 5): a metadata error is not
+        // evidence the marker is absent. Treating it as absent would let
+        // stored-SHA == HEAD equality skip the rebuild a timed-out shutdown
+        // promised. A redundant rebuild is the safe failure mode.
+        Err(e) => {
+            warn!(
+                error = %e,
+                "could not inspect reindex-required marker — failing closed \
+                 and rebuilding from git truth"
+            );
+            return true;
+        }
     }
     head_sha != stored_sha
 }
@@ -1196,10 +1225,11 @@ pub fn startup_needs_reindex(
 /// a clean shutting-down error before touching any state, and the drain
 /// converges over exactly the sealed-in units.
 ///
-/// Returns `true` when every unit completed within `deadline`. On timeout it
-/// records a mirror gap, *revokes the index's stored certification SHA*, and
-/// writes a durable reindex-required marker into `index_dir` before
-/// returning `false`. Revocation must not depend on HEAD comparison (#329
+/// Returns `Ok(true)` when every unit completed within `deadline`. On
+/// timeout it records a mirror gap, *revokes the index's stored
+/// certification SHA*, and writes a durable reindex-required marker into
+/// `index_dir` before returning `Ok(false)`. Revocation must not depend on
+/// HEAD comparison (#329
 /// review, round 4): an abandoned `remember`/`edit` may have mutated the
 /// vector index while its shielded git save never advanced HEAD, so the
 /// previously verified SHA can still equal HEAD while the index is dirty —
@@ -1210,14 +1240,23 @@ pub fn startup_needs_reindex(
 /// — only the on-disk marker makes the forced next-start reindex durable
 /// (#329 review, round 4, remaining Low). A hard shutdown deadline may
 /// abandon a mutation, but it must never certify the index as intact.
+///
+/// Marker I/O must not fail open (#329 review, round 5): when the marker
+/// cannot be written, the durable guarantee falls back to revoking the
+/// certification inside the persisted snapshot itself
+/// ([`crate::index::usearch::revoke_persisted_certification`] — rewrites
+/// only the stored `commit_sha`, never dirty in-memory index state). Only
+/// if *both* durable channels fail does this return `Err`, so the caller
+/// propagates a shutdown error instead of logging the guarantee away and
+/// exiting as if it held.
 pub async fn drain_mutations_before_persist(
     state: &AppState,
     index_dir: &std::path::Path,
     deadline: std::time::Duration,
-) -> bool {
+) -> Result<bool, MemoryError> {
     state.mutations.seal();
     if state.mutations.drained_within(deadline).await {
-        true
+        Ok(true)
     } else {
         warn!(
             in_flight = state.mutations.in_flight(),
@@ -1232,15 +1271,25 @@ pub async fn drain_mutations_before_persist(
         state.index.set_commit_sha(None);
         // The in-memory revocation dies with this process while persistence
         // is skipped — make the forced next-start reindex durable.
-        if let Err(e) = write_reindex_required_marker(index_dir) {
+        if let Err(marker_err) = write_reindex_required_marker(index_dir) {
             tracing::error!(
-                error = %e,
-                "failed to write reindex-required marker — if git HEAD did \
-                 not advance, the next startup may wrongly certify the old \
-                 on-disk snapshot as fresh"
+                error = %marker_err,
+                "failed to write reindex-required marker — falling back to \
+                 revoking the certification inside the persisted snapshot"
             );
+            if let Err(revoke_err) =
+                crate::index::usearch::revoke_persisted_certification(index_dir)
+            {
+                return Err(MemoryError::Internal(format!(
+                    "shutdown drain deadline expired but no durable revocation \
+                     could be recorded: reindex-required marker write failed \
+                     ({marker_err}) and persisted-certification revocation \
+                     failed ({revoke_err}); the next startup could wrongly \
+                     certify the stale on-disk snapshot"
+                )));
+            }
         }
-        false
+        Ok(false)
     }
 }
 
@@ -4947,7 +4996,10 @@ mod tests {
                 Some((&auth, "main")),
                 &router,
                 &MockEmbedding,
-                server_default_dir.path().join(".memory-mcp-index").as_path(),
+                server_default_dir
+                    .path()
+                    .join(".memory-mcp-index")
+                    .as_path(),
                 Box::new(InMemoryStore::new(4)),
                 || Box::new(InMemoryStore::new(4)),
             )
@@ -5205,10 +5257,11 @@ mod tests {
                 dir_a.path(),
                 std::time::Duration::from_millis(50),
             )
-            .await;
+            .await
+            .expect("marker write must succeed on a writable index dir");
             assert!(!drained, "drain must report the expired deadline");
             assert!(
-                reindex_required_marker_present(dir_a.path()),
+                reindex_required_marker_present(dir_a.path()).expect("inspect marker"),
                 "an expired drain deadline must leave a durable marker"
             );
             assert!(
@@ -5291,7 +5344,8 @@ mod tests {
                         index_dir.path(),
                         std::time::Duration::from_millis(200)
                     )
-                    .await,
+                    .await
+                    .expect("clean drain must not error"),
                     "an idle registry must drain cleanly"
                 );
                 persist_index_on_shutdown(&state, index_dir.path())
@@ -5300,7 +5354,7 @@ mod tests {
                 state.index.commit_sha().expect("verified SHA at A")
             };
             assert!(
-                !reindex_required_marker_present(index_dir.path()),
+                !reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
                 "a clean shutdown must not leave a reindex-required marker"
             );
 
@@ -5340,7 +5394,8 @@ mod tests {
                     index_dir.path(),
                     std::time::Duration::from_millis(50),
                 )
-                .await;
+                .await
+                .expect("marker write must succeed on a writable index dir");
                 assert!(!drained, "drain must report the expired deadline");
                 assert_eq!(
                     state.index.commit_sha(),
@@ -5349,7 +5404,7 @@ mod tests {
                      still equals HEAD"
                 );
                 assert!(
-                    reindex_required_marker_present(index_dir.path()),
+                    reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
                     "the timeout must leave a durable reindex-required marker"
                 );
 
@@ -5412,7 +5467,7 @@ mod tests {
             assert_eq!(fresh.commit_sha(), head, "the rebuild must stamp HEAD");
             clear_reindex_required_marker(index_dir.path());
             assert!(
-                !reindex_required_marker_present(index_dir.path()),
+                !reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
                 "a certified rebuild must consume the marker"
             );
             assert!(
@@ -5424,6 +5479,293 @@ mod tests {
                 "with the marker consumed and the rebuild certified, the \
                  next boot may skip the reindex again"
             );
+        }
+
+        /// #329 review round 5: the marker write must never follow a
+        /// pre-planted symlink. A symlink at the temp path must fail the
+        /// write (`O_NOFOLLOW`) instead of truncating its target; a symlink
+        /// at the final marker path is atomically replaced by the rename
+        /// without the target ever being written through.
+        #[cfg(unix)]
+        #[test]
+        fn reindex_marker_write_does_not_follow_planted_symlinks() {
+            // Temp-path attack.
+            let index_dir = tempfile::tempdir().expect("index dir");
+            let victim = index_dir.path().join("victim");
+            std::fs::write(&victim, b"precious").expect("victim");
+            let tmp_path = index_dir
+                .path()
+                .join(format!(".{REINDEX_REQUIRED_MARKER}.tmp"));
+            std::os::unix::fs::symlink(&victim, &tmp_path).expect("plant temp symlink");
+            write_reindex_required_marker(index_dir.path())
+                .expect_err("writing through a planted temp symlink must fail, not truncate");
+            assert_eq!(
+                std::fs::read(&victim).expect("victim survives"),
+                b"precious",
+                "the planted temp symlink must not truncate its target"
+            );
+            assert!(
+                !reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
+                "the failed write must not leave a marker behind"
+            );
+
+            // Final-path attack.
+            let index_dir2 = tempfile::tempdir().expect("index dir 2");
+            let victim2 = index_dir2.path().join("victim2");
+            std::fs::write(&victim2, b"precious2").expect("victim2");
+            let marker_path = index_dir2.path().join(REINDEX_REQUIRED_MARKER);
+            std::os::unix::fs::symlink(&victim2, &marker_path).expect("plant marker symlink");
+            write_reindex_required_marker(index_dir2.path())
+                .expect("replacing a planted final-path symlink is safe");
+            assert_eq!(
+                std::fs::read(&victim2).expect("victim2 survives"),
+                b"precious2",
+                "the rename must replace the symlink, never write through it"
+            );
+            let meta = std::fs::symlink_metadata(&marker_path).expect("marker meta");
+            assert!(
+                meta.file_type().is_file(),
+                "the marker must be a regular file, not the planted symlink"
+            );
+        }
+
+        /// #329 review round 5: a failed marker write must surface as `Err`
+        /// (so the drain can fall back / propagate) and must leave neither a
+        /// marker nor a stray temp file behind.
+        #[cfg(unix)]
+        #[test]
+        fn reindex_marker_write_failure_surfaces_and_leaves_no_marker() {
+            use std::os::unix::fs::PermissionsExt;
+            // Permission-based failure injection is meaningless as root.
+            if unsafe { libc::geteuid() } == 0 {
+                return;
+            }
+            let index_dir = tempfile::tempdir().expect("index dir");
+            let set_mode = |mode: u32| {
+                let mut perms = std::fs::metadata(index_dir.path())
+                    .expect("meta")
+                    .permissions();
+                perms.set_mode(mode);
+                std::fs::set_permissions(index_dir.path(), perms).expect("chmod");
+            };
+            set_mode(0o555);
+            write_reindex_required_marker(index_dir.path())
+                .expect_err("a read-only index dir must fail the marker write");
+            set_mode(0o755);
+            assert!(
+                !reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
+                "the failed write must not leave a marker"
+            );
+            assert!(
+                std::fs::read_dir(index_dir.path())
+                    .expect("read dir")
+                    .next()
+                    .is_none(),
+                "the failed write must not leave a stray temp file"
+            );
+        }
+
+        /// #329 review round 5: marker inspection must fail closed. A
+        /// dangling symlink or an uninspectable directory is not evidence of
+        /// absence — both must force the rebuild even when the stored SHA
+        /// equals HEAD.
+        #[cfg(unix)]
+        #[test]
+        fn startup_reindex_check_fails_closed_on_marker_inspection() {
+            // Dangling symlink at the marker path: `Path::exists()` would
+            // collapse this to `false`; `symlink_metadata` sees the entry.
+            let index_dir = tempfile::tempdir().expect("index dir");
+            std::os::unix::fs::symlink(
+                index_dir.path().join("nonexistent-target"),
+                index_dir.path().join(REINDEX_REQUIRED_MARKER),
+            )
+            .expect("plant dangling symlink");
+            assert!(
+                reindex_required_marker_present(index_dir.path())
+                    .expect("a dangling symlink is inspectable"),
+                "a dangling symlink at the marker path must count as present"
+            );
+            assert!(
+                startup_needs_reindex(index_dir.path(), Some("sha-a"), Some("sha-a")),
+                "a dangling-symlink marker must force the rebuild despite \
+                 stored SHA == HEAD"
+            );
+
+            // Uninspectable directory: metadata errors surface as Err and
+            // the startup decision fails closed. Meaningless as root.
+            if unsafe { libc::geteuid() } == 0 {
+                return;
+            }
+            use std::os::unix::fs::PermissionsExt;
+            let locked = tempfile::tempdir().expect("locked dir");
+            let orig = std::fs::metadata(locked.path())
+                .expect("meta")
+                .permissions();
+            let mut none = orig.clone();
+            none.set_mode(0o000);
+            std::fs::set_permissions(locked.path(), none).expect("lock dir");
+            assert!(
+                reindex_required_marker_present(locked.path()).is_err(),
+                "a metadata error must surface as Err, never collapse to false"
+            );
+            assert!(
+                startup_needs_reindex(locked.path(), Some("sha-a"), Some("sha-a")),
+                "an uninspectable marker must fail closed into a rebuild"
+            );
+            std::fs::set_permissions(locked.path(), orig).expect("restore perms");
+        }
+
+        /// #329 review round 5: marker I/O must not fail open. When the
+        /// marker cannot be created, the drain falls back to durably
+        /// revoking the certification inside the persisted snapshot itself
+        /// — so a restart with unchanged HEAD still rebuilds. When that
+        /// fallback has no writable channel either, the drain propagates an
+        /// error instead of exiting as if the guarantee held.
+        #[cfg(unix)]
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn drain_timeout_marker_write_failure_revokes_persisted_certification() {
+            use std::os::unix::fs::PermissionsExt;
+            // Permission-based failure injection is meaningless as root.
+            if unsafe { libc::geteuid() } == 0 {
+                return;
+            }
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let index_dir = tempfile::tempdir().expect("index dir");
+            let set_mode = |path: &std::path::Path, mode: u32| {
+                let mut perms = std::fs::metadata(path).expect("meta").permissions();
+                perms.set_mode(mode);
+                std::fs::set_permissions(path, perms).expect("chmod");
+            };
+            let usearch_state = |index: Box<dyn VectorStore>| {
+                let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo init");
+                Arc::new(AppState::new(
+                    Arc::new(repo),
+                    "main".to_string(),
+                    Box::new(MockEmbedding),
+                    index,
+                    AuthProvider::new(),
+                    HealthRegistry::new(),
+                    None,
+                ))
+            };
+
+            // A clean shutdown leaves an on-disk snapshot certified at
+            // HEAD-A.
+            let sha_a = {
+                let state = usearch_state(Box::new(
+                    crate::index::UsearchStore::new(4).expect("usearch store"),
+                ));
+                let note = Memory::from_validated(
+                    MemoryName::new("note-a".to_string()).unwrap(),
+                    "payload a".to_string(),
+                    MemoryMetadata::new(Scope::Root, vec![], None),
+                );
+                state.repo.save_memory(&note).await.expect("save a");
+                assert!(
+                    drain_mutations_before_persist(
+                        &state,
+                        index_dir.path(),
+                        std::time::Duration::from_millis(200)
+                    )
+                    .await
+                    .expect("clean drain must not error"),
+                    "an idle registry must drain cleanly"
+                );
+                persist_index_on_shutdown(&state, index_dir.path())
+                    .await
+                    .expect("persist at A");
+                state.index.commit_sha().expect("verified SHA at A")
+            };
+
+            // Marker writes into the index-dir root now fail (read-only)
+            // while `all/` stays writable for the fallback.
+            set_mode(index_dir.path(), 0o555);
+
+            // A drain timeout with a stuck unit and unchanged HEAD: the
+            // marker write fails, the fallback must absorb it.
+            {
+                let loaded = crate::index::UsearchStore::load(index_dir.path(), 4)
+                    .expect("load snapshot at A");
+                assert_eq!(
+                    loaded.commit_sha().as_deref(),
+                    Some(sha_a.as_str()),
+                    "precondition: the loaded snapshot is certified at A"
+                );
+                let state = usearch_state(Box::new(loaded));
+                let stuck_unit_slot = state.mutations.enter();
+                let drained = drain_mutations_before_persist(
+                    &state,
+                    index_dir.path(),
+                    std::time::Duration::from_millis(50),
+                )
+                .await
+                .expect("the fallback revocation must absorb the marker-write failure");
+                assert!(!drained, "drain must report the expired deadline");
+                drop(stuck_unit_slot);
+            }
+            assert!(
+                !reindex_required_marker_present(index_dir.path()).expect("inspect marker"),
+                "precondition: the marker write must have failed on the \
+                 read-only index dir"
+            );
+
+            // The certification inside the snapshot itself was revoked
+            // durably…
+            let loaded =
+                crate::index::UsearchStore::load(index_dir.path(), 4).expect("reload snapshot");
+            assert_eq!(
+                loaded.commit_sha().as_deref(),
+                Some(crate::index::usearch::REVOKED_COMMIT_SHA_SENTINEL),
+                "the fallback must rewrite the persisted commit_sha to the \
+                 revocation sentinel"
+            );
+            // …so a restart with UNCHANGED git HEAD still rebuilds.
+            let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo reopen");
+            let router = RepoRouter::single(Arc::new(repo));
+            let head = router.head_sha().await;
+            assert_eq!(
+                head.as_deref(),
+                Some(sha_a.as_str()),
+                "precondition: git HEAD is unchanged"
+            );
+            assert!(
+                startup_needs_reindex(
+                    index_dir.path(),
+                    head.as_deref(),
+                    loaded.commit_sha().as_deref()
+                ),
+                "the revoked persisted certification must force the rebuild \
+                 without any marker"
+            );
+
+            // When the fallback ALSO has no durable channel, the drain must
+            // propagate instead of logging the guarantee away.
+            set_mode(&index_dir.path().join("all"), 0o555);
+            {
+                let state = usearch_state(Box::new(
+                    crate::index::UsearchStore::new(4).expect("usearch store"),
+                ));
+                let stuck_unit_slot = state.mutations.enter();
+                let err = drain_mutations_before_persist(
+                    &state,
+                    index_dir.path(),
+                    std::time::Duration::from_millis(50),
+                )
+                .await
+                .expect_err(
+                    "with no durable revocation channel the drain must error, \
+                     not fail open",
+                );
+                assert!(
+                    err.to_string().contains("reindex-required marker"),
+                    "the error must name both failed channels, got: {err}"
+                );
+                drop(stuck_unit_slot);
+            }
+
+            // Restore permissions so the tempdir can clean up.
+            set_mode(&index_dir.path().join("all"), 0o755);
+            set_mode(index_dir.path(), 0o755);
         }
 
         /// #329 review round 4: once the shutdown drain seals admission,
@@ -5444,11 +5786,12 @@ mod tests {
                     marker_dir.path(),
                     std::time::Duration::from_millis(200)
                 )
-                .await,
+                .await
+                .expect("clean drain must not error"),
                 "an idle registry must drain cleanly"
             );
             assert!(
-                !reindex_required_marker_present(marker_dir.path()),
+                !reindex_required_marker_present(marker_dir.path()).expect("inspect marker"),
                 "a clean drain must not leave a reindex-required marker"
             );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -442,6 +442,13 @@ impl Drop for EditStageTiming {
 /// not the transport — to know when application mutations have quiesced. The
 /// slot is held by an RAII guard inside the detached task, so panic unwinds
 /// and task drops release it alongside the `DegradeOnDrop` marking.
+///
+/// The unconditional `enter` below is *nested* accounting: every caller is a
+/// handler that already holds an admission slot from [`admit_mutation`]
+/// (#329 review, round 4), so this unit is sealed-in work by construction —
+/// the shutdown seal must not reject it. The nested slot exists because the
+/// detached task can outlive its (cancellable) requester, whose admission
+/// guard dies with the handler future.
 async fn shielded_mutation_unit<T, F>(state: &Arc<AppState>, unit: F) -> Result<T, MemoryError>
 where
     F: std::future::Future<Output = Result<T, MemoryError>> + Send + 'static,
@@ -465,6 +472,23 @@ where
         Ok(outcome) => outcome,
         Err(e) => Err(MemoryError::Join(format!("mutation unit task failed: {e}"))),
     }
+}
+
+/// Admit a mutating handler into the shutdown registry, or reject it cleanly.
+///
+/// Called at handler *admission* — before any await point or state mutation
+/// (#329 review, round 4). Registration cannot happen later: `remember` and
+/// `edit` embed and mutate the vector index before their shielded unit
+/// spawns, so a slot first taken inside `shielded_mutation_unit` would leave
+/// that pre-registration work invisible to the shutdown drain — the drain
+/// could observe zero in-flight, certify, and exit around it.
+///
+/// After [`MutationRegistry::seal`](crate::types::MutationRegistry::seal)
+/// the admission is refused with [`MemoryError::ShuttingDown`]; nothing has
+/// mutated at that point, so the client can safely retry against the next
+/// server instance.
+fn admit_mutation(state: &AppState) -> Result<crate::types::MutationGuard, MemoryError> {
+    state.mutations.try_enter().ok_or(MemoryError::ShuttingDown)
 }
 
 // ---------------------------------------------------------------------------
@@ -1085,17 +1109,29 @@ pub async fn startup_prepare_index(
 /// application's [`MutationRegistry`](crate::types::MutationRegistry)
 /// instead, with no transport-imposed ceiling.
 ///
+/// Admission is sealed first (#329 review, round 4): a handler task the
+/// transport detached but has not yet polled would otherwise slip in *after*
+/// the drain observed zero in-flight. Once sealed, mutating tools fail with
+/// a clean shutting-down error before touching any state, and the drain
+/// converges over exactly the sealed-in units.
+///
 /// Returns `true` when every unit completed within `deadline`. On timeout it
-/// records a mirror gap and returns `false`: persistence then keeps the last
-/// verified SHA instead of stamping the (already mutated) git HEAD onto an
-/// index whose mirror the killed unit never finished, so the next startup
-/// detects the mismatch and reindexes from git truth. A hard shutdown
+/// records a mirror gap, *revokes the index's stored certification SHA*, and
+/// returns `false`. Revocation must not depend on HEAD comparison (#329
+/// review, round 4): an abandoned `remember`/`edit` may have mutated the
+/// vector index while its shielded git save never advanced HEAD, so the
+/// previously verified SHA can still equal HEAD while the index is dirty —
+/// keeping it would let the next startup certify the dirty index and skip
+/// the reindex. With the SHA revoked (and `run_serve` additionally skipping
+/// persistence entirely on timeout), the next startup can never match
+/// stored-SHA == HEAD and always rebuilds from git truth. A hard shutdown
 /// deadline may abandon a mutation, but it must never certify the index as
 /// intact.
 pub async fn drain_mutations_before_persist(
     state: &AppState,
     deadline: std::time::Duration,
 ) -> bool {
+    state.mutations.seal();
     if state.mutations.drained_within(deadline).await {
         true
     } else {
@@ -1103,9 +1139,13 @@ pub async fn drain_mutations_before_persist(
             in_flight = state.mutations.in_flight(),
             deadline_ms = deadline.as_millis() as u64,
             "mutation units still in flight at shutdown drain deadline — \
-             refusing index certification so the next startup reindexes from git truth"
+             revoking index certification so the next startup reindexes from git truth"
         );
         state.mark_index_mirror_incomplete();
+        // Independent of HEAD equality: the abandoned unit may have dirtied
+        // the vector index without advancing git HEAD, so the last verified
+        // SHA is no longer trustworthy evidence of freshness.
+        state.index.set_commit_sha(None);
         false
     }
 }
@@ -1167,6 +1207,11 @@ impl MemoryServer {
         Parameters(args): Parameters<RememberArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await or state mutation (#329 review, round
+        // 4): the slot spans the handler's full lifetime, so the embed and
+        // vector-index add below — which run *before* the shielded unit
+        // takes its own nested slot — are visible to the shutdown drain.
+        let _mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.len() > MAX_CONTENT_SIZE {
             return Err(ErrorData::from(crate::error::MemoryError::InvalidInput {
@@ -1384,9 +1429,25 @@ impl MemoryServer {
                 results_vec.push(recall_entry_json(&memory, &hit));
             }
 
+            // The recall-log write is durable state, so it takes a registry
+            // slot for its (synchronous, no-await) duration — otherwise the
+            // shutdown drain could observe zero in-flight and `process::exit`
+            // could kill the SQLite write mid-flight (#329 review, round 4,
+            // low). After the seal the write is skipped instead: losing one
+            // recall log entry at shutdown is preferable to failing the read.
             if let Some(ref log) = state.recall_log {
-                if let Err(e) = log.log_results(&recall_id, &session_id, &log_entries) {
-                    warn!(error = %e, "failed to write recall log entries");
+                match state.mutations.try_enter() {
+                    Some(_write_slot) => {
+                        if let Err(e) = log.log_results(&recall_id, &session_id, &log_entries) {
+                            warn!(error = %e, "failed to write recall log entries");
+                        }
+                    }
+                    None => {
+                        warn!(
+                            recall_id = %recall_id,
+                            "shutdown sealed mutation admission — skipping recall log write"
+                        );
+                    }
                 }
             }
 
@@ -1425,6 +1486,8 @@ impl MemoryServer {
         Parameters(args): Parameters<ForgetArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await or state mutation (#329 review, round 4).
+        let _mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
@@ -1504,6 +1567,11 @@ impl MemoryServer {
         Parameters(args): Parameters<EditArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await or state mutation (#329 review, round
+        // 4): the re-embed and vector-index upsert below run before the
+        // shielded unit's nested slot, so this handler-lifetime slot is what
+        // makes them visible to the shutdown drain.
+        let _mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let mut timing = EditStageTiming::new();
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         if args.content.is_none() && args.tags.is_none() {
@@ -1655,6 +1723,8 @@ impl MemoryServer {
         Parameters(args): Parameters<MoveArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await or state mutation (#329 review, round 4).
+        let _mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let name = MemoryName::new(args.name).map_err(ErrorData::from)?;
         let new_name = match args.new_name {
             Some(n) => MemoryName::new(n).map_err(ErrorData::from)?,
@@ -1964,6 +2034,8 @@ impl MemoryServer {
         Parameters(args): Parameters<SyncArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await or state mutation (#329 review, round 4).
+        let _mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let pull_first = args.pull_first.unwrap_or(true);
         let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
@@ -2078,6 +2150,11 @@ impl MemoryServer {
         Parameters(args): Parameters<MarkAppliedArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await (#329 review, round 4, low): the SQLite
+        // verdict write is durable state the shutdown drain must count. The
+        // slot moves into the blocking closure below so the write stays
+        // covered even if this (cancellable) handler future is dropped.
+        let mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let session_id = extract_session_id(&extensions);
         let span = tracing::info_span!(
             "handler.mark_applied",
@@ -2109,6 +2186,10 @@ impl MemoryServer {
                 let application = args.application.clone();
                 let confidence = args.confidence.clone();
                 traced_spawn_blocking(move || {
+                    // Hold the admission slot inside the blocking task: a
+                    // dropped handler future must not strand this write
+                    // outside the shutdown drain.
+                    let _mutation_admission = mutation_admission;
                     log.mark_applied(
                         &recall_id,
                         &memory,
@@ -2172,6 +2253,9 @@ impl MemoryServer {
         Parameters(args): Parameters<BatchMarkAppliedArgs>,
         extensions: Extensions,
     ) -> Result<String, ErrorData> {
+        // Admission before any await (#329 review, round 4, low) — see
+        // `mark_applied`; the slot rides inside the blocking write.
+        let mutation_admission = admit_mutation(&self.state).map_err(ErrorData::from)?;
         let session_id = extract_session_id(&extensions);
         let count = args.verdicts.len();
         let span = tracing::info_span!(
@@ -2221,6 +2305,10 @@ impl MemoryServer {
                     .collect();
 
                 let per_entry = traced_spawn_blocking(move || {
+                    // Hold the admission slot inside the blocking task: a
+                    // dropped handler future must not strand this write
+                    // outside the shutdown drain.
+                    let _mutation_admission = mutation_admission;
                     let refs: Vec<BatchVerdict<'_>> = owned
                         .iter()
                         .map(|o| BatchVerdict {
@@ -5024,16 +5112,24 @@ mod tests {
                 "an expired drain deadline must record a mirror gap — \
                  certifying here is exactly the round-3 data-loss path"
             );
+            // …and revoked outright (#329 review, round 4): keeping the SHA
+            // verified at A is only safe while HEAD has moved past A.
+            assert_eq!(
+                state.index.commit_sha(),
+                None,
+                "an expired drain deadline must revoke the stored certification"
+            );
 
-            // …so persistence keeps the SHA verified at A, not HEAD-B.
+            // Even if a persistence path runs anyway, no certification
+            // survives: the next startup cannot match stored-SHA == HEAD.
             let dir_b = tempfile::tempdir().expect("index dir b");
             persist_index_on_shutdown(&state, dir_b.path())
                 .await
                 .expect("persist after timeout");
             assert_eq!(
-                state.index.commit_sha().as_deref(),
-                Some(sha_a.as_str()),
-                "timeout persistence must keep the last verified SHA"
+                state.index.commit_sha(),
+                None,
+                "timeout persistence must not resurrect a certification SHA"
             );
             assert_ne!(
                 state.index.commit_sha().as_deref(),
@@ -5042,6 +5138,222 @@ mod tests {
                  startup skip the reindex that repairs the missing mirror"
             );
             drop(stuck_unit_slot);
+        }
+
+        /// #329 review round 4: the round-3 test above advances HEAD A→B
+        /// before the timeout, so it only ever exercises the SHA-mismatch
+        /// path. Here the abandoned unit has dirtied the *vector index*
+        /// while git HEAD never advanced — `remember`/`edit` mutate the
+        /// index before their shielded git save — so the previously
+        /// verified SHA still equals current HEAD. Certification must be
+        /// revoked independently of HEAD equality, or the next startup
+        /// would accept the dirty index and skip the reindex.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn shutdown_drain_timeout_forces_reindex_without_head_advance() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+
+            // Verified state at A: stored SHA == git HEAD.
+            let note_a = Memory::from_validated(
+                MemoryName::new("note-a".to_string()).unwrap(),
+                "payload a".to_string(),
+                MemoryMetadata::new(Scope::Root, vec![], None),
+            );
+            state.repo.save_memory(&note_a).await.expect("save a");
+            let dir_a = tempfile::tempdir().expect("index dir a");
+            persist_index_on_shutdown(&state, dir_a.path())
+                .await
+                .expect("persist at A");
+            let sha_a = state.index.commit_sha().expect("verified SHA at A");
+
+            // An admitted unit dirties the vector index (the pre-shielded
+            // `remember`/`edit` step) and then stalls before its git save —
+            // HEAD does NOT advance.
+            let stuck_unit_slot = state.mutations.enter();
+            state
+                .index
+                .add(
+                    &Scope::Root,
+                    &[0.0, 0.0, 1.0, 0.0],
+                    qualified(&Scope::Root, "ghost"),
+                )
+                .expect("dirty the vector index without a git commit");
+            assert_eq!(
+                state.router.head_sha().await.as_deref(),
+                Some(sha_a.as_str()),
+                "precondition: git HEAD must not have advanced past A"
+            );
+
+            let drained =
+                drain_mutations_before_persist(&state, std::time::Duration::from_millis(50)).await;
+            assert!(!drained, "drain must report the expired deadline");
+
+            // The falsely fresh SHA (old SHA == current HEAD) must be gone…
+            assert_eq!(
+                state.index.commit_sha(),
+                None,
+                "certification must be revoked even though stored SHA still \
+                 equals HEAD — HEAD equality is not evidence of a clean mirror"
+            );
+
+            // …including through any persistence that runs afterwards, so
+            // the next boot can never see stored-SHA == HEAD and must
+            // reindex from git truth.
+            let dir_b = tempfile::tempdir().expect("index dir b");
+            persist_index_on_shutdown(&state, dir_b.path())
+                .await
+                .expect("persist after timeout");
+            assert_eq!(state.index.commit_sha(), None);
+            assert_ne!(
+                state.index.commit_sha().as_deref(),
+                state.router.head_sha().await.as_deref(),
+                "the dirty index must not be bootable as fresh"
+            );
+            drop(stuck_unit_slot);
+        }
+
+        /// #329 review round 4: once the shutdown drain seals admission,
+        /// mutating tools must fail with a clean shutting-down error before
+        /// touching any state, and the registry must remain drained — a
+        /// late entrant can neither mutate nor extend the drain.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn sealed_shutdown_rejects_late_mutating_handlers() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = test_state(&tmp);
+            let server = MemoryServer::new(Arc::clone(&state));
+
+            // An idle shutdown drain seals admission and reports drained.
+            assert!(
+                drain_mutations_before_persist(&state, std::time::Duration::from_millis(200)).await,
+                "an idle registry must drain cleanly"
+            );
+
+            // A handler arriving after the seal (e.g. a detached task the
+            // transport spawned but had not yet polled) is rejected cleanly.
+            let err = server
+                .remember(
+                    Parameters(RememberArgs {
+                        name: "late".to_string(),
+                        content: "late payload".to_string(),
+                        scope: None,
+                        tags: vec![],
+                        source: None,
+                    }),
+                    test_extensions(),
+                )
+                .await
+                .expect_err("a sealed registry must reject the handler");
+            assert!(
+                err.message.contains("shutting down"),
+                "rejection must be a clean shutting-down error, got: {}",
+                err.message
+            );
+
+            // Nothing was admitted or mutated: the registry is still
+            // drained and the memory was never written.
+            assert_eq!(state.mutations.in_flight(), 0);
+            let late_name = MemoryName::new("late".to_string()).unwrap();
+            assert!(
+                state
+                    .router
+                    .read_memory(&late_name, &Scope::Root)
+                    .await
+                    .is_err(),
+                "the rejected handler must not have written the memory"
+            );
+        }
+
+        /// #329 review round 4: `remember` embeds and mutates the vector
+        /// index *before* `shielded_mutation_unit` takes its nested slot.
+        /// Admission-time registration must make that pre-shielded section
+        /// visible to the shutdown drain: while the handler is stalled
+        /// inside the embed await, the registry must not report drained.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn handler_admission_covers_pre_shielded_embedding() {
+            struct GatedEmbedding {
+                entered: Arc<tokio::sync::Notify>,
+                release: Arc<tokio::sync::Notify>,
+            }
+
+            #[async_trait]
+            impl crate::embedding::EmbeddingBackend for GatedEmbedding {
+                async fn embed(
+                    &self,
+                    texts: &[String],
+                ) -> Result<Vec<Vec<f32>>, crate::error::MemoryError> {
+                    self.entered.notify_one();
+                    self.release.notified().await;
+                    Ok(texts.iter().map(|_| vec![0.0, 0.0, 0.0, 1.0]).collect())
+                }
+
+                fn dimensions(&self) -> usize {
+                    4
+                }
+            }
+
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let entered = Arc::new(tokio::sync::Notify::new());
+            let release = Arc::new(tokio::sync::Notify::new());
+            let repo = MemoryRepo::init_or_open(tmp.path(), None).expect("repo init");
+            let state = Arc::new(AppState::new(
+                Arc::new(repo),
+                "main".to_string(),
+                Box::new(GatedEmbedding {
+                    entered: Arc::clone(&entered),
+                    release: Arc::clone(&release),
+                }),
+                Box::new(InMemoryStore::new(4)),
+                AuthProvider::new(),
+                HealthRegistry::new(),
+                None,
+            ));
+            let server = MemoryServer::new(Arc::clone(&state));
+
+            let handler_state = Arc::clone(&state);
+            let handler = tokio::spawn(async move {
+                MemoryServer::new(handler_state)
+                    .remember(
+                        Parameters(RememberArgs {
+                            name: "gated".to_string(),
+                            content: "gated payload".to_string(),
+                            scope: None,
+                            tags: vec![],
+                            source: None,
+                        }),
+                        test_extensions(),
+                    )
+                    .await
+            });
+
+            // The handler is provably stalled in the embed await — before
+            // any shielded unit exists — and must already hold its slot.
+            entered.notified().await;
+            assert!(
+                state.mutations.in_flight() >= 1,
+                "admission must register the handler before the embed await"
+            );
+            assert!(
+                !state
+                    .mutations
+                    .drained_within(std::time::Duration::from_millis(50))
+                    .await,
+                "the drain must not report quiescence while pre-shielded \
+                 handler work is executing — this is the round-4 late-entrant gap"
+            );
+
+            release.notify_one();
+            handler
+                .await
+                .expect("handler task")
+                .expect("remember must succeed");
+            assert!(
+                state
+                    .mutations
+                    .drained_within(std::time::Duration::from_secs(5))
+                    .await,
+                "the slot must release when the handler completes"
+            );
+            drop(server);
         }
 
         /// #329 review round 3: `shielded_mutation_unit` must account its

--- a/src/server.rs
+++ b/src/server.rs
@@ -1117,7 +1117,8 @@ fn reindex_marker_path(index_dir: &std::path::Path) -> std::path::PathBuf {
 
 /// Durably record that the next startup must rebuild the vector index.
 ///
-/// Goes through [`crate::fs_util::atomic_write`] (#329 review, round 5):
+/// Goes through the hardened `crate::fs_util::atomic_write_durable` helper
+/// (#329 review, round 5):
 /// the temp file is fsynced before the atomic rename and the parent
 /// directory is fsynced after it, so the marker survives power loss once
 /// this returns and a partially written marker never exists under the final
@@ -1129,7 +1130,7 @@ fn reindex_marker_path(index_dir: &std::path::Path) -> std::path::PathBuf {
 /// persisted on the timeout path.
 pub fn write_reindex_required_marker(index_dir: &std::path::Path) -> std::io::Result<()> {
     std::fs::create_dir_all(index_dir)?;
-    crate::fs_util::atomic_write(
+    crate::fs_util::atomic_write_durable(
         &reindex_marker_path(index_dir),
         b"shutdown mutation drain deadline expired; the on-disk index snapshot \
           is no longer certified - startup must rebuild from git truth\n",

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -375,6 +375,94 @@ pub struct ReindexStats {
 }
 
 // ---------------------------------------------------------------------------
+// MutationRegistry
+// ---------------------------------------------------------------------------
+
+/// Registry of in-flight application mutation units, awaited at shutdown
+/// independently of the transport's bounded response drain (#329 review,
+/// round 3).
+///
+/// rmcp's awaited cancellation drains handler *responses* for a bounded
+/// window (~2s in rmcp 1.8) and detaches handler tasks — a mutation that
+/// outlives the window also outlives `waiting()`. Index persistence must
+/// therefore gate on the application's own accounting of mutation units:
+/// each unit registers here before it is spawned and releases its slot via
+/// an RAII [`MutationGuard`] — so panic unwinds and task drops release too —
+/// and shutdown awaits quiescence with no transport-imposed ceiling before
+/// the index SHA may be certified.
+#[derive(Debug, Default)]
+pub struct MutationRegistry {
+    in_flight: std::sync::atomic::AtomicUsize,
+    drained: tokio::sync::Notify,
+}
+
+impl MutationRegistry {
+    /// Register one in-flight mutation unit.
+    ///
+    /// The returned guard must be held for the unit's full duration;
+    /// dropping it (normal completion, panic unwind, or task drop) releases
+    /// the slot and wakes shutdown waiters when the registry empties.
+    pub fn enter(self: &Arc<Self>) -> MutationGuard {
+        self.in_flight
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        MutationGuard {
+            registry: Arc::clone(self),
+        }
+    }
+
+    /// Number of currently registered units.
+    pub fn in_flight(&self) -> usize {
+        self.in_flight.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Resolve once no mutation units are in flight. No internal deadline —
+    /// the whole point is to outwait the transport's bounded drain.
+    pub async fn drained(&self) {
+        loop {
+            let notified = self.drained.notified();
+            tokio::pin!(notified);
+            // Register for `notify_waiters` *before* reading the counter, so
+            // a guard dropped between the load and the await cannot strand
+            // this waiter (an unpolled `Notified` receives no wakeup).
+            notified.as_mut().enable();
+            if self.in_flight() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Await quiescence, giving up after `deadline`.
+    ///
+    /// Returns `true` when every unit completed. Returns `false` on timeout
+    /// — the caller must then refuse to certify derived state as intact,
+    /// because a unit may still be mutating git or index state.
+    pub async fn drained_within(&self, deadline: std::time::Duration) -> bool {
+        tokio::time::timeout(deadline, self.drained()).await.is_ok()
+    }
+}
+
+/// RAII slot held by one in-flight mutation unit. See
+/// [`MutationRegistry::enter`].
+#[derive(Debug)]
+pub struct MutationGuard {
+    registry: Arc<MutationRegistry>,
+}
+
+impl Drop for MutationGuard {
+    fn drop(&mut self) {
+        if self
+            .registry
+            .in_flight
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
+            == 1
+        {
+            self.registry.drained.notify_waiters();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // AppState
 // ---------------------------------------------------------------------------
 
@@ -402,6 +490,9 @@ pub struct AppState {
     pub health: HealthRegistry,
     /// Optional append-only recall event log for threshold calibration.
     pub recall_log: Option<Arc<crate::recall_log::RecallLog>>,
+    /// In-flight mutation units, awaited at shutdown before index
+    /// persistence may certify (#329 review, round 3).
+    pub mutations: Arc<MutationRegistry>,
     /// `true` while every git HEAD advance since the vector index's stored
     /// commit SHA has been fully mirrored into the vector index.
     ///
@@ -438,6 +529,7 @@ impl AppState {
             branch,
             health,
             recall_log,
+            mutations: Arc::new(MutationRegistry::default()),
             index_mirror_intact: std::sync::atomic::AtomicBool::new(true),
         }
     }
@@ -468,6 +560,7 @@ impl AppState {
             branch,
             health,
             recall_log,
+            mutations: Arc::new(MutationRegistry::default()),
             index_mirror_intact: std::sync::atomic::AtomicBool::new(true),
         }
     }
@@ -679,5 +772,58 @@ mod tests {
                 "fields schema must advertise '{field}': {serialized}"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // MutationRegistry (#329 review, round 3)
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn mutation_registry_drain_waits_for_last_guard() {
+        let registry = Arc::new(MutationRegistry::default());
+        let guard = registry.enter();
+        assert_eq!(registry.in_flight(), 1);
+
+        // While the guard is held, drain must not report quiescence.
+        assert!(
+            !registry
+                .drained_within(std::time::Duration::from_millis(50))
+                .await,
+            "drain must time out while a mutation unit is registered"
+        );
+
+        // Release from another task; the waiter must observe it.
+        let release_registry = Arc::clone(&registry);
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            drop(guard);
+            drop(release_registry);
+        });
+        assert!(
+            registry
+                .drained_within(std::time::Duration::from_secs(10))
+                .await,
+            "drain must resolve once the last guard drops"
+        );
+        assert_eq!(registry.in_flight(), 0);
+        releaser.await.expect("releaser task");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn mutation_registry_releases_slot_on_panic() {
+        let registry = Arc::new(MutationRegistry::default());
+        let guard = registry.enter();
+        let worker = tokio::spawn(async move {
+            let _held = guard;
+            panic!("injected panic while holding a mutation slot");
+        });
+        assert!(worker.await.is_err(), "worker must have panicked");
+        assert!(
+            registry
+                .drained_within(std::time::Duration::from_secs(5))
+                .await,
+            "a panicked unit must release its slot via the RAII guard — \
+             otherwise shutdown would wait forever on a dead mutation"
+        );
     }
 }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -386,18 +386,32 @@ pub struct ReindexStats {
 /// window (~2s in rmcp 1.8) and detaches handler tasks — a mutation that
 /// outlives the window also outlives `waiting()`. Index persistence must
 /// therefore gate on the application's own accounting of mutation units:
-/// each unit registers here before it is spawned and releases its slot via
-/// an RAII [`MutationGuard`] — so panic unwinds and task drops release too —
-/// and shutdown awaits quiescence with no transport-imposed ceiling before
-/// the index SHA may be certified.
+/// each handler admits itself here *before any await or state mutation* and
+/// releases its slot via an RAII [`MutationGuard`] — so panic unwinds and
+/// task drops release too — and shutdown awaits quiescence with no
+/// transport-imposed ceiling before the index SHA may be certified.
+///
+/// Admission is *sealable* (#329 review, round 4): a handler task the
+/// transport detached but has not yet polled would otherwise register
+/// *after* shutdown observed zero in-flight — a late entrant the drain
+/// never counts. Once [`seal`](Self::seal) is called, [`try_enter`]
+/// (Self::try_enter) refuses new admissions, so the drain converges over
+/// exactly the sealed-in units.
 #[derive(Debug, Default)]
 pub struct MutationRegistry {
     in_flight: std::sync::atomic::AtomicUsize,
+    sealed: std::sync::atomic::AtomicBool,
     drained: tokio::sync::Notify,
 }
 
 impl MutationRegistry {
-    /// Register one in-flight mutation unit.
+    /// Register one in-flight mutation unit, bypassing the shutdown seal.
+    ///
+    /// Only for work *nested under an admission slot that is already held*
+    /// (e.g. the detached task `shielded_mutation_unit` spawns on behalf of
+    /// an admitted handler) — such work is sealed-in by construction. New
+    /// top-level work must go through [`try_enter`](Self::try_enter) so the
+    /// shutdown seal can reject it.
     ///
     /// The returned guard must be held for the unit's full duration;
     /// dropping it (normal completion, panic unwind, or task drop) releases
@@ -408,6 +422,40 @@ impl MutationRegistry {
         MutationGuard {
             registry: Arc::clone(self),
         }
+    }
+
+    /// Admit one mutation unit unless shutdown has sealed the registry.
+    ///
+    /// Returns `None` once [`seal`](Self::seal) has been called — the caller
+    /// must fail cleanly without mutating any state. Increment-then-check
+    /// makes the race with `seal` safe: both the counter increment and the
+    /// seal flag use `SeqCst`, so if this load observes the registry
+    /// unsealed, the preceding increment is ordered before the seal in the
+    /// single total order — a drain that starts after sealing therefore
+    /// cannot miss this admission.
+    pub fn try_enter(self: &Arc<Self>) -> Option<MutationGuard> {
+        let guard = self.enter();
+        if self.sealed.load(std::sync::atomic::Ordering::SeqCst) {
+            // Guard drop releases the provisional slot and wakes waiters.
+            drop(guard);
+            None
+        } else {
+            Some(guard)
+        }
+    }
+
+    /// Seal admission for shutdown: every subsequent
+    /// [`try_enter`](Self::try_enter) is refused, so
+    /// [`drained`](Self::drained) converges over exactly the units admitted
+    /// before the seal (plus their nested [`enter`](Self::enter) slots).
+    /// Sealing is sticky for the registry's lifetime.
+    pub fn seal(&self) {
+        self.sealed.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// `true` once shutdown has sealed admission.
+    pub fn is_sealed(&self) -> bool {
+        self.sealed.load(std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Number of currently registered units.
@@ -824,6 +872,68 @@ mod tests {
                 .await,
             "a panicked unit must release its slot via the RAII guard — \
              otherwise shutdown would wait forever on a dead mutation"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Admission seal (#329 review, round 4)
+    // -----------------------------------------------------------------------
+
+    /// A sealed registry refuses new admissions without leaking the
+    /// provisional slot, while pre-seal admissions are still counted by the
+    /// drain — the late-entrant window from the round-4 review.
+    #[tokio::test]
+    async fn mutation_registry_seal_rejects_late_admissions() {
+        let registry = Arc::new(MutationRegistry::default());
+
+        let pre_seal = registry.try_enter().expect("unsealed registry admits");
+        assert_eq!(registry.in_flight(), 1);
+
+        registry.seal();
+        assert!(registry.is_sealed());
+        assert!(
+            registry.try_enter().is_none(),
+            "a sealed registry must reject new admissions"
+        );
+        assert_eq!(
+            registry.in_flight(),
+            1,
+            "a rejected admission must not leak its provisional slot"
+        );
+
+        // The sealed-in unit still gates the drain…
+        assert!(
+            !registry
+                .drained_within(std::time::Duration::from_millis(50))
+                .await,
+            "drain must wait for the unit admitted before the seal"
+        );
+        // …and nested (bypass) slots for sealed-in work are still allowed.
+        let nested = registry.enter();
+        assert_eq!(registry.in_flight(), 2);
+        drop(nested);
+        drop(pre_seal);
+        assert!(
+            registry
+                .drained_within(std::time::Duration::from_secs(5))
+                .await,
+            "drain must resolve once sealed-in work completes"
+        );
+    }
+
+    /// A rejected admission on an otherwise idle sealed registry must leave
+    /// it immediately drained — the provisional increment/decrement pair
+    /// must not wedge a waiter.
+    #[tokio::test]
+    async fn mutation_registry_rejected_admission_leaves_registry_drained() {
+        let registry = Arc::new(MutationRegistry::default());
+        registry.seal();
+        assert!(registry.try_enter().is_none());
+        assert!(
+            registry
+                .drained_within(std::time::Duration::from_millis(200))
+                .await,
+            "a rejected admission must leave the sealed registry drained"
         );
     }
 }

--- a/src/types/args.rs
+++ b/src/types/args.rs
@@ -394,8 +394,8 @@ pub struct ReindexStats {
 /// Admission is *sealable* (#329 review, round 4): a handler task the
 /// transport detached but has not yet polled would otherwise register
 /// *after* shutdown observed zero in-flight — a late entrant the drain
-/// never counts. Once [`seal`](Self::seal) is called, [`try_enter`]
-/// (Self::try_enter) refuses new admissions, so the drain converges over
+/// never counts. Once [`seal`](Self::seal) is called,
+/// [`try_enter`](Self::try_enter) refuses new admissions, so the drain converges over
 /// exactly the sealed-in units.
 #[derive(Debug, Default)]
 pub struct MutationRegistry {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -13,8 +13,8 @@ mod validated;
 pub(crate) use args::ResolvedChanges;
 pub use args::{
     AppState, BatchMarkAppliedArgs, ChangedMemories, EditArgs, ForgetArgs, ListArgs, ListField,
-    MarkAppliedArgs, MoveArgs, PullResult, ReadArgs, RecallArgs, RecallStatsArgs, ReindexStats,
-    RememberArgs, SyncArgs, Verdict, VerdictEntry,
+    MarkAppliedArgs, MoveArgs, MutationGuard, MutationRegistry, PullResult, ReadArgs, RecallArgs,
+    RecallStatsArgs, ReindexStats, RememberArgs, SyncArgs, Verdict, VerdictEntry,
 };
 
 pub(crate) use args::{ListToolArgs, LIST_MAX_LIMIT};

--- a/tests/stdio_transport.rs
+++ b/tests/stdio_transport.rs
@@ -268,3 +268,149 @@ fn second_instance_fails_fast_while_first_holds_the_lock() {
         "first instance clean exit, got: {status:?}"
     );
 }
+
+/// Scope-mapped repositories are covered by the single-writer lock too
+/// (#329 review, round 2): two processes with *distinct* default repos that
+/// share one mapped repo must contend on the shared repo's lock — the
+/// second exits non-zero, fast, naming the holder's pid and the contended
+/// path.
+#[test]
+fn second_instance_fails_fast_when_configs_share_a_mapped_repo() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let default_a = tmp.path().join("default-a");
+    let default_b = tmp.path().join("default-b");
+    let shared = tmp.path().join("shared-mapped");
+    std::fs::create_dir_all(&default_a).expect("create default-a");
+    std::fs::create_dir_all(&default_b).expect("create default-b");
+
+    // Two configs, both mapping the `work` scope to the same local repo.
+    // The URL is never fetched at startup; only the path matters here.
+    let write_config = |name: &str| {
+        let path = tmp.path().join(name);
+        std::fs::write(
+            &path,
+            format!(
+                "[[remotes]]\nscope = \"work\"\nurl = \"https://example.invalid/shared.git\"\npath = \"{}\"\n",
+                shared.display()
+            ),
+        )
+        .expect("write config");
+        path
+    };
+    let config_a = write_config("config-a.toml");
+    let config_b = write_config("config-b.toml");
+
+    let stderr_file =
+        std::fs::File::create(tmp.path().join("first-stderr.log")).expect("stderr capture");
+    let mut first = Command::new(env!("CARGO_BIN_EXE_memory-mcp"))
+        .args([
+            "serve",
+            "--transport",
+            "stdio",
+            "--repo-path",
+            default_a.to_str().expect("utf8 temp path"),
+            "--config",
+            config_a.to_str().expect("utf8 temp path"),
+        ])
+        .env("RUST_LOG", "debug")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .map(ServerGuard)
+        .expect("spawn first instance");
+    let rx = stdout_lines(&mut first.0);
+
+    // Complete the handshake so the first instance provably holds every
+    // lock (they are all acquired before subsystem init).
+    initialize(&mut first.0, &rx);
+
+    // Second instance: different default repo, same mapped repo. Without
+    // mapped-repo locking both processes would happily serve and mutate the
+    // shared git repo concurrently; it must fail fast on the shared lock.
+    let output = Command::new(env!("CARGO_BIN_EXE_memory-mcp"))
+        .args([
+            "serve",
+            "--repo-path",
+            default_b.to_str().expect("utf8 temp path"),
+            "--config",
+            config_b.to_str().expect("utf8 temp path"),
+            "--bind",
+            "127.0.0.1:0",
+        ])
+        .output()
+        .expect("run second memory-mcp instance");
+
+    assert!(
+        !output.status.success(),
+        "second instance must exit non-zero while the shared mapped repo \
+         lock is held, got: {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already serving"),
+        "second instance should explain the contention: {stderr}"
+    );
+    assert!(
+        stderr.contains("shared-mapped"),
+        "second instance should name the contended mapped repo path: {stderr}"
+    );
+    let first_pid = first.0.id().to_string();
+    assert!(
+        stderr.contains(&first_pid),
+        "second instance should name the holder pid {first_pid}: {stderr}"
+    );
+
+    drop(first.0.stdin.take());
+    let status = wait_with_timeout(&mut first.0, Duration::from_secs(60));
+    assert!(
+        status.success(),
+        "first instance clean exit, got: {status:?}"
+    );
+}
+
+/// SIGTERM during an active session exercises the signal branch of
+/// shutdown (#329 review, round 2): the running service must be cancelled
+/// and awaited — draining rmcp cleanup — *before* `run_serve` persists the
+/// vector index. The stderr log order is the receipt: the drain completion
+/// line must precede the index-saved line, and the exit must be clean
+/// (the in-process `shutdown_signal_drains_in_flight_tool_call_before_returning`
+/// unit test proves the drain blocks on in-flight mutations).
+#[cfg(unix)]
+#[test]
+fn sigterm_drains_service_before_index_persistence() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stderr_path = tmp.path().join("stderr.log");
+    let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr capture");
+
+    let mut server = spawn_stdio_server(tmp.path(), Stdio::from(stderr_file));
+    let rx = stdout_lines(&mut server.0);
+    initialize(&mut server.0, &rx);
+
+    // SIGTERM, not stdin EOF: the client end stays open so only the signal
+    // path can end the session.
+    let kill_status = Command::new("kill")
+        .args(["-TERM", &server.0.id().to_string()])
+        .status()
+        .expect("send SIGTERM");
+    assert!(kill_status.success(), "kill -TERM failed: {kill_status:?}");
+
+    let status = wait_with_timeout(&mut server.0, Duration::from_secs(60));
+    assert!(
+        status.success(),
+        "clean exit after SIGTERM (graceful shutdown, not signal death), got: {status:?}"
+    );
+
+    let stderr = std::fs::read_to_string(&stderr_path).expect("read captured stderr");
+    let drained = stderr
+        .find("stdio transport drained and closed")
+        .unwrap_or_else(|| panic!("missing drain completion log line in stderr:\n{stderr}"));
+    let saved = stderr
+        .find("vector index saved")
+        .unwrap_or_else(|| panic!("missing index persistence log line in stderr:\n{stderr}"));
+    assert!(
+        drained < saved,
+        "service drain must complete before index persistence:\n{stderr}"
+    );
+}

--- a/tests/stdio_transport.rs
+++ b/tests/stdio_transport.rs
@@ -1,0 +1,270 @@
+//! stdio transport integration tests (#104, ADR-0040).
+//!
+//! These are subprocess tests because the behavior under test is process
+//! shape: JSON-RPC framing on stdout with zero pollution, tracing on stderr,
+//! the single-writer lock across process boundaries, and clean exit on stdin
+//! EOF. In-process tower tests (ADR-0036) cannot observe any of that.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// Response budget per stdout line: the embedding model loads synchronously
+/// before the server answers `initialize` (same startup budget as the HTTP
+/// subprocess tests).
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Kill the child on test panic so failures don't leak server processes.
+struct ServerGuard(Child);
+
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn spawn_stdio_server(repo: &Path, stderr_to: Stdio) -> ServerGuard {
+    let child = Command::new(env!("CARGO_BIN_EXE_memory-mcp"))
+        .args([
+            "serve",
+            "--transport",
+            "stdio",
+            "--repo-path",
+            repo.to_str().expect("utf8 temp path"),
+        ])
+        // Force verbose tracing: any log line that leaked to stdout would
+        // fail the pollution assertions below.
+        .env("RUST_LOG", "debug")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(stderr_to)
+        .spawn()
+        .expect("failed to spawn memory-mcp serve --transport stdio");
+    ServerGuard(child)
+}
+
+/// Pump child stdout lines over a channel so response waits can time out
+/// instead of hanging the test on a wedged server.
+fn stdout_lines(child: &mut Child) -> mpsc::Receiver<String> {
+    let stdout = child.stdout.take().expect("child stdout piped");
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+fn next_line(rx: &mpsc::Receiver<String>) -> String {
+    rx.recv_timeout(RESPONSE_TIMEOUT)
+        .expect("timed out waiting for a stdout line from the server")
+}
+
+fn send(child: &mut Child, msg: &serde_json::Value) {
+    let stdin = child.stdin.as_mut().expect("child stdin piped");
+    let mut line = msg.to_string();
+    line.push('\n');
+    stdin
+        .write_all(line.as_bytes())
+        .expect("write to child stdin");
+    stdin.flush().expect("flush child stdin");
+}
+
+/// Drive the MCP initialize handshake to completion and return the
+/// `initialize` response.
+fn initialize(child: &mut Child, rx: &mpsc::Receiver<String>) -> serde_json::Value {
+    send(
+        child,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "stdio-transport-test", "version": "0"}
+            }
+        }),
+    );
+    let resp: serde_json::Value =
+        serde_json::from_str(&next_line(rx)).expect("initialize response is valid JSON");
+    assert_eq!(resp["id"], 1, "initialize response id: {resp}");
+    assert!(
+        resp.get("error").is_none(),
+        "initialize must not error: {resp}"
+    );
+    send(
+        child,
+        &serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    );
+    resp
+}
+
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> std::process::ExitStatus {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("try_wait on server") {
+            return status;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "server did not exit within {timeout:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Full stdio round trip: initialize handshake, tools/list, one recall —
+/// every stdout byte is JSON-RPC (zero pollution, verified under
+/// RUST_LOG=debug), tracing lands on stderr, and stdin EOF is a clean exit.
+#[test]
+fn stdio_round_trip_serves_tools_with_clean_stdout() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stderr_path = tmp.path().join("stderr.log");
+    let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr capture");
+
+    let mut server = spawn_stdio_server(tmp.path(), Stdio::from(stderr_file));
+    let rx = stdout_lines(&mut server.0);
+    let mut transcript: Vec<String> = Vec::new();
+
+    let init_resp = initialize(&mut server.0, &rx);
+    transcript.push(init_resp.to_string());
+    assert!(
+        init_resp["result"]["serverInfo"]["name"].is_string(),
+        "initialize result should carry serverInfo: {init_resp}"
+    );
+
+    // tools/list must include the memory tools.
+    send(
+        &mut server.0,
+        &serde_json::json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    );
+    let line = next_line(&rx);
+    transcript.push(line.clone());
+    let tools_resp: serde_json::Value =
+        serde_json::from_str(&line).expect("tools/list response is valid JSON");
+    assert_eq!(tools_resp["id"], 2, "tools/list response id: {tools_resp}");
+    let tools = tools_resp["result"]["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tools/list result has a tools array: {tools_resp}"));
+    assert!(
+        tools.iter().any(|t| t["name"] == "recall"),
+        "tools/list should include recall: {tools_resp}"
+    );
+
+    // One real tool call end to end: recall exercises the embedding engine
+    // and the vector index over the stdio channel.
+    send(
+        &mut server.0,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "recall", "arguments": {"query": "stdio transport"}}
+        }),
+    );
+    let line = next_line(&rx);
+    transcript.push(line.clone());
+    let recall_resp: serde_json::Value =
+        serde_json::from_str(&line).expect("recall response is valid JSON");
+    assert_eq!(recall_resp["id"], 3, "recall response id: {recall_resp}");
+    assert!(
+        recall_resp.get("error").is_none(),
+        "recall must not error: {recall_resp}"
+    );
+    assert_ne!(
+        recall_resp["result"]["isError"],
+        serde_json::Value::Bool(true),
+        "recall tool result must not be an error: {recall_resp}"
+    );
+
+    // Closing stdin is the normal MCP end-of-session: the server must exit
+    // cleanly (this is also when the vector index is persisted).
+    drop(server.0.stdin.take());
+    let status = wait_with_timeout(&mut server.0, Duration::from_secs(60));
+    assert!(status.success(), "clean exit on stdin EOF, got: {status:?}");
+
+    // Drain anything the server wrote during shutdown, then assert zero
+    // stdout pollution: every line is a JSON-RPC message, nothing else.
+    while let Ok(line) = rx.recv_timeout(Duration::from_secs(5)) {
+        transcript.push(line);
+    }
+    for line in &transcript {
+        let msg: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("non-JSON bytes on stdout ({e}): {line:?}"));
+        assert_eq!(
+            msg["jsonrpc"], "2.0",
+            "stdout line is not a JSON-RPC message: {line:?}"
+        );
+    }
+
+    // The tracing receipt: with RUST_LOG=debug the server logs plenty — and
+    // all of it must have landed on stderr, not stdout.
+    let stderr = std::fs::read_to_string(&stderr_path).expect("read captured stderr");
+    assert!(
+        !stderr.trim().is_empty(),
+        "expected tracing output on stderr under RUST_LOG=debug"
+    );
+}
+
+/// Single-writer enforcement (ADR-0040): while one instance holds the lock,
+/// a second instance — regardless of transport — exits non-zero, fast, with
+/// an error naming the holder's pid.
+#[test]
+fn second_instance_fails_fast_while_first_holds_the_lock() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let stderr_file =
+        std::fs::File::create(tmp.path().join("first-stderr.log")).expect("stderr capture");
+
+    let mut first = spawn_stdio_server(tmp.path(), Stdio::from(stderr_file));
+    let rx = stdout_lines(&mut first.0);
+
+    // Complete the handshake so the first instance is provably up. The lock
+    // is acquired before subsystem init, so this wait is conservative.
+    initialize(&mut first.0, &rx);
+
+    // Second instance against the same repo, using the default HTTP
+    // transport: the lock applies across transports, and it must fail before
+    // the (slow) embedding init or any bind.
+    let output = Command::new(env!("CARGO_BIN_EXE_memory-mcp"))
+        .args([
+            "serve",
+            "--repo-path",
+            tmp.path().to_str().expect("utf8 temp path"),
+            "--bind",
+            "127.0.0.1:0",
+        ])
+        .output()
+        .expect("run second memory-mcp instance");
+
+    assert!(
+        !output.status.success(),
+        "second instance must exit non-zero while the lock is held, got: {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already serving"),
+        "second instance should explain the contention: {stderr}"
+    );
+    let first_pid = first.0.id().to_string();
+    assert!(
+        stderr.contains(&first_pid),
+        "second instance should name the holder pid {first_pid}: {stderr}"
+    );
+
+    // Clean shutdown of the first instance releases the lock via the kernel.
+    drop(first.0.stdin.take());
+    let status = wait_with_timeout(&mut first.0, Duration::from_secs(60));
+    assert!(
+        status.success(),
+        "first instance clean exit, got: {status:?}"
+    );
+}

--- a/tests/stdio_transport.rs
+++ b/tests/stdio_transport.rs
@@ -373,10 +373,13 @@ fn second_instance_fails_fast_when_configs_share_a_mapped_repo() {
 /// SIGTERM during an active session exercises the signal branch of
 /// shutdown (#329 review, round 2): the running service must be cancelled
 /// and awaited — draining rmcp cleanup — *before* `run_serve` persists the
-/// vector index. The stderr log order is the receipt: the drain completion
-/// line must precede the index-saved line, and the exit must be clean
-/// (the in-process `shutdown_signal_drains_in_flight_tool_call_before_returning`
-/// unit test proves the drain blocks on in-flight mutations).
+/// vector index. The stderr log order is the receipt: the transport drain
+/// line, then the mutation-registry drain line (#329 review, round 3 — the
+/// application-side gate with no transport-imposed ceiling), then the
+/// index-saved line, and the exit must be clean. The in-process unit tests
+/// (`shutdown_signal_drains_in_flight_tool_call_before_returning` and
+/// `shutdown_awaits_mutation_blocked_beyond_rmcp_drain_window`) prove the
+/// two drains actually block on in-flight work.
 #[cfg(unix)]
 #[test]
 fn sigterm_drains_service_before_index_persistence() {
@@ -406,11 +409,15 @@ fn sigterm_drains_service_before_index_persistence() {
     let drained = stderr
         .find("stdio transport drained and closed")
         .unwrap_or_else(|| panic!("missing drain completion log line in stderr:\n{stderr}"));
+    let mutations_drained = stderr
+        .find("mutation units drained")
+        .unwrap_or_else(|| panic!("missing mutation-registry drain log line in stderr:\n{stderr}"));
     let saved = stderr
         .find("vector index saved")
         .unwrap_or_else(|| panic!("missing index persistence log line in stderr:\n{stderr}"));
     assert!(
-        drained < saved,
-        "service drain must complete before index persistence:\n{stderr}"
+        drained < mutations_drained && mutations_drained < saved,
+        "shutdown order must be transport drain, then mutation-registry \
+         drain (#329 round 3), then index persistence:\n{stderr}"
     );
 }

--- a/tests/stdio_transport.rs
+++ b/tests/stdio_transport.rs
@@ -79,7 +79,11 @@ fn send(child: &mut Child, msg: &serde_json::Value) {
 
 /// Drive the MCP initialize handshake to completion and return the
 /// `initialize` response.
-fn initialize(child: &mut Child, rx: &mpsc::Receiver<String>) -> serde_json::Value {
+fn initialize(
+    child: &mut Child,
+    rx: &mpsc::Receiver<String>,
+    stderr_path: &Path,
+) -> serde_json::Value {
     send(
         child,
         &serde_json::json!({
@@ -93,13 +97,22 @@ fn initialize(child: &mut Child, rx: &mpsc::Receiver<String>) -> serde_json::Val
             }
         }),
     );
-    let resp: serde_json::Value =
-        serde_json::from_str(&next_line(rx)).expect("initialize response is valid JSON");
+    let line = rx.recv_timeout(RESPONSE_TIMEOUT).unwrap_or_else(|e| {
+        let stderr = std::fs::read_to_string(stderr_path)
+            .unwrap_or_else(|read_err| format!("<failed to read stderr: {read_err}>"));
+        panic!("failed waiting for initialize response ({e}); child stderr:\n{stderr}")
+    });
+    let resp: serde_json::Value = serde_json::from_str(&line).unwrap_or_else(|e| {
+        let stderr = std::fs::read_to_string(stderr_path)
+            .unwrap_or_else(|read_err| format!("<failed to read stderr: {read_err}>"));
+        panic!("initialize response is not valid JSON ({e}): {line}; child stderr:\n{stderr}")
+    });
     assert_eq!(resp["id"], 1, "initialize response id: {resp}");
-    assert!(
-        resp.get("error").is_none(),
-        "initialize must not error: {resp}"
-    );
+    if resp.get("error").is_some() {
+        let stderr = std::fs::read_to_string(stderr_path)
+            .unwrap_or_else(|e| format!("<failed to read stderr: {e}>"));
+        panic!("initialize must not error: {resp}; child stderr:\n{stderr}");
+    }
     send(
         child,
         &serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
@@ -134,7 +147,7 @@ fn stdio_round_trip_serves_tools_with_clean_stdout() {
     let rx = stdout_lines(&mut server.0);
     let mut transcript: Vec<String> = Vec::new();
 
-    let init_resp = initialize(&mut server.0, &rx);
+    let init_resp = initialize(&mut server.0, &rx, &stderr_path);
     transcript.push(init_resp.to_string());
     assert!(
         init_resp["result"]["serverInfo"]["name"].is_string(),
@@ -220,15 +233,15 @@ fn stdio_round_trip_serves_tools_with_clean_stdout() {
 #[test]
 fn second_instance_fails_fast_while_first_holds_the_lock() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    let stderr_file =
-        std::fs::File::create(tmp.path().join("first-stderr.log")).expect("stderr capture");
+    let stderr_path = tmp.path().join("first-stderr.log");
+    let stderr_file = std::fs::File::create(&stderr_path).expect("stderr capture");
 
     let mut first = spawn_stdio_server(tmp.path(), Stdio::from(stderr_file));
     let rx = stdout_lines(&mut first.0);
 
     // Complete the handshake so the first instance is provably up. The lock
     // is acquired before subsystem init, so this wait is conservative.
-    initialize(&mut first.0, &rx);
+    initialize(&mut first.0, &rx, &stderr_path);
 
     // Second instance against the same repo, using the default HTTP
     // transport: the lock applies across transports, and it must fail before
@@ -300,8 +313,8 @@ fn second_instance_fails_fast_when_configs_share_a_mapped_repo() {
     let config_a = write_config("config-a.toml");
     let config_b = write_config("config-b.toml");
 
-    let stderr_file =
-        std::fs::File::create(tmp.path().join("first-stderr.log")).expect("stderr capture");
+    let stderr_path = tmp.path().join("first-stderr.log");
+    let stderr_file = std::fs::File::create(&stderr_path).expect("stderr capture");
     let mut first = Command::new(env!("CARGO_BIN_EXE_memory-mcp"))
         .args([
             "serve",
@@ -323,7 +336,7 @@ fn second_instance_fails_fast_when_configs_share_a_mapped_repo() {
 
     // Complete the handshake so the first instance provably holds every
     // lock (they are all acquired before subsystem init).
-    initialize(&mut first.0, &rx);
+    initialize(&mut first.0, &rx, &stderr_path);
 
     // Second instance: different default repo, same mapped repo. Without
     // mapped-repo locking both processes would happily serve and mutate the
@@ -389,7 +402,7 @@ fn sigterm_drains_service_before_index_persistence() {
 
     let mut server = spawn_stdio_server(tmp.path(), Stdio::from(stderr_file));
     let rx = stdout_lines(&mut server.0);
-    initialize(&mut server.0, &rx);
+    initialize(&mut server.0, &rx, &stderr_path);
 
     // SIGTERM, not stdin EOF: the client end stays open so only the signal
     // path can end the session.


### PR DESCRIPTION
## Motivation

The first external adopter runs the server on the same machine as the MCP client, where HTTP means a background daemon, a bind address, and a Host-header allowlist — friction with no benefit for a single local user. MCP clients (including Claude Code) manage process lifecycle natively over stdio. Fixes the "just works on my machine" case; HTTP remains the default and the only supported transport for networked/multi-client deployments.

## Design

- `serve --transport {http|stdio}` (env `MEMORY_MCP_TRANSPORT`), default `http`. Shared bootstrap (repo, embedder, vector/lexical index, recall log) runs identically for both; HTTP-only pieces (session manager, axum router, health endpoints) live in the HTTP arm. Shutdown index persistence runs after either transport closes — stdin EOF is a clean shutdown under stdio.
- **Single-writer enforcement (flock-and-fail-fast):** OS advisory lock on `<repo>/.memory-mcp-index/.lock`, acquired before any subsystem opens (so contention fails before the slow embedding init). A second process — stdio or HTTP — exits non-zero with an error naming the holder's pid. No waiting, no lease heuristics: the kernel releases the lock on process exit, including crashes. This also closes the latent two-HTTP-daemons foot-gun.
- Session-id extraction now reads `http::request::Parts` out of the request extensions instead of hard-requiring it via `Extension<Parts>` (which errors when absent — all 11 tool handlers would have failed over stdio). stdio sessions are labelled `stdio` in spans.

## ADR

[ADR-0040](docs/adr/0040-stdio-transport-single-writer-lock.md) — supersedes ADR-0001 in part; records the flock-and-fail-fast decision and the rejected alternatives (multi-writer coordination, lease/TTL lockfiles, document-only constraint).

## Test coverage

- `tests/stdio_transport.rs` (subprocess tests, real binary):
  - **Round trip:** initialize handshake, `tools/list`, one `recall` over stdin/stdout under `RUST_LOG=debug`; asserts every stdout line is a JSON-RPC message (zero pollution), tracing lands on stderr, and stdin EOF exits 0.
  - **Lock contention:** second instance (default HTTP transport, same repo) exits non-zero naming the first instance's pid while the lock is held; first instance still shuts down cleanly.
- Unit tests: lock excludes a second acquisition and releases on drop; `--transport` parses, defaults to http, rejects unknown values.
- Full suite: 459 passed, 2 skipped (pre-existing feature-gated skips); `cargo fmt`, `clippy --all-targets -D warnings` clean.

Closes #104